### PR TITLE
Add metric identity and deterministic aggregate-instance linkage fields

### DIFF
--- a/eval.schema.json
+++ b/eval.schema.json
@@ -122,6 +122,10 @@
                     "score_details"
                 ],
                 "properties": {
+                    "evaluation_result_id": {
+                        "type": "string",
+                        "description": "Stable identifier for this metric result inside an evaluation run. Recommended deterministic join key for instance-level records."
+                    },
                     "evaluation_name": {
                         "type": "string",
                         "description": "Name of the evaluation"
@@ -154,6 +158,34 @@
                             "evaluation_description": {
                                 "type": "string",
                                 "description": "Description of the evaluation"
+                            },
+                            "metric_id": {
+                                "type": "string",
+                                "description": "Canonical metric identifier for cross-source normalization (e.g. accuracy, f1_macro, auroc, pass_at_k)."
+                            },
+                            "metric_name": {
+                                "type": "string",
+                                "description": "Display name for the metric (e.g. Accuracy, F1-macro, pass@1)."
+                            },
+                            "metric_kind": {
+                                "type": "string",
+                                "description": "Normalized metric family/type used for safe aggregation (e.g. accuracy, f1, auroc, rmse, mae, pass_rate, elo)."
+                            },
+                            "metric_unit": {
+                                "type": "string",
+                                "description": "Unit of the metric values (e.g. proportion, percent, points, ms, tokens)."
+                            },
+                            "metric_parameters": {
+                                "type": "object",
+                                "description": "Metric-specific parameters (e.g. {\"k\": 1} for pass@k).",
+                                "additionalProperties": {
+                                    "type": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                    ]
+                                }
                             },
                             "lower_is_better": {
                                 "type": "boolean",

--- a/eval.schema.json
+++ b/eval.schema.json
@@ -161,7 +161,7 @@
                             },
                             "metric_id": {
                                 "type": "string",
-                                "description": "Canonical metric identifier for cross-source normalization (e.g. accuracy, f1_macro, auroc, pass_at_k)."
+                                "description": "Stable metric identifier for joining/deduping/querying. Use a canonical global id when applicable (e.g. accuracy, f1_macro, auroc, rmse, pass_at_k). For benchmark/leaderboard-specific metrics, use a namespaced id (e.g. rewardbench.overall, lmarena.elo)."
                             },
                             "metric_name": {
                                 "type": "string",

--- a/instance_level_eval.schema.json
+++ b/instance_level_eval.schema.json
@@ -29,11 +29,11 @@
         },
         "evaluation_name": {
             "type": "string",
-            "description": "The specific eval name, ideally unique (e.g. GSM8K, mmlu_physics). Primarily for display/filtering when evaluation_result_id is unavailable."
+            "description": "The specific eval name, ideally unique (e.g. GSM8K, mmlu_physics). Primarily for display/filtering when evaluation_result_id is unavailable. If an evaluation run reports multiple aggregate results/metrics for the same sample, emit multiple instance records (one per aggregate result) rather than trying to attach a single instance record to many aggregate results."
         },
         "evaluation_result_id": {
             "type": "string",
-            "description": "Preferred deterministic foreign key to aggregate evaluation_results[].evaluation_result_id."
+            "description": "Preferred deterministic foreign key to aggregate evaluation_results[].evaluation_result_id. This is intended to point to exactly one aggregate evaluation result; if a single underlying interaction/sample contributes to multiple aggregate results, emit multiple instance records with different evaluation_result_id values."
         },
         "sample_id": {
             "type": "string",

--- a/instance_level_eval.schema.json
+++ b/instance_level_eval.schema.json
@@ -29,7 +29,11 @@
         },
         "evaluation_name": {
             "type": "string",
-            "description": "The specific eval name, ideally unique (e.g. GSM8K, mmlu_physics)"
+            "description": "The specific eval name, ideally unique (e.g. GSM8K, mmlu_physics). Primarily for display/filtering when evaluation_result_id is unavailable."
+        },
+        "evaluation_result_id": {
+            "type": "string",
+            "description": "Preferred deterministic foreign key to aggregate evaluation_results[].evaluation_result_id."
         },
         "sample_id": {
             "type": "string",


### PR DESCRIPTION
This PR updates the evaluation result schemas to improve metric identity and enable deterministic aggregate <-> instance joins.

**Changes**
- Add `evaluation_results[].evaluation_result_id` (aggregate) and `evaluation_result_id` (instance) as a stable join key.
- Add optional metric identity fields under `evaluation_results[].metric_config`: `metric_id`, `metric_name`, `metric_kind`, `metric_unit`, `metric_parameters`.

**Metric identity guidance (all optional)**
- `metric_id`: stable identifier for joining/deduping/querying. Use a canonical global id when applicable (e.g. `accuracy`, `f1_macro`, `auroc`, `rmse`, `pass_at_k`). For benchmark/leaderboard-specific metrics, use a namespaced id (e.g. `rewardbench.overall`, `lmarena.elo`).
- `metric_kind`: normalized metric family used for safe aggregation (e.g. `accuracy`, `f1`, `auroc`, `rmse`, `mae`, `pass_rate`, `elo`).
- `metric_name`: display name for the metric (e.g. `Score`, `Accuracy`, `pass@1`).
- `metric_unit`: representation of the numeric values (e.g. `proportion`, `percent`, `points`, `ms`, `tokens`).
- `metric_parameters`: metric-specific configuration (e.g. `{ "k": 1 }` for `pass@k`).

**Deterministic `evaluation_result_id` recipe**
Suggested construction:
- `evaluation_result_id = "er_" + sha256(canonical_json(payload))`
- `canonical_json`: JSON with sorted keys and stable separators (no whitespace)
- `payload`: at minimum `{ evaluation_id, evaluation_name, source_data.dataset_name, metric_id, metric_kind, metric_unit, metric_parameters }` (include `generation_config` if you need to disambiguate multiple computations of the same metric)

**Before/after examples**

Example A (RewardBench overall, where `evaluation_name: "Score"` is ambiguous across sources):

Before:
```json
{
  "evaluation_name": "Score",
  "metric_config": {
    "evaluation_description": "Overall RewardBench Score",
    "lower_is_better": false,
    "score_type": "continuous",
    "min_score": 0.0,
    "max_score": 1.0
  },
  "score_details": { "score": 0.612599 }
}
```

After:
```json
{
  "evaluation_result_id": "er_<sha256(...)>",
  "evaluation_name": "Score",
  "metric_config": {
    "metric_id": "rewardbench.overall",
    "metric_name": "Score",
    "metric_kind": "preference_rate",
    "metric_unit": "proportion",
    "metric_parameters": {},
    "evaluation_description": "Overall RewardBench Score",
    "lower_is_better": false,
    "score_type": "continuous",
    "min_score": 0.0,
    "max_score": 1.0
  },
  "score_details": { "score": 0.612599 }
}
```

Example B (`pass@k`, where `k` is indispensable):

Before:
```json
{
  "evaluation_name": "multiple-js",
  "metric_config": {
    "evaluation_description": "pass@1 on multiple-js",
    "lower_is_better": false,
    "score_type": "continuous",
    "min_score": 0.0,
    "max_score": 1.0
  },
  "score_details": { "score": 0.189814 }
}
```

After:
```json
{
  "evaluation_result_id": "er_<sha256(...)>",
  "evaluation_name": "multiple-js",
  "metric_config": {
    "metric_id": "pass_at_k",
    "metric_name": "pass@1",
    "metric_kind": "pass_rate",
    "metric_unit": "proportion",
    "metric_parameters": { "k": 1 },
    "evaluation_description": "pass@1 on multiple-js",
    "lower_is_better": false,
    "score_type": "continuous",
    "min_score": 0.0,
    "max_score": 1.0
  },
  "score_details": { "score": 0.189814 }
}
```
