### PR TITLE
fix: correct typo "orchain-of-thought" in schema description

### DIFF
--- a/every_eval_ever/eval_types.py
+++ b/every_eval_ever/eval_types.py
@@ -211,7 +211,7 @@ class GenerationArgs(BaseModel):
     )
     reasoning: bool | None = Field(
         None,
-        description='Whether reasoning orchain-of-thought was used to generate results',
+        description='Whether reasoning or chain-of-thought was used to generate results',
     )
     prompt_template: str | None = Field(
         None,

--- a/every_eval_ever/schemas/eval.schema.json
+++ b/every_eval_ever/schemas/eval.schema.json
@@ -420,7 +420,7 @@
                                     },
                                     "reasoning": {
                                         "type": "boolean",
-                                        "description": "Whether reasoning orchain-of-thought was used to generate results"
+                                        "description": "Whether reasoning or chain-of-thought was used to generate results"
                                     },
                                     "prompt_template": {
                                         "type": "string",


### PR DESCRIPTION
Missing space in the reasoning field description:
"reasoning orchain-of-thought" -> "reasoning or chain-of-thought".

- Fix in eval.schema.json (source of truth)
- Update auto-generated eval_types.py to match