### PR TITLE
fix: preserve falsy generation args in HELM adapter

### DIFF
--- a/every_eval_ever/converters/helm/adapter.py
+++ b/every_eval_ever/converters/helm/adapter.py
@@ -231,16 +231,17 @@ class HELMAdapter(BaseEvaluationAdapter):
             adapter_spec: The global adapter specification from run_spec.json.
             request: The specific request object from scenario_state.json (optional).
         """
-        temperature = request_state.request.temperature or getattr(
+        req = request_state.request
+        temperature = req.temperature if req.temperature is not None else getattr(
             adapter_spec, 'temperature', None
         )
-        max_tokens = request_state.request.max_tokens or getattr(
+        max_tokens = req.max_tokens if req.max_tokens is not None else getattr(
             adapter_spec, 'max_tokens', None
         )
-        top_p = request_state.request.top_p or getattr(
+        top_p = req.top_p if req.top_p is not None else getattr(
             adapter_spec, 'top_p', None
         )
-        top_k = request_state.request.top_k_per_token or getattr(
+        top_k = req.top_k_per_token if req.top_k_per_token is not None else getattr(
             adapter_spec, 'top_k_per_token', None
         )
 

--- a/tests/test_helm_generation_args.py
+++ b/tests/test_helm_generation_args.py
@@ -1,0 +1,105 @@
+"""Tests for HELM adapter generation args extraction.
+
+Verifies that falsy-but-valid values like temperature=0 are preserved,
+not silently replaced by adapter defaults.
+"""
+
+import pytest
+
+pytest.importorskip(
+    'helm', reason='crfm-helm not installed; install with: uv sync --extra helm'
+)
+
+from types import SimpleNamespace
+
+from every_eval_ever.converters.helm.adapter import HELMAdapter
+
+
+def _make_request_state(temperature=None, max_tokens=None, top_p=None, top_k=None):
+    """Build a minimal mock RequestState with the given request-level values."""
+    request = SimpleNamespace(
+        temperature=temperature,
+        max_tokens=max_tokens,
+        top_p=top_p,
+        top_k_per_token=top_k,
+    )
+    return SimpleNamespace(
+        request=request,
+        result=None,  # no completions → extract_reasoning returns None
+    )
+
+
+def _make_adapter_spec(temperature=None, max_tokens=None, top_p=None, top_k=None):
+    """Build a minimal mock AdapterSpec with the given fallback values."""
+    return SimpleNamespace(
+        temperature=temperature,
+        max_tokens=max_tokens,
+        top_p=top_p,
+        top_k_per_token=top_k,
+    )
+
+
+class TestExtractGenerationArgsFalsyValues:
+    """Verify that 0 is treated as a real value, not as missing."""
+
+    def test_temperature_zero_is_preserved(self):
+        adapter = HELMAdapter()
+        request_state = _make_request_state(temperature=0)
+        adapter_spec = _make_adapter_spec(temperature=0.7)
+
+        args = adapter._extract_generation_args(adapter_spec, request_state)
+
+        assert args.temperature == 0, (
+            f'temperature=0 was replaced by adapter default {args.temperature}'
+        )
+
+    def test_max_tokens_low_value_is_preserved(self):
+        """max_tokens has a schema constraint of ge=1, so test with 1 not 0."""
+        adapter = HELMAdapter()
+        request_state = _make_request_state(max_tokens=1)
+        adapter_spec = _make_adapter_spec(max_tokens=100)
+
+        args = adapter._extract_generation_args(adapter_spec, request_state)
+
+        assert args.max_tokens == 1, (
+            f'max_tokens=1 was replaced by adapter default {args.max_tokens}'
+        )
+
+    def test_top_p_zero_is_preserved(self):
+        adapter = HELMAdapter()
+        request_state = _make_request_state(top_p=0)
+        adapter_spec = _make_adapter_spec(top_p=0.9)
+
+        args = adapter._extract_generation_args(adapter_spec, request_state)
+
+        assert args.top_p == 0, (
+            f'top_p=0 was replaced by adapter default {args.top_p}'
+        )
+
+    def test_top_k_zero_is_preserved(self):
+        adapter = HELMAdapter()
+        request_state = _make_request_state(top_k=0)
+        adapter_spec = _make_adapter_spec(top_k=50)
+
+        args = adapter._extract_generation_args(adapter_spec, request_state)
+
+        assert args.top_k == 0, (
+            f'top_k=0 was replaced by adapter default {args.top_k}'
+        )
+
+    def test_none_falls_back_to_adapter_spec(self):
+        """When request value is None, the adapter default should be used."""
+        adapter = HELMAdapter()
+        request_state = _make_request_state(
+            temperature=None, max_tokens=None, top_p=None, top_k=None
+        )
+        adapter_spec = _make_adapter_spec(
+            temperature=0.7, max_tokens=100, top_p=0.9, top_k=50
+        )
+
+        args = adapter._extract_generation_args(adapter_spec, request_state)
+
+        assert args.temperature == 0.7
+        assert args.max_tokens == 100
+        assert args.top_p == 0.9
+        assert args.top_k == 50


### PR DESCRIPTION
Previously _extract_generation_args() used `or` to fall back to adapter defaults. This treated legitimate values like temperature=0 (deterministic sampling) as missing and silently replaced them with the adapter spec defaults. Converted HELM metadata could therefore lie about how a run was actually configured.

- Replace `or` with `if ... is not None` for temperature, max_tokens, top_p, and top_k
- Add tests verifying zero values are preserved and None falls back correctly