### PR TITLE
Schema Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Note: Each file can contain multiple individual results related to one model. Se
 - `inference_platform`: Use this field when the evaluation was run through a remote API (e.g., `openai`, `huggingface`, `openrouter`, `anthropic`, `xai`).
 - `inference_engine`: Use this field when the evaluation was run through a local inference engine (e.g. `vLLM`, `Ollama`).
 
-4. The `source_type` has two options: `documentation` and `evaluation_platform`. Use `documentation` when the evaluation results are extracted from a documentation source (e.g., a leaderboard website or API). Use `evaluation_platform` when the evaluation was run through a dedicated evaluation platform (e.g., EvalEval, LeaderboardHub).
+4. The `source_type` has two options: `documentation` and `evaluation_platform`. Use `documentation` when the evaluation results are extracted from a documentation source (e.g., a leaderboard website or API). Use `evaluation_platform` when the evaluation was run locally or through an evaluation platform.
 
 5. The schema is designed to accomodate both numeric and level-based (e.g. Low, Medium, High) metrics. For level-based metrics, the actual 'value' should be converted to an integer (e.g. Low = 1, Medium = 2, High = 3), and the 'level_names' propert should be used to specify the mapping of levels to integers.
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ Note: Each file can contain multiple individual results related to one model. Se
 - `inference_platform`: Use this field when the evaluation was run through a remote API (e.g., `openai`, `huggingface`, `openrouter`, `anthropic`, `xai`).
 - `inference_engine`: Use this field when the evaluation was run through a local inference engine (e.g. `vLLM`, `Ollama`).
 
-4. The schema is designed to accomodate both numeric and level-based (e.g. Low, Medium, High) metrics. For level-based metrics, the actual 'value' should be converted to an integer (e.g. Low = 1, Medium = 2, High = 3), and the 'level_names' propert should be used to specify the mapping of levels to integers.
+4. The `source_type` has two options: `documentation` and `evaluation_platform`. Use `documentation` when the evaluation results are extracted from a documentation source (e.g., a leaderboard website or API). Use `evaluation_platform` when the evaluation was run through a dedicated evaluation platform (e.g., EvalEval, LeaderboardHub).
 
-5. Additional details can be provided in several places in the schema. They are not required, but can be useful for detailed analysis.
+5. The schema is designed to accomodate both numeric and level-based (e.g. Low, Medium, High) metrics. For level-based metrics, the actual 'value' should be converted to an integer (e.g. Low = 1, Medium = 2, High = 3), and the 'level_names' propert should be used to specify the mapping of levels to integers.
+
+6. Additional details can be provided in several places in the schema. They are not required, but can be useful for detailed analysis.
 - `model_info.additional_details`: Use this field to provide any additional information about the model itself (e.g. number of parameters)
 - `evaluation_results.generation_config.generation_args`: Specify additional arguments used to generate outputs from the model
 - `evaluation_results.generation_config.additional_details`: Use this field to provide any additional information about the evaluation process that is not captured elsewhere
@@ -104,17 +106,15 @@ Each evaluation (e.g., `livecodebenchpro`, `hfopenllm_v2`) has its own directory
 
 ```
 {
-  "schema_version": "0.0.1",
+  "schema_version": "0.1.0",
   "evaluation_id": "hfopenllm_v2/Qwen_Qwen2.5-Math-72B-Instruct/1762652579.847774", # {eval_name}/{model_id}/{retrieved_timestamp}
   "retrieved_timestamp": "1762652579.847775",  # UNIX timestamp
   "source_data": [
     "https://open-llm-leaderboard-open-llm-leaderboard.hf.space/api/leaderboard/formatted"
   ],
-  "evaluation_source": {
-    "evaluation_source_name": "HF Open LLM v2",
-    "evaluation_source_type": "leaderboard" # This can be leaderboard OR evaluation_platform
-  },
   "source_metadata": { # This information will be repeated in every model file
+    "evaluation_source_name": "HF Open LLM v2",
+    "evaluation_source_type": "documentation" # This can be documentation OR evaluation_platform
     "source_organization_name": "Hugging Face",
     "evaluator_relationship": "third_party"
   },

--- a/eval.schema.json
+++ b/eval.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "type": "object",
     "description": "Schema for storing and validating LLMs evaluation data, including model configuration, prompts, instances, Output, and evaluation metrics",
     "required": [
@@ -76,36 +76,27 @@
                 }
             ]
         },
-        "evaluation_source": {
-            "type": "object",
-            "description": "Details about evaluation origin. There are options that evaluations come from leaderboards (e.g. Live Code Bench Pro) or evaluation platforms (e.g. lm-eval, inspect ai, HELM...).",
-            "required": [
-                "evaluation_source_name",
-                "evaluation_source_type"
-            ],
-            "properties": {
-                "evaluation_source_name": {
-                    "type": "string",
-                    "description": "Name of the source (e.g. title of the source leaderboard or name of the platform used for the evaluation."
-                },
-                "evaluation_source_type": {
-                    "type": "string",
-                    "enum": [
-                        "leaderboard",
-                        "evaluation_platform"
-                    ],
-                    "description": "Type of evaluation source, e.g., leaderboard or evaluation platform"
-                }
-            }
-        },
         "source_metadata": {
             "type": "object",
             "description": "Metadata about the source of the leaderboard data",
             "required": [
+                "source_type",
                 "source_organization_name",
                 "evaluator_relationship"
             ],
             "properties": {
+                "source_name": {
+                    "type": "string",
+                    "description": "Name of the source (e.g. title of the source leaderboard or name of the platform used for the evaluation)."
+                },
+                "source_type": {
+                    "type": "string",
+                    "enum": [
+                        "documentation",
+                        "evaluation_run"
+                    ],
+                    "description": "Whether the data comes from a direct evaluation run or from documentation"
+                },
                 "source_organization_name": {
                     "type": "string",
                     "description": "Name of the organization that provides the data"
@@ -316,6 +307,14 @@
                                     "type": "integer",
                                     "minimum": 1,
                                     "description": "Maximum number of tokens to generate"
+                                },
+                                "execution_command": {
+                                    "type": "string",
+                                    "description": "Command used to run the model to generate results"
+                                },
+                                "chain_of_thought": {
+                                    "type": "boolean",
+                                    "description": "Whether chain-of-thought or reasoning was used to generate results"
                                 }
                             },
                             "additionalProperties": true

--- a/eval.schema.json
+++ b/eval.schema.json
@@ -312,9 +312,9 @@
                                     "type": "string",
                                     "description": "Command used to run the model to generate results"
                                 },
-                                "chain_of_thought": {
+                                "reasoning": {
                                     "type": "boolean",
-                                    "description": "Whether chain-of-thought or reasoning was used to generate results"
+                                    "description": "Whether reasoning orchain-of-thought was used to generate results"
                                 }
                             },
                             "additionalProperties": true

--- a/eval.schema.json
+++ b/eval.schema.json
@@ -6,7 +6,6 @@
     "required": [
         "schema_version",
         "evaluation_id",
-        "evaluation_source",
         "retrieved_timestamp",
         "source_data",
         "source_metadata",


### PR DESCRIPTION
1. Changes schema version to `0.1.0`
2. Adds two additional common generation parameters: 'reasoning' and 'execution_command'
3. Moves `evaluation_source` under `source_metadata` AND changes `source_type` enum values to 'documentation' and 'evaluation_run'