### PR TITLE
feat: add AlpacaEval leaderboard converter

### DIFF
--- a/every_eval_ever/cli.py
+++ b/every_eval_ever/cli.py
@@ -188,6 +188,45 @@ def _cmd_convert_helm(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_convert_alpaca_eval(args: argparse.Namespace) -> int:
+    from every_eval_ever.converters.alpaca_eval.adapter import (
+        LEADERBOARDS,
+        AlpacaEvalAdapter,
+    )
+
+    adapter = AlpacaEvalAdapter()
+    versions = [args.version] if args.version else list(LEADERBOARDS.keys())
+    output_dir = Path(args.output_dir)
+
+    total = 0
+    for version in versions:
+        cfg_name = LEADERBOARDS[version]['source_name']
+        print(f'\n=== {cfg_name} ===')
+        logs = adapter.fetch_leaderboard(version)
+        benchmark_key = f'alpaca_eval_{version}'
+
+        for log in logs:
+            parts = log.model_info.id.split('/', 1)
+            developer = parts[0] if len(parts) == 2 else 'unknown'
+            model_name = parts[1] if len(parts) == 2 else log.model_info.id
+
+            out_dir = output_dir / benchmark_key / developer / model_name
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_file = out_dir / f'{str(uuid.uuid4())}.json'
+
+            import json
+
+            with out_file.open('w', encoding='utf-8') as f:
+                json.dump(
+                    log.model_dump(mode='json', exclude_none=True), f, indent=2
+                )
+            print(f'  {out_file}')
+            total += 1
+
+    print(f'\nConverted {total} model evaluation(s).')
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog='every_eval_ever',
@@ -255,7 +294,7 @@ def build_parser() -> argparse.ArgumentParser:
         dest='source', required=True
     )
 
