### PR TITLE
Changes to schema for v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,35 +104,37 @@ Each evaluation (e.g., `livecodebenchpro`, `hfopenllm_v2`) has its own directory
 
 ## Detailed Example
 
-```
+```json
 {
-  "schema_version": "0.1.0",
-  "evaluation_id": "hfopenllm_v2/Qwen_Qwen2.5-Math-72B-Instruct/1762652579.847774", # {eval_name}/{model_id}/{retrieved_timestamp}
-  "retrieved_timestamp": "1762652579.847775",  # UNIX timestamp
-  "source_data": [
-    "https://open-llm-leaderboard-open-llm-leaderboard.hf.space/api/leaderboard/formatted"
-  ],
-  "source_metadata": { # This information will be repeated in every model file
+  "schema_version": "0.2.0",
+  "evaluation_id": "hfopenllm_v2/meta-llama_Llama-3.1-8B/1762652580.351093",
+  "retrieved_timestamp": "1762652580.351093",
+  "source_metadata": {
     "source_name": "HF Open LLM v2",
-    "source_type": "documentation" # This can be documentation OR evaluation_run
+    "source_type": "documentation",
     "source_organization_name": "Hugging Face",
     "evaluator_relationship": "third_party"
   },
   "model_info": {
-    "name": "Qwen/Qwen2.5-Math-72B-Instruct",
-    "developer": "Qwen",
+    "name": "meta-llama/Llama-3.1-8B",
+    "developer": "meta-llama",
     "inference_platform": "unknown",
-    "id": "Qwen/Qwen2.5-Math-72B-Instruct",
-    "additional_details": { # Optional details about the model
-        "precision": "bfloat16",
-        "architecture": "Qwen2ForCausalLM",
-        "params_billions": 72.706
+    "id": "meta-llama/Llama-3.1-8B",
+    "additional_details": {
+      "precision": "float16",
+      "architecture": "LlamaForCausalLM",
+      "params_billions": 8.03
     }
   },
   "evaluation_results": [
     {
       "evaluation_name": "IFEval",
-      "metric_config": { # This information will be repeated in every model file
+      "source_data": {
+        "dataset_name": "IFEval",
+        "source_type": "hf_dataset",
+        "hf_repo": "google/IFEval"
+      },
+      "metric_config": {
         "evaluation_description": "Accuracy on IFEval",
         "lower_is_better": false,
         "score_type": "continuous",
@@ -140,10 +142,27 @@ Each evaluation (e.g., `livecodebenchpro`, `hfopenllm_v2`) has its own directory
         "max_score": 1
       },
       "score_details": {
-        "score": 0.4003466358151926
+        "score": 0.12459828809780273
+      }
+    },
+    {
+      "evaluation_name": "BBH",
+      "source_data": {
+        "dataset_name": "BBH",
+        "source_type": "hf_dataset",
+        "hf_repo": "lukaemon/bbh"
+      },
+      "metric_config": {
+        "evaluation_description": "Accuracy on BBH",
+        "lower_is_better": false,
+        "score_type": "continuous",
+        "min_score": 0,
+        "max_score": 1
+      },
+      "score_details": {
+        "score": 0.46595905446007296
       }
     }
-...
   ]
 }
 ```

--- a/eval.schema.json
+++ b/eval.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "type": "object",
     "description": "Schema for storing and validating LLMs evaluation data, including model configuration, prompts, instances, Output, and evaluation metrics",
     "required": [
@@ -162,13 +162,18 @@
                             {
                                 "type": "object",
                                 "description": "Generic source data when neither URL array nor HuggingFace dataset applies",
+                                "additionalProperties": true,
                                 "required": [
-                                    "dataset_name"
+                                    "dataset_name",
+                                    "source_type"
                                 ],
                                 "properties": {
                                     "dataset_name": {
                                         "type": "string",
                                         "description": "Name of the source dataset"
+                                    },
+                                    "source_type": {
+                                        "const": "other"
                                     },
                                     "additional_details": {
                                         "$ref": "#/$defs/additional_properties_object"
@@ -236,19 +241,26 @@
                                 "description": "Configuration when LLM is used as scorer/judge",
                                 "additionalProperties": true,
                                 "required": [
-                                    "model_info",
+                                    "judges",
                                     "input_prompt"
                                 ],
                                 "properties": {
-                                    "model_info": {
-                                        "$ref": "#/$defs/model_info"
+                                    "judges": {
+                                        "type": "array",
+                                        "description": "LLM judge(s) - single item for judge, multiple for jury",
+                                        "items": {
+                                            "$ref": "#/$defs/judge_config"
+                                        },
+                                        "minItems": 1
                                     },
                                     "input_prompt": {
                                         "type": "string",
                                         "description": "Prompt template used for judging"
                                     },
-                                    "temperature": {
-                                        "type": "number"
+                                    "aggregation_method": {
+                                        "type": "string",
+                                        "enum": ["majority_vote", "average", "weighted_average", "median"],
+                                        "description": "How to aggregate scores when multiple judges"
                                     },
                                     "expert_baseline": {
                                         "type": "number",
@@ -489,8 +501,9 @@
                 "hash_algorithm": {
                     "type": "string",
                     "description": "Hash algorithm used for checksum and sample_hash in instance-level data",
-                    "enum": ["sha256", "md5"
+                    "enum": ["sha256", "md5"]
                 },
+
                 "checksum": {
                     "type": "string",
                     "description": "Checksum value of the file"
@@ -507,6 +520,23 @@
             "type": "object",
             "description": "Additional parameters (key-value object)",
             "additionalProperties": true
+        },
+        "judge_config": {
+            "type": "object",
+            "description": "Configuration for a single LLM judge/juror",
+            "required": ["model_info"],
+            "properties": {
+                "model_info": {
+                    "$ref": "#/$defs/model_info"
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "weight": {
+                    "type": "number",
+                    "description": "Weight of this judge's score in aggregation (used in jury)"
+                }
+            }
         },
         "model_info": {
             "type": "object",

--- a/instance_level_eval.schema.json
+++ b/instance_level_eval.schema.json
@@ -1,5 +1,5 @@
 {   "$schema": "http://json-schema.org/draft-07/schema#",
-    "version": "instance_level_eval_0.0.1",
+    "version": "instance_level_eval_0.2.0",
     "type": "object",
     "description": "Schema for storing instance-level evaluation data for LLM evaluations, supporting single-turn, multi-turn, and agentic interactions",
     "required": [


### PR DESCRIPTION
- Move source_data to evaluation_results

  * **source_data** - This data should be specified per eval, I have moved into evaluation_results and removed it from the root of the schema. Overrode the change from source_data with a contribution from @janbatzner 
  * **inference_engine** - converted to object and added version as an additional attribute.
  * **LLM as a judge** - llm_scoring added by @janbatzner 
  * **confidence_interval** - added object to score_details.
  * **detailed_evaluation_results_url** - removed this parameter as it was redundant
  * **detailed_evaluation_results_per_samples** - replaced with detailed_evaluation_results
  * Added instance_level_eval.schema.json for single_turn, multi_turn and agentic as described in #26 