### PR TITLE
Move non-core dependencies to optional extras

### DIFF
--- a/eval_converters/README.md
+++ b/eval_converters/README.md
@@ -2,10 +2,14 @@
 A collection of scripts to convert evaluation logs from local runs from evaluation frameworks (e.g., `Inspect AI` and `lm-eval-harness`). 
 
 ### Installation
-- Install the required dependencies:
+
+Install dependencies for the converter(s) you need:
 
 ```bash
-uv sync
+uv sync                   # core dependencies only (includes lm-eval)
+uv sync --extra inspect   # + Inspect AI
+uv sync --extra helm      # + HELM
+uv sync --extra all       # + all
 ```
 
 ### Inspect

--- a/eval_converters/helm/__main__.py
+++ b/eval_converters/helm/__main__.py
@@ -6,7 +6,14 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
-from eval_converters.helm.adapter import HELMAdapter
+try:
+    from eval_converters.helm.adapter import HELMAdapter
+except ImportError as exc:
+    raise SystemExit(
+        "The 'crfm-helm' package is required to use the HELM converter.\n"
+        "Install it with: uv sync --extra helm"
+    ) from exc
+
 from eval_types import (
     EvaluatorRelationship,
     EvaluationLog

--- a/eval_converters/inspect/__main__.py
+++ b/eval_converters/inspect/__main__.py
@@ -7,8 +7,15 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 
-from inspect_ai.log import list_eval_logs
-from eval_converters.inspect.adapter import InspectAIAdapter
+try:
+    from inspect_ai.log import list_eval_logs
+    from eval_converters.inspect.adapter import InspectAIAdapter
+except ImportError as exc:
+    raise SystemExit(
+        "The 'inspect-ai' package is required to use the Inspect AI converter.\n"
+        "Install it with: uv sync --extra inspect"
+    ) from exc
+
 from eval_types import (
     EvaluatorRelationship,
     EvaluationLog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,19 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "crfm-helm>=0.5.12",
     "datamodel-code-generator[ruff]>=0.52.2",
     "huggingface-hub>=0.36.0,<1.0.0",
-    "inspect-ai>=0.3.160,<0.4.0",
     "jsonschema>=4.26.0,<5.0.0",
     "pydantic>=2.12.5,<3.0.0",
     "requests>=2.32.5,<3.0.0",
+]
+
+[project.optional-dependencies]
+inspect = ["inspect-ai>=0.3.160,<0.4.0"]
+helm = ["crfm-helm>=0.5.12"]
+all = [
+    "every-eval-ever[inspect]",
+    "every-eval-ever[helm]",
 ]
 
 [dependency-groups]

--- a/tests/test_helm_adapter.py
+++ b/tests/test_helm_adapter.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip("helm", reason="crfm-helm not installed; install with: uv sync --extra helm")
+
 from pathlib import Path
 import tempfile
 

--- a/tests/test_helm_instance_level_adapter.py
+++ b/tests/test_helm_instance_level_adapter.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip("helm", reason="crfm-helm not installed; install with: uv sync --extra helm")
+
 import json
 import tempfile
 from pathlib import Path

--- a/tests/test_inspect_adapter.py
+++ b/tests/test_inspect_adapter.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip("inspect_ai", reason="inspect-ai not installed; install with: uv sync --extra inspect")
+
 import contextlib
 from pathlib import Path
 import tempfile

--- a/tests/test_inspect_instance_level_adapter.py
+++ b/tests/test_inspect_instance_level_adapter.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip("inspect_ai", reason="inspect-ai not installed; install with: uv sync --extra inspect")
+
 import json
 import tempfile
 from pathlib import Path

--- a/uv.lock
+++ b/uv.lock
@@ -752,13 +752,23 @@ name = "every-eval-ever"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "crfm-helm" },
     { name = "datamodel-code-generator", extra = ["ruff"] },
     { name = "huggingface-hub" },
-    { name = "inspect-ai" },
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "requests" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "crfm-helm" },
+    { name = "inspect-ai" },
+]
+helm = [
+    { name = "crfm-helm" },
+]
+inspect = [
+    { name = "inspect-ai" },
 ]
 
 [package.dev-dependencies]
@@ -771,14 +781,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "crfm-helm", specifier = ">=0.5.12" },
+    { name = "crfm-helm", marker = "extra == 'helm'", specifier = ">=0.5.12" },
     { name = "datamodel-code-generator", extras = ["ruff"], specifier = ">=0.52.2" },
+    { name = "every-eval-ever", extras = ["helm"], marker = "extra == 'all'" },
+    { name = "every-eval-ever", extras = ["inspect"], marker = "extra == 'all'" },
     { name = "huggingface-hub", specifier = ">=0.36.0,<1.0.0" },
-    { name = "inspect-ai", specifier = ">=0.3.160,<0.4.0" },
+    { name = "inspect-ai", marker = "extra == 'inspect'", specifier = ">=0.3.160,<0.4.0" },
     { name = "jsonschema", specifier = ">=4.26.0,<5.0.0" },
     { name = "pydantic", specifier = ">=2.12.5,<3.0.0" },
     { name = "requests", specifier = ">=2.32.5,<3.0.0" },
 ]
+provides-extras = ["inspect", "helm", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3313,6 +3326,11 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
     { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
     { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
     { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },


### PR DESCRIPTION
Changing dependencies and moving non-core ones to optional extras. This keeps the default install lightweight and avoids pulling in heavy transitive deps like `torch` for users who only need specific converters.