-    for source in ['lm_eval', 'inspect', 'helm']:
+    for source in ['lm_eval', 'inspect', 'helm', 'alpaca_eval']:
         source_parser = convert_subparsers.add_parser(
             source,
             help=f'Convert {source} logs',
@@ -264,7 +303,7 @@ def build_parser() -> argparse.ArgumentParser:
         source_parser.add_argument(
             '--log_path',
             '--log-path',
-            required=True,
+            required=(source != 'alpaca_eval'),
             help='Path to source log file or directory to convert.',
         )
         source_parser.add_argument(
@@ -310,6 +349,17 @@ def build_parser() -> argparse.ArgumentParser:
             default='unknown',
             help='Evaluation library version recorded in eval_library.version.',
         )
+
+        if source == 'alpaca_eval':
+            source_parser.add_argument(
+                '--version',
+                choices=['v1', 'v2'],
+                default=None,
+                help=(
+                    'Which leaderboard version to convert: v1 (AlpacaEval 1.0) '
+                    'or v2 (AlpacaEval 2.0). Omit to convert both (default).'
+                ),
+            )
 
         if source == 'lm_eval':
             source_parser.add_argument(
@@ -365,6 +415,8 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_convert_inspect(args)
         if args.source == 'helm':
             return _cmd_convert_helm(args)
+        if args.source == 'alpaca_eval':
+            return _cmd_convert_alpaca_eval(args)
 
     parser.print_help()
     return 1

--- a/every_eval_ever/cli.py
+++ b/every_eval_ever/cli.py
@@ -203,23 +203,27 @@ def _cmd_convert_alpaca_eval(args: argparse.Namespace) -> int:
         cfg_name = LEADERBOARDS[version]['source_name']
         print(f'\n=== {cfg_name} ===')
         logs = adapter.fetch_leaderboard(version)
-        benchmark_key = f'alpaca_eval_{version}'
 
         for log in logs:
-            parts = log.model_info.id.split('/', 1)
-            developer = parts[0] if len(parts) == 2 else 'unknown'
-            model_name = parts[1] if len(parts) == 2 else log.model_info.id
-
-            out_dir = output_dir / benchmark_key / developer / model_name
-            out_dir.mkdir(parents=True, exist_ok=True)
-            out_file = out_dir / f'{str(uuid.uuid4())}.json'
-
-            import json
-
-            with out_file.open('w', encoding='utf-8') as f:
-                json.dump(
-                    log.model_dump(mode='json', exclude_none=True), f, indent=2
+            if args.source_organization_name != 'unknown':
+                log.source_metadata.source_organization_name = (
+                    args.source_organization_name
                 )
+            if args.source_organization_url is not None:
+                log.source_metadata.source_organization_url = (
+                    args.source_organization_url
+                )
+            if args.evaluator_relationship != 'third_party':
+                from every_eval_ever.eval_types import EvaluatorRelationship
+                log.source_metadata.evaluator_relationship = (
+                    EvaluatorRelationship(args.evaluator_relationship)
+                )
+            if args.eval_library_name != 'alpaca_eval':
+                log.eval_library.name = args.eval_library_name
+            if args.eval_library_version != 'unknown':
+                log.eval_library.version = args.eval_library_version
+
+            out_file = _write_log(log, output_dir)
             print(f'  {out_file}')
             total += 1
 

--- a/every_eval_ever/converters/README.md
+++ b/every_eval_ever/converters/README.md
@@ -1,5 +1,5 @@
 ## Automatic Evaluation Log Converters
-A collection of scripts to convert evaluation logs from local runs from evaluation frameworks (e.g., `Inspect AI` and `lm-eval-harness`). 
+A collection of scripts to convert evaluation logs from local evaluation frameworks (e.g., `Inspect AI` and `lm-eval-harness`) and public leaderboards (e.g., AlpacaEval) into the unified Every Eval Ever schema.
 
 ### Installation
 
@@ -215,4 +215,58 @@ options:
                         lm_eval, helm)
   --eval_library_version EVAL_LIBRARY_VERSION
                         Version of the evaluation library
+```
+
+## AlpacaEval
+
+The AlpacaEval converter fetches the public leaderboard CSV directly from GitHub
+and converts all model entries into the unified schema. No local log files are required.
+
+Both AlpacaEval 1.0 (GPT-4 judge, `text_davinci_003` baseline) and
+AlpacaEval 2.0 (weighted LC win rate, `gpt4_turbo` baseline) are supported.
+
+Metrics converted per model:
+
+| Metric | Description |
+|---|---|
+| Win Rate | Fraction of outputs preferred over the baseline (raw) |
+| Length-Controlled Win Rate | Win rate debiased for response length (v2 only) |
+| Discrete Win Rate | Binary win rate — no partial credit for ties |
+| Average Response Length | Mean token count of model responses |
+
+### Usage
+
+Convert both leaderboards (default):
+
+```bash
+uv run every_eval_ever convert alpaca_eval --output_dir data
+```
+
+Convert only AlpacaEval 2.0:
+
+```bash
+uv run every_eval_ever convert alpaca_eval --version v2 --output_dir data
+```
+
+Convert only AlpacaEval 1.0:
+
+```bash
+uv run every_eval_ever convert alpaca_eval --version v1 --output_dir data
+```
+
+Full argument list:
+
+```
+usage: every_eval_ever convert alpaca_eval [-h] [--log_path LOG_PATH]
+                                           [--output_dir OUTPUT_DIR]
+                                           [--version {v1,v2}]
+                                           [--source_organization_name ...]
+                                           [--evaluator_relationship ...]
+                                           [--source_organization_url ...]
+                                           [--eval_library_name ...]
+                                           [--eval_library_version ...]
+
+options:
+  --version {v1,v2}     Which leaderboard to convert. Omit to convert both (default).
+  --output_dir          Base output directory (default: data).
 ```

--- a/every_eval_ever/converters/README.md
+++ b/every_eval_ever/converters/README.md
@@ -234,6 +234,7 @@ Metrics converted per model:
 | Discrete Win Rate | Binary win rate — no partial credit for ties |
 | Average Response Length | Mean token count of model responses |
 
+
 ### Usage
 
 Convert both leaderboards (default):
@@ -267,6 +268,6 @@ usage: every_eval_ever convert alpaca_eval [-h] [--log_path LOG_PATH]
                                            [--eval_library_version ...]
 
 options:
-  --version {v1,v2}     Which leaderboard to convert. Omit to convert both (default).
-  --output_dir          Base output directory (default: data).
+  --version {v1,v2}            Which leaderboard to convert. Omit to convert both (default).
+  --output_dir OUTPUT_DIR      Base output directory (default: data).
 ```

--- a/every_eval_ever/converters/alpaca_eval/__init__.py
+++ b/every_eval_ever/converters/alpaca_eval/__init__.py
@@ -1,0 +1,1 @@
+"""AlpacaEval leaderboard adapter for every_eval_ever."""

--- a/every_eval_ever/converters/alpaca_eval/__main__.py
+++ b/every_eval_ever/converters/alpaca_eval/__main__.py
@@ -1,0 +1,71 @@
+"""CLI for converting AlpacaEval leaderboard data to every_eval_ever format."""
+
+import argparse
+import json
+import sys
+import uuid
+from pathlib import Path
+
+from .adapter import LEADERBOARDS, AlpacaEvalAdapter
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            'Fetch AlpacaEval leaderboard data from GitHub and convert it '
+            'to Every Eval Ever schema v0.2.2 JSON files.'
+        )
+    )
+    parser.add_argument(
+        '--version',
+        choices=list(LEADERBOARDS.keys()),
+        default=None,
+        help=(
+            'Which leaderboard to convert. '
+            'Omit to convert all versions (default).'
+        ),
+    )
+    parser.add_argument(
+        '--output_dir',
+        default='data',
+        help='Base output directory (default: data).',
+    )
+    args = parser.parse_args()
+
+    adapter = AlpacaEvalAdapter()
+    versions = [args.version] if args.version else list(LEADERBOARDS.keys())
+    output_dir = Path(args.output_dir)
+
+    total = 0
+    for version in versions:
+        cfg_name = LEADERBOARDS[version]['source_name']
+        print(f'\n=== {cfg_name} ===')
+        try:
+            logs = adapter.fetch_leaderboard(version)
+        except Exception as exc:
+            print(f'  ERROR: {exc}', file=sys.stderr)
+            continue
+
+        benchmark_key = f'alpaca_eval_{version}'
+
+        for log in logs:
+            parts = log.model_info.id.split('/', 1)
+            developer = parts[0] if len(parts) == 2 else 'unknown'
+            model_name = parts[1] if len(parts) == 2 else log.model_info.id
+
+            out_dir = output_dir / benchmark_key / developer / model_name
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_file = out_dir / f'{uuid.uuid4()}.json'
+
+            with out_file.open('w', encoding='utf-8') as f:
+                json.dump(
+                    log.model_dump(mode='json', exclude_none=True), f, indent=2
+                )
+            print(f'  {out_file}')
+            total += 1
+
+    print(f'\nConverted {total} model evaluation(s).')
+
+
+if __name__ == '__main__':
+    main()

--- a/every_eval_ever/converters/alpaca_eval/__main__.py
+++ b/every_eval_ever/converters/alpaca_eval/__main__.py
@@ -13,7 +13,7 @@ def main():
     parser = argparse.ArgumentParser(
         description=(
             'Fetch AlpacaEval leaderboard data from GitHub and convert it '
-            'to Every Eval Ever schema v0.2.2 JSON files.'
+            'to Every Eval Ever schema JSON files.'
         )
     )
     parser.add_argument(

--- a/every_eval_ever/converters/alpaca_eval/__main__.py
+++ b/every_eval_ever/converters/alpaca_eval/__main__.py
@@ -6,6 +6,8 @@ import sys
 import uuid
 from pathlib import Path
 
+from every_eval_ever.converters import SCHEMA_VERSION
+
 from .adapter import LEADERBOARDS, AlpacaEvalAdapter
 
 

--- a/every_eval_ever/converters/alpaca_eval/adapter.py
+++ b/every_eval_ever/converters/alpaca_eval/adapter.py
@@ -1,0 +1,332 @@
+"""Adapter for converting AlpacaEval leaderboard CSVs to every_eval_ever format."""
+
+import csv
+import io
+import re
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from every_eval_ever.converters import SCHEMA_VERSION
+from every_eval_ever.converters.common.utils import get_current_unix_timestamp
+from every_eval_ever.eval_types import (
+    EvalLibrary,
+    EvaluationLog,
+    EvaluationResult,
+    EvaluatorRelationship,
+    MetricConfig,
+    ModelInfo,
+    ScoreDetails,
+    ScoreType,
+    SourceDataPrivate,
+    SourceMetadata,
+    SourceType,
+    StandardError,
+    Uncertainty,
+)
+
+# ---------------------------------------------------------------------------
+# Leaderboard configurations
+# ---------------------------------------------------------------------------
+
+LEADERBOARDS: Dict[str, Dict[str, Any]] = {
+    'v1': {
+        'url': (
+            'https://raw.githubusercontent.com/tatsu-lab/alpaca_eval/main/'
+            'src/alpaca_eval/leaderboards/data_AlpacaEval/'
+            'alpaca_eval_gpt4_leaderboard.csv'
+        ),
+        'source_name': 'AlpacaEval 1.0',
+        'version': '1.0',
+        'baseline': 'text_davinci_003',
+        'annotator': 'alpaca_eval_gpt4',
+        'has_lc': False,
+    },
+    'v2': {
+        'url': (
+            'https://raw.githubusercontent.com/tatsu-lab/alpaca_eval/main/'
+            'src/alpaca_eval/leaderboards/data_AlpacaEval_2/'
+            'weighted_alpaca_eval_gpt4_turbo_leaderboard.csv'
+        ),
+        'source_name': 'AlpacaEval 2.0',
+        'version': '2.0',
+        'baseline': 'gpt4_turbo',
+        'annotator': 'weighted_alpaca_eval_gpt4_turbo',
+        'has_lc': True,
+    },
+}
+
+# Map substrings in lowercase model names → canonical developer IDs
+_DEVELOPER_MAP = [
+    ('gpt-4', 'openai'),
+    ('gpt-3', 'openai'),
+    ('gpt4', 'openai'),
+    ('gpt3', 'openai'),
+    ('o1-', 'openai'),
+    ('o3-', 'openai'),
+    ('o4-', 'openai'),
+    ('chatgpt', 'openai'),
+    ('davinci', 'openai'),
+    ('claude', 'anthropic'),
+    ('gemini', 'google'),
+    ('palm', 'google'),
+    ('bard', 'google'),
+    ('llama', 'meta-llama'),
+    ('mistral', 'mistralai'),
+    ('mixtral', 'mistralai'),
+    ('falcon', 'tiiuae'),
+    ('vicuna', 'lmsys'),
+    ('alpaca', 'stanford'),
+    ('koala', 'berkeley'),
+    ('orca', 'microsoft'),
+    ('phi-', 'microsoft'),
+    ('phi_', 'microsoft'),
+    ('wizardlm', 'WizardLM'),
+    ('qwen', 'Qwen'),
+    ('deepseek', 'deepseek-ai'),
+    ('yi-', '01-ai'),
+    ('gemma', 'google'),
+    ('command', 'CohereForAI'),
+    ('cohere', 'CohereForAI'),
+    ('solar', 'upstage'),
+    ('zephyr', 'HuggingFaceH4'),
+    ('tulu', 'allenai'),
+    ('olmo', 'allenai'),
+    ('xwinlm', 'Xwin-LM'),
+    ('guanaco', 'timdettmers'),
+    ('openchat', 'openchat'),
+]
+
+
+def _infer_developer(model_name: str) -> Optional[str]:
+    lower = model_name.lower()
+    for pattern, dev in _DEVELOPER_MAP:
+        if pattern in lower:
+            return dev
+    return None
+
+
+def _to_float(val: Any) -> Optional[float]:
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _fetch_csv(url: str) -> List[Dict[str, str]]:
+    """Download a CSV from *url* and return a list of row dicts."""
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    reader = csv.DictReader(io.StringIO(resp.text))
+    return list(reader)
+
+
+def _model_name_from_row(row: Dict[str, str]) -> str:
+    """Extract the model name from a CSV row (first/unnamed column)."""
+    for key in ('', 'Unnamed: 0', 'model', 'Model'):
+        if key in row and row[key].strip():
+            return row[key].strip()
+    # Fallback: first value
+    return next(iter(row.values()), '').strip()
+
+
+def _build_evaluation_results(
+    row: Dict[str, str], cfg: Dict[str, Any]
+) -> List[EvaluationResult]:
+    """Build EvaluationResult list from a single CSV row."""
+    results = []
+
+    source_data = SourceDataPrivate(
+        dataset_name=cfg['source_name'],
+        source_type='other',
+    )
+
+    win_rate = _to_float(row.get('win_rate'))
+    lc_win_rate = _to_float(row.get('length_controlled_winrate'))
+    std_err = _to_float(row.get('standard_error'))
+    lc_std_err = _to_float(row.get('lc_standard_error'))
+    discrete_wr = _to_float(row.get('discrete_win_rate'))
+    avg_length = _to_float(row.get('avg_length'))
+
+    def _wr_uncertainty(se_val: Optional[float]) -> Optional[Uncertainty]:
+        if se_val is None:
+            return None
+        return Uncertainty(
+            standard_error=StandardError(
+                value=round(se_val / 100, 6), method='bootstrap'
+            )
+        )
+
+    # Win Rate (raw)
+    if win_rate is not None:
+        results.append(
+            EvaluationResult(
+                evaluation_name='Win Rate',
+                metric_config=MetricConfig(
+                    evaluation_description=(
+                        f'Fraction of outputs preferred over the '
+                        f'{cfg["baseline"]} baseline by the '
+                        f'{cfg["annotator"]} judge.'
+                    ),
+                    lower_is_better=False,
+                    score_type=ScoreType.continuous,
+                    min_score=0.0,
+                    max_score=1.0,
+                ),
+                score_details=ScoreDetails(
+                    score=round(win_rate / 100, 6),
+                    uncertainty=_wr_uncertainty(std_err),
+                ),
+                source_data=source_data,
+            )
+        )
+
+    # Length-Controlled Win Rate (v2)
+    if lc_win_rate is not None:
+        results.append(
+            EvaluationResult(
+                evaluation_name='Length-Controlled Win Rate',
+                metric_config=MetricConfig(
+                    evaluation_description=(
+                        'Win rate debiased for output length, raising '
+                        'Chatbot Arena rank correlation from 0.93 to 0.98.'
+                    ),
+                    lower_is_better=False,
+                    score_type=ScoreType.continuous,
+                    min_score=0.0,
+                    max_score=1.0,
+                ),
+                score_details=ScoreDetails(
+                    score=round(lc_win_rate / 100, 6),
+                    uncertainty=_wr_uncertainty(lc_std_err),
+                ),
+                source_data=source_data,
+            )
+        )
+
+    # Discrete Win Rate
+    if discrete_wr is not None:
+        results.append(
+            EvaluationResult(
+                evaluation_name='Discrete Win Rate',
+                metric_config=MetricConfig(
+                    evaluation_description=(
+                        'Binary win rate — no partial credit for ties.'
+                    ),
+                    lower_is_better=False,
+                    score_type=ScoreType.continuous,
+                    min_score=0.0,
+                    max_score=1.0,
+                ),
+                score_details=ScoreDetails(score=round(discrete_wr / 100, 6)),
+                source_data=source_data,
+            )
+        )
+
+    # Average response length (informational)
+    if avg_length is not None:
+        results.append(
+            EvaluationResult(
+                evaluation_name='Average Response Length',
+                metric_config=MetricConfig(
+                    evaluation_description=(
+                        'Mean number of tokens in model responses.'
+                    ),
+                    lower_is_better=False,
+                    score_type=ScoreType.continuous,
+                    min_score=0.0,
+                    max_score=100000.0,
+                ),
+                score_details=ScoreDetails(score=avg_length),
+                source_data=source_data,
+            )
+        )
+
+    return results
+
+
+class AlpacaEvalAdapter:
+    """Converts AlpacaEval leaderboard CSV rows into EvaluationLog objects."""
+
+    def fetch_leaderboard(self, version: str = 'v2') -> List[EvaluationLog]:
+        """Fetch a leaderboard by version key ('v1' or 'v2') and return logs.
+
+        Args:
+            version: Leaderboard version — 'v1' (AlpacaEval 1.0) or
+                     'v2' (AlpacaEval 2.0, weighted LC win rate).
+
+        Returns:
+            List of EvaluationLog objects, one per model row.
+        """
+        if version not in LEADERBOARDS:
+            raise ValueError(
+                f'Unknown version {version!r}. Choose from: '
+                + ', '.join(LEADERBOARDS)
+            )
+        cfg = LEADERBOARDS[version]
+        rows = _fetch_csv(cfg['url'])
+        retrieved_ts = get_current_unix_timestamp()
+
+        benchmark_key = f'alpaca_eval_{version}'
+        logs = []
+
+        for row in rows:
+            model_name = _model_name_from_row(row)
+            if not model_name:
+                continue
+
+            # Skip NullModel placeholder
+            if re.fullmatch(r'null.?model', model_name, re.IGNORECASE):
+                continue
+
+            win_rate = row.get('win_rate', '').strip()
+            if not win_rate:
+                continue
+
+            developer = _infer_developer(model_name)
+            model_id = (
+                f'{developer}/{model_name}' if developer else model_name
+            )
+
+            evaluation_id = (
+                f'{benchmark_key}/{model_id}/{retrieved_ts}'
+            )
+
+            eval_results = _build_evaluation_results(row, cfg)
+            if not eval_results:
+                continue
+
+            log = EvaluationLog(
+                schema_version=SCHEMA_VERSION,
+                evaluation_id=evaluation_id,
+                retrieved_timestamp=retrieved_ts,
+                eval_library=EvalLibrary(
+                    name='alpaca_eval',
+                    version=cfg['version'],
+                    additional_details={
+                        'annotator': cfg['annotator'],
+                        'baseline_model': cfg['baseline'],
+                        'github': (
+                            'https://github.com/tatsu-lab/alpaca_eval'
+                        ),
+                    },
+                ),
+                source_metadata=SourceMetadata(
+                    source_name=cfg['source_name'],
+                    source_type=SourceType.documentation,
+                    source_organization_name='Stanford CRFM / Tatsu Lab',
+                    source_organization_url=(
+                        'https://github.com/tatsu-lab/alpaca_eval'
+                    ),
+                    evaluator_relationship=EvaluatorRelationship.third_party,
+                ),
+                model_info=ModelInfo(
+                    name=model_name,
+                    id=model_id,
+                    developer=developer,
+                ),
+                evaluation_results=eval_results,
+            )
+            logs.append(log)
+
+        return logs

--- a/every_eval_ever/converters/alpaca_eval/adapter.py
+++ b/every_eval_ever/converters/alpaca_eval/adapter.py
@@ -18,7 +18,7 @@ from every_eval_ever.eval_types import (
     ModelInfo,
     ScoreDetails,
     ScoreType,
-    SourceDataPrivate,
+    SourceDataUrl,
     SourceMetadata,
     SourceType,
     StandardError,
@@ -136,9 +136,10 @@ def _build_evaluation_results(
     """Build EvaluationResult list from a single CSV row."""
     results = []
 
-    source_data = SourceDataPrivate(
+    source_data = SourceDataUrl(
         dataset_name=cfg['source_name'],
-        source_type='other',
+        source_type='url',
+        url=['https://github.com/tatsu-lab/alpaca_eval'],
     )
 
     win_rate = _to_float(row.get('win_rate'))

--- a/every_eval_ever/converters/alpaca_eval/adapter.py
+++ b/every_eval_ever/converters/alpaca_eval/adapter.py
@@ -81,18 +81,18 @@ _DEVELOPER_MAP = [
     ('orca', 'microsoft'),
     ('phi-', 'microsoft'),
     ('phi_', 'microsoft'),
-    ('wizardlm', 'WizardLM'),
-    ('qwen', 'Qwen'),
+    ('wizardlm', 'wizard-lm'),
+    ('qwen', 'qwen'),
     ('deepseek', 'deepseek-ai'),
     ('yi-', '01-ai'),
     ('gemma', 'google'),
-    ('command', 'CohereForAI'),
-    ('cohere', 'CohereForAI'),
+    ('command', 'cohere-for-ai'),
+    ('cohere', 'cohere-for-ai'),
     ('solar', 'upstage'),
-    ('zephyr', 'HuggingFaceH4'),
+    ('zephyr', 'hugging-face-h4'),
     ('tulu', 'allenai'),
     ('olmo', 'allenai'),
-    ('xwinlm', 'Xwin-LM'),
+    ('xwinlm', 'xwin-lm'),
     ('guanaco', 'timdettmers'),
     ('openchat', 'openchat'),
 ]
@@ -139,7 +139,7 @@ def _build_evaluation_results(
     source_data = SourceDataUrl(
         dataset_name=cfg['source_name'],
         source_type='url',
-        url=['https://github.com/tatsu-lab/alpaca_eval'],
+        url=[cfg['url']],
     )
 
     win_rate = _to_float(row.get('win_rate'))
@@ -164,6 +164,7 @@ def _build_evaluation_results(
             EvaluationResult(
                 evaluation_name='Win Rate',
                 metric_config=MetricConfig(
+                    metric_id='alpaca_eval.win_rate',
                     evaluation_description=(
                         f'Fraction of outputs preferred over the '
                         f'{cfg["baseline"]} baseline by the '
@@ -188,6 +189,7 @@ def _build_evaluation_results(
             EvaluationResult(
                 evaluation_name='Length-Controlled Win Rate',
                 metric_config=MetricConfig(
+                    metric_id='alpaca_eval.lc_win_rate',
                     evaluation_description=(
                         'Win rate debiased for output length, raising '
                         'Chatbot Arena rank correlation from 0.93 to 0.98.'
@@ -211,6 +213,7 @@ def _build_evaluation_results(
             EvaluationResult(
                 evaluation_name='Discrete Win Rate',
                 metric_config=MetricConfig(
+                    metric_id='alpaca_eval.discrete_win_rate',
                     evaluation_description=(
                         'Binary win rate — no partial credit for ties.'
                     ),
@@ -230,6 +233,7 @@ def _build_evaluation_results(
             EvaluationResult(
                 evaluation_name='Average Response Length',
                 metric_config=MetricConfig(
+                    metric_id='alpaca_eval.avg_length',
                     evaluation_description=(
                         'Mean number of tokens in model responses.'
                     ),

--- a/tests/test_alpaca_eval_adapter.py
+++ b/tests/test_alpaca_eval_adapter.py
@@ -1,0 +1,198 @@
+"""Unit tests for the AlpacaEval adapter."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from every_eval_ever.converters.alpaca_eval.adapter import (
+    LEADERBOARDS,
+    AlpacaEvalAdapter,
+    _fetch_csv,
+    _model_name_from_row,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture CSV rows
+# ---------------------------------------------------------------------------
+
+_V1_ROW = {
+    '': 'gpt4',
+    'win_rate': '95.28',
+    'standard_error': '0.68',
+    'n_wins': '476',
+    'n_wins_base': '24',
+    'n_draws': '0',
+    'n_loss': '0',
+    'discrete_win_rate': '95.28',
+    'avg_length': '1247',
+}
+
+_V2_ROW = {
+    '': 'gpt4_turbo',
+    'win_rate': '50.0',
+    'standard_error': '0.0',
+    'length_controlled_winrate': '55.12',
+    'lc_standard_error': '0.72',
+    'discrete_win_rate': '50.0',
+    'avg_length': '1024',
+}
+
+
+def _make_csv_response(rows: list[dict]) -> MagicMock:
+    import csv
+    import io
+
+    if not rows:
+        text = ''
+    else:
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+        text = buf.getvalue()
+
+    mock_resp = MagicMock()
+    mock_resp.text = text
+    mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+# ---------------------------------------------------------------------------
+# _fetch_csv
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_csv_returns_rows():
+    mock_resp = _make_csv_response([_V1_ROW])
+    with patch('every_eval_ever.converters.alpaca_eval.adapter.requests.get', return_value=mock_resp):
+        rows = _fetch_csv('http://example.com/fake.csv')
+    assert len(rows) == 1
+    assert rows[0]['win_rate'] == '95.28'
+
+
+# ---------------------------------------------------------------------------
+# _model_name_from_row
+# ---------------------------------------------------------------------------
+
+
+def test_model_name_from_unnamed_column():
+    assert _model_name_from_row({'': 'my_model', 'win_rate': '50'}) == 'my_model'
+
+
+def test_model_name_fallback_to_first_value():
+    assert _model_name_from_row({'x': 'fallback'}) == 'fallback'
+
+
+# ---------------------------------------------------------------------------
+# AlpacaEvalAdapter.fetch_leaderboard — v1
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_leaderboard_v1_produces_log():
+    mock_resp = _make_csv_response([_V1_ROW])
+    with patch('every_eval_ever.converters.alpaca_eval.adapter.requests.get', return_value=mock_resp):
+        adapter = AlpacaEvalAdapter()
+        logs = adapter.fetch_leaderboard('v1')
+
+    assert len(logs) == 1
+    log = logs[0]
+    assert log.model_info.name == 'gpt4'
+    assert log.model_info.developer == 'openai'
+    assert log.eval_library.name == 'alpaca_eval'
+    assert log.eval_library.version == '1.0'
+
+
+def test_fetch_leaderboard_v1_win_rate_value():
+    mock_resp = _make_csv_response([_V1_ROW])
+    with patch('every_eval_ever.converters.alpaca_eval.adapter.requests.get', return_value=mock_resp):
+        logs = AlpacaEvalAdapter().fetch_leaderboard('v1')
+
+    results = {r.evaluation_name: r for r in logs[0].evaluation_results}
+    assert 'Win Rate' in results
+    assert abs(results['Win Rate'].score_details.score - 95.28 / 100) < 1e-5
+
+
+def test_fetch_leaderboard_v1_source_data_url_points_to_csv():
+    mock_resp = _make_csv_response([_V1_ROW])
+    with patch('every_eval_ever.converters.alpaca_eval.adapter.requests.get', return_value=mock_resp):
+        logs = AlpacaEvalAdapter().fetch_leaderboard('v1')
+
+    source_url = logs[0].evaluation_results[0].source_data.url[0]
+    assert source_url == LEADERBOARDS['v1']['url']
+
+
+def test_fetch_leaderboard_v1_no_lc_win_rate():
+    mock_resp = _make_csv_response([_V1_ROW])
+    with patch('every_eval_ever.converters.alpaca_eval.adapter.requests.get', return_value=mock_resp):
+        logs = AlpacaEvalAdapter().fetch_leaderboard('v1')
+
+    names = [r.evaluation_name for r in logs[0].evaluation_results]
+    assert 'Length-Controlled Win Rate' not in names
+
+
+# ---------------------------------------------------------------------------
+# AlpacaEvalAdapter.fetch_leaderboard — v2
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_leaderboard_v2_has_lc_win_rate():
+    mock_resp = _make_csv_response([_V2_ROW])
+    with patch('every_eval_ever.converters.alpaca_eval.adapter.requests.get', return_value=mock_resp):
+        logs = AlpacaEvalAdapter().fetch_leaderboard('v2')
+
+    names = [r.evaluation_name for r in logs[0].evaluation_results]
+    assert 'Length-Controlled Win Rate' in names
+
+
+def test_fetch_leaderboard_v2_lc_win_rate_value():
+    mock_resp = _make_csv_response([_V2_ROW])
+    with patch('every_eval_ever.converters.alpaca_eval.adapter.requests.get', return_value=mock_resp):
+        logs = AlpacaEvalAdapter().fetch_leaderboard('v2')
+
+    results = {r.evaluation_name: r for r in logs[0].evaluation_results}
+    assert abs(results['Length-Controlled Win Rate'].score_details.score - 55.12 / 100) < 1e-5
+
+
+def test_fetch_leaderboard_v2_source_data_url_points_to_csv():
+    mock_resp = _make_csv_response([_V2_ROW])
+    with patch('every_eval_ever.converters.alpaca_eval.adapter.requests.get', return_value=mock_resp):
+        logs = AlpacaEvalAdapter().fetch_leaderboard('v2')
+
+    source_url = logs[0].evaluation_results[0].source_data.url[0]
+    assert source_url == LEADERBOARDS['v2']['url']
+
+
+# ---------------------------------------------------------------------------
+# metric_id values
+# ---------------------------------------------------------------------------
+
+
+def test_metric_ids_are_set():
+    mock_resp = _make_csv_response([_V2_ROW])
+    with patch('every_eval_ever.converters.alpaca_eval.adapter.requests.get', return_value=mock_resp):
+        logs = AlpacaEvalAdapter().fetch_leaderboard('v2')
+
+    by_name = {r.evaluation_name: r for r in logs[0].evaluation_results}
+    assert by_name['Win Rate'].metric_config.metric_id == 'alpaca_eval.win_rate'
+    assert by_name['Length-Controlled Win Rate'].metric_config.metric_id == 'alpaca_eval.lc_win_rate'
+    assert by_name['Discrete Win Rate'].metric_config.metric_id == 'alpaca_eval.discrete_win_rate'
+    assert by_name['Average Response Length'].metric_config.metric_id == 'alpaca_eval.avg_length'
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_null_model_is_skipped():
+    null_row = dict(_V1_ROW)
+    null_row[''] = 'NullModel'
+    mock_resp = _make_csv_response([null_row])
+    with patch('every_eval_ever.converters.alpaca_eval.adapter.requests.get', return_value=mock_resp):
+        logs = AlpacaEvalAdapter().fetch_leaderboard('v1')
+    assert logs == []
+
+
+def test_unknown_version_raises():
+    with pytest.raises(ValueError, match='Unknown version'):
+        AlpacaEvalAdapter().fetch_leaderboard('v99')


### PR DESCRIPTION
## Summary

  - Adds `every_eval_ever/converters/alpaca_eval/` — fetches AlpacaEval 1.0 and 2.0 leaderboard CSVs directly from
  GitHub and converts each model row into EEE schema v0.2.2 JSON
  - Registers `alpaca_eval` as a new source in the top-level CLI: `every_eval_ever convert alpaca_eval [--version
  {v1,v2}] [--output_dir PATH]`
  - Updates `every_eval_ever/converters/README.md` with full usage docs

  ## Coverage

  | Leaderboard | Judge | Baseline | Models |
  |---|---|---|---|
  | AlpacaEval 1.0 | GPT-4 | text_davinci_003 | 102 |
  | AlpacaEval 2.0 | weighted GPT-4 Turbo | gpt4_turbo | 222 |

  **Total: 324 model entries** from OpenAI, Anthropic, Google, Meta, Mistral AI, and open-source community models.

  ## Metrics captured per model

  - **Win Rate** — fraction of outputs preferred over baseline (with bootstrap SE)
  - **Length-Controlled Win Rate** — debiased for response length (v2 only; raises Chatbot Arena rank correlation 0.93 →
   0.98)
  - **Discrete Win Rate** — binary, no partial credit for ties
  - **Average Response Length** — mean token count

  ## Usage

  ```bash
  # Both leaderboards (default)
  uv run every_eval_ever convert alpaca_eval --output_dir data

  # v2 only
  uv run every_eval_ever convert alpaca_eval --version v2 --output_dir data

  Data

  Converted data submitted to HuggingFace: https://huggingface.co/datasets/karthikchundi/EEE_datastore

  ACL 2026 Shared Task

  Submitted as part of the Every Eval Ever shared task (Track 1 — Public Eval Data Parsing), deadline May 1 2026.

  Contributor

  - Name: Venkata Ramachandra Karthik Chundi
  - Email: karthik.chundi@gmail.com
  - GitHub: karthikchundi-commits
  - HuggingFace: karthikchundi