### PR TITLE
feat: add base script for displaying statistics and creating visuals

### DIFF
--- a/every_eval_ever/helpers/eee_stats.py
+++ b/every_eval_ever/helpers/eee_stats.py
@@ -12,6 +12,11 @@ from tqdm import tqdm
 SEP = '=' * 60
 SUB = '-' * 60
 
+REPO_ID = 'evaleval/EEE_datastore'
+FOLDER_PATH = 'viewer_parquets'
+
+HUGGING_FACE_DATASTORE = f'datasets/{REPO_ID}/{FOLDER_PATH}/**/*.parquet'
+
 
 def execute_query(con, sql):
     return con.execute(sql).fetchall()
@@ -179,10 +184,6 @@ def analyze_data(con, schema_table, instance_table) -> None:
 
 
 def main():
-    repo_id = 'evaleval/EEE_datastore'
-    folder_path = 'viewer_parquets'
-
-    HUGGING_FACE_DATASTORE = f'datasets/{repo_id}/{folder_path}/**/*.parquet'
     print(f'\n{SEP}')
     print('EVERY EVAL EVER STATS')
     print(f'DATASTORE: {HUGGING_FACE_DATASTORE}')

--- a/every_eval_ever/helpers/eee_stats.py
+++ b/every_eval_ever/helpers/eee_stats.py
@@ -36,7 +36,7 @@ def print_startup_summary(
     instance_urls: List[str],
 ) -> None:
     print(f'\n{SEP}')
-    print('  EVERY EVAL EVER STATS')
+    print('EVERY EVAL EVER STATS')
     print(SUB)
     print(f'datastore: {datastore}')
     print(f'tables:    {table_name}_schema, {table_name}_instances')
@@ -77,15 +77,15 @@ def build_instance_select_sql(available_columns: set[str]) -> str:
         scalar_column('sample_id', 'VARCHAR'),
         scalar_column('sample_hash', 'VARCHAR'),
         scalar_column('interaction_type', 'VARCHAR'),
-        json_column('input', 'input_json'),
-        json_column('output', 'output_json'),
-        json_column('messages', 'messages_json'),
-        json_column('answer_attribution', 'answer_attribution_json'),
-        json_column('evaluation', 'evaluation_json'),
-        json_column('token_usage', 'token_usage_json'),
-        json_column('performance', 'performance_json'),
+        json_column('input', 'input'),
+        json_column('output', 'output'),
+        json_column('messages', 'messages'),
+        json_column('answer_attribution', 'answer_attribution'),
+        json_column('evaluation', 'evaluation'),
+        json_column('token_usage', 'token_usage'),
+        json_column('performance', 'performance'),
         scalar_column('error', 'VARCHAR'),
-        json_column('metadata', 'metadata_json'),
+        json_column('metadata', 'metadata'),
         scalar_column('filename', 'VARCHAR'),
     ]
 
@@ -267,15 +267,15 @@ def main():
                     sample_id VARCHAR NOT NULL,
                     sample_hash VARCHAR,
                     interaction_type VARCHAR NOT NULL,
-                    input_json JSON NOT NULL,
-                    output_json JSON,
-                    messages_json JSON,
-                    answer_attribution_json JSON NOT NULL,
-                    evaluation_json JSON NOT NULL,
-                    token_usage_json JSON,
-                    performance_json JSON,
+                    input JSON NOT NULL,
+                    output JSON,
+                    messages JSON,
+                    answer_attribution JSON NOT NULL,
+                    evaluation JSON NOT NULL,
+                    token_usage JSON,
+                    performance JSON,
                     error VARCHAR,
-                    metadata_json JSON,
+                    metadata JSON,
                     filename VARCHAR NOT NULL
                 )
                 """

--- a/every_eval_ever/helpers/eee_stats.py
+++ b/every_eval_ever/helpers/eee_stats.py
@@ -1,0 +1,315 @@
+"""Display and summarize Every Eval Ever dataset statistics."""
+
+import argparse
+import sys
+from typing import List, Optional, Tuple
+
+import duckdb
+from huggingface_hub import HfFileSystem
+from tqdm import tqdm
+
+SEP = '=' * 60
+SUB = '-' * 60
+
+hffs = HfFileSystem()
+
+repo_id = 'evaleval/EEE_datastore'
+folder_path = 'viewer_parquets'
+
+HUGGING_FACE_DATASTORE = f'datasets/{repo_id}/{folder_path}/**/*.parquet'
+
+
+def execute_query(con, sql):
+    return con.execute(sql).fetchall()
+
+
+def section(title: str) -> None:
+    print(f'\n{SEP}')
+    print(f'  {title.upper()}')
+    print(SUB)
+
+
+def print_startup_summary(
+    datastore: str,
+    table_name: str,
+    schema_urls: List[str],
+    instance_urls: List[str],
+) -> None:
+    print(f'\n{SEP}')
+    print('  EVERY EVAL EVER STATS')
+    print(SUB)
+    print(f'datastore: {datastore}')
+    print(f'tables:    {table_name}_schema, {table_name}_instances')
+    print(f'schema files:   {len(schema_urls):,}')
+    print(f'instance files: {len(instance_urls):,}')
+
+
+def print_table_ready(name: str, row_count: int, file_count: int) -> None:
+    print(
+        f'\nLoaded {name}: {row_count:,} rows from {file_count:,} parquet files.\n'
+    )
+
+
+def get_parquet_columns(con, url: str) -> set[str]:
+    columns = con.execute(
+        'DESCRIBE SELECT * FROM read_parquet(?, filename=true)', [url]
+    ).fetchall()
+    return {column_name for column_name, *_ in columns}
+
+
+def build_instance_select_sql(available_columns: set[str]) -> str:
+    def scalar_column(name: str, sql_type: str) -> str:
+        if name in available_columns:
+            return f'CAST({name} AS {sql_type}) AS {name}'
+        return f'CAST(NULL AS {sql_type}) AS {name}'
+
+    def json_column(source_name: str, alias: str) -> str:
+        if source_name in available_columns:
+            return f'CAST(to_json({source_name}) AS JSON) AS {alias}'
+        return f'CAST(NULL AS JSON) AS {alias}'
+
+    select_columns = [
+        scalar_column('schema_version', 'VARCHAR'),
+        scalar_column('evaluation_id', 'VARCHAR'),
+        scalar_column('model_id', 'VARCHAR'),
+        scalar_column('evaluation_name', 'VARCHAR'),
+        scalar_column('evaluation_result_id', 'VARCHAR'),
+        scalar_column('sample_id', 'VARCHAR'),
+        scalar_column('sample_hash', 'VARCHAR'),
+        scalar_column('interaction_type', 'VARCHAR'),
+        json_column('input', 'input_json'),
+        json_column('output', 'output_json'),
+        json_column('messages', 'messages_json'),
+        json_column('answer_attribution', 'answer_attribution_json'),
+        json_column('evaluation', 'evaluation_json'),
+        json_column('token_usage', 'token_usage_json'),
+        json_column('performance', 'performance_json'),
+        scalar_column('error', 'VARCHAR'),
+        json_column('metadata', 'metadata_json'),
+        scalar_column('filename', 'VARCHAR'),
+    ]
+
+    return ',\n'.join(select_columns)
+
+
+def read_data(datastore) -> Optional[Tuple[List[str], List[str]]]:
+    files = hffs.glob(datastore)
+
+    if not files:
+        print('No parquet files found.')
+        return None
+
+    schema_urls = [f'hf://{f}' for f in files if f.endswith('dataset.parquet')]
+    instance_urls = [
+        f'hf://{f}' for f in files if f.endswith('dataset_samples.parquet')
+    ]
+
+    return schema_urls, instance_urls
+
+
+def analyze_data(con, schema_table, instance_table) -> None:
+    print(f'\n{SEP}')
+    print('  EVERY EVAL EVER — DATASET ANALYSIS')
+    print(f'  tables: {schema_table}, {instance_table}')
+    print(SEP)
+
+    # schema vs instance
+    n_schema_files = execute_query(
+        con, f'SELECT COUNT(DISTINCT filename) FROM {schema_table};'
+    )[0][0]
+    n_schema_rows = execute_query(con, f'SELECT COUNT(*) FROM {schema_table};')[
+        0
+    ][0]
+
+    n_instance_files = execute_query(
+        con, f'SELECT COUNT(DISTINCT filename) FROM {instance_table};'
+    )[0][0]
+    n_instance_rows = execute_query(
+        con, f'SELECT COUNT(*) FROM {instance_table};'
+    )[0][0]
+
+    section('overview')
+    print(f'  {"total files":<32} {n_schema_files + n_instance_files:>10,}')
+    print(f'  {"total rows":<32} {n_schema_rows + n_instance_rows:>10,}')
+    print(f'  {"schema files":<32} {n_schema_files:>10,}')
+    print(f'  {"instance files":<32} {n_instance_files:>10,}')
+    print(f'  {"schema rows":<32} {n_schema_rows:>10,}')
+    print(f'  {"instance rows":<32} {n_instance_rows:>10,}')
+
+    # scehma vs instance columns
+    cols = execute_query(
+        con,
+        f"""
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = '{schema_table}';
+    """,
+    )
+    section(f'columns  ({len(cols)} total)')
+    for (col,) in cols:
+        print(f'  - {col}')
+
+    cols = execute_query(
+        con,
+        f"""
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = '{instance_table}';
+    """,
+    )
+    section(f'columns  ({len(cols)} total)')
+    for (col,) in cols:
+        print(f'  - {col}')
+
+    # schema eval library names
+    lib_count = execute_query(
+        con,
+        f"""
+        SELECT eval_library.name AS lib, COUNT(*) AS n
+        FROM {schema_table}
+        WHERE eval_library IS NOT NULL
+        GROUP BY 1 ORDER BY 2 DESC;
+    """,
+    )
+    section('eval library usage  (schema level)')
+    for lib, n in lib_count:
+        print(f'  {str(lib):<42} {n:>8,}')
+
+    # scheme source metadata
+    src_counts = execute_query(
+        con,
+        f"""
+        SELECT source_metadata.source_type AS src, COUNT(*) AS n
+        FROM {schema_table}
+        WHERE source_metadata.source_type IS NOT NULL
+        GROUP BY 1 ORDER BY 2 DESC;
+    """,
+    )
+    section('source type breakdown  (schema level)')
+    for src, n in src_counts:
+        print(f'  {str(src):<42} {n:>8,}')
+
+    # parameter range
+    param_range = execute_query(
+        con,
+        f"""
+        SELECT
+            MIN(CAST(model_info.additional_details.params_billions AS FLOAT)),
+            MAX(CAST(model_info.additional_details.params_billions AS FLOAT))
+        FROM {schema_table}
+        WHERE model_info.additional_details.params_billions IS NOT NULL;
+    """,
+    )
+    section('model parameter range  (billions)')
+    if param_range and param_range[0][0] is not None:
+        min_p, max_p = param_range[0]
+        print(f'  {"min":<32} {min_p:>10.2f}B')
+        print(f'  {"max":<32} {max_p:>10.2f}B')
+    else:
+        print('  no params_billions data found')
+
+    print(f'\n{SEP}\n')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--table', default='eee', help='Table name for database'
+    )
+
+    args = parser.parse_args()
+    table_name = args.table
+
+    datastore = HUGGING_FACE_DATASTORE
+
+    with duckdb.connect(':memory:') as con:
+        con.execute('INSTALL httpfs; LOAD httpfs;')
+        data_urls = read_data(datastore)
+
+        if not data_urls:
+            sys.exit(1)
+
+        schema_urls, instance_urls = data_urls
+        print_startup_summary(
+            datastore=datastore,
+            table_name=table_name,
+            schema_urls=schema_urls,
+            instance_urls=instance_urls,
+        )
+
+        if not schema_urls and not instance_urls:
+            sys.exit(1)
+
+        if schema_urls:
+            con.execute(
+                f"""
+                CREATE OR REPLACE TABLE {table_name}_schema AS
+                SELECT * FROM read_parquet(?, union_by_name=true, filename=true)
+            """,
+                [schema_urls],
+            )
+            schema_row_count = execute_query(
+                con, f'SELECT COUNT(*) FROM {table_name}_schema;'
+            )[0][0]
+            print_table_ready(
+                name=f'{table_name}_schema',
+                row_count=schema_row_count,
+                file_count=len(schema_urls),
+            )
+
+        if instance_urls:
+            con.execute(
+                f"""
+                CREATE OR REPLACE TABLE {table_name}_instances (
+                    schema_version VARCHAR NOT NULL,
+                    evaluation_id VARCHAR NOT NULL,
+                    model_id VARCHAR NOT NULL,
+                    evaluation_name VARCHAR NOT NULL,
+                    evaluation_result_id VARCHAR,
+                    sample_id VARCHAR NOT NULL,
+                    sample_hash VARCHAR,
+                    interaction_type VARCHAR NOT NULL,
+                    input_json JSON NOT NULL,
+                    output_json JSON,
+                    messages_json JSON,
+                    answer_attribution_json JSON NOT NULL,
+                    evaluation_json JSON NOT NULL,
+                    token_usage_json JSON,
+                    performance_json JSON,
+                    error VARCHAR,
+                    metadata_json JSON,
+                    filename VARCHAR NOT NULL
+                )
+                """
+            )
+            for url in tqdm(
+                instance_urls,
+                desc='Loading instance parquet files',
+                unit='file',
+            ):
+                available_columns = get_parquet_columns(con, url)
+                instance_select_sql = build_instance_select_sql(
+                    available_columns
+                )
+                con.execute(
+                    f"""
+                    INSERT INTO {table_name}_instances
+                    SELECT
+                        {instance_select_sql}
+                    FROM read_parquet(?, filename=true)
+                    """,
+                    [url],
+                )
+
+            instance_row_count = execute_query(
+                con, f'SELECT COUNT(*) FROM {table_name}_instances;'
+            )[0][0]
+            print_table_ready(
+                name=f'{table_name}_instances',
+                row_count=instance_row_count,
+                file_count=len(instance_urls),
+            )
+
+        analyze_data(con, f'{table_name}_schema', f'{table_name}_instances')
+
+
+if __name__ == '__main__':
+    main()

--- a/every_eval_ever/helpers/eee_stats.py
+++ b/every_eval_ever/helpers/eee_stats.py
@@ -1,8 +1,9 @@
 """Display and summarize Every Eval Ever dataset statistics."""
 
 import argparse
+import re
 import sys
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import duckdb
 from huggingface_hub import HfFileSystem
@@ -10,13 +11,6 @@ from tqdm import tqdm
 
 SEP = '=' * 60
 SUB = '-' * 60
-
-hffs = HfFileSystem()
-
-repo_id = 'evaleval/EEE_datastore'
-folder_path = 'viewer_parquets'
-
-HUGGING_FACE_DATASTORE = f'datasets/{repo_id}/{folder_path}/**/*.parquet'
 
 
 def execute_query(con, sql):
@@ -27,27 +21,6 @@ def section(title: str) -> None:
     print(f'\n{SEP}')
     print(f'  {title.upper()}')
     print(SUB)
-
-
-def print_startup_summary(
-    datastore: str,
-    table_name: str,
-    schema_urls: List[str],
-    instance_urls: List[str],
-) -> None:
-    print(f'\n{SEP}')
-    print('EVERY EVAL EVER STATS')
-    print(SUB)
-    print(f'datastore: {datastore}')
-    print(f'tables:    {table_name}_schema, {table_name}_instances')
-    print(f'schema files:   {len(schema_urls):,}')
-    print(f'instance files: {len(instance_urls):,}')
-
-
-def print_table_ready(name: str, row_count: int, file_count: int) -> None:
-    print(
-        f'\nLoaded {name}: {row_count:,} rows from {file_count:,} parquet files.\n'
-    )
 
 
 def get_parquet_columns(con, url: str) -> set[str]:
@@ -92,12 +65,9 @@ def build_instance_select_sql(available_columns: set[str]) -> str:
     return ',\n'.join(select_columns)
 
 
-def read_data(datastore) -> Optional[Tuple[List[str], List[str]]]:
+def read_data(datastore) -> Tuple[List[str], List[str]]:
+    hffs = HfFileSystem()
     files = hffs.glob(datastore)
-
-    if not files:
-        print('No parquet files found.')
-        return None
 
     schema_urls = [f'hf://{f}' for f in files if f.endswith('dataset.parquet')]
     instance_urls = [
@@ -109,8 +79,7 @@ def read_data(datastore) -> Optional[Tuple[List[str], List[str]]]:
 
 def analyze_data(con, schema_table, instance_table) -> None:
     print(f'\n{SEP}')
-    print('  EVERY EVAL EVER — DATASET ANALYSIS')
-    print(f'  tables: {schema_table}, {instance_table}')
+    print(f'Tables: {schema_table}, {instance_table}')
     print(SEP)
 
     # schema vs instance
@@ -136,28 +105,28 @@ def analyze_data(con, schema_table, instance_table) -> None:
     print(f'  {"schema rows":<32} {n_schema_rows:>10,}')
     print(f'  {"instance rows":<32} {n_instance_rows:>10,}')
 
-    # scehma vs instance columns
-    cols = execute_query(
+    # schema vs instance columns
+    schema_cols = execute_query(
         con,
         f"""
         SELECT column_name FROM information_schema.columns
         WHERE table_name = '{schema_table}';
     """,
     )
-    section(f'columns  ({len(cols)} total)')
-    for (col,) in cols:
-        print(f'  - {col}')
+    section(f'columns  ({len(schema_cols)} total)')
+    for (scc,) in schema_cols:
+        print(f'  - {scc}')
 
-    cols = execute_query(
+    instance_cols = execute_query(
         con,
         f"""
         SELECT column_name FROM information_schema.columns
         WHERE table_name = '{instance_table}';
     """,
     )
-    section(f'columns  ({len(cols)} total)')
-    for (col,) in cols:
-        print(f'  - {col}')
+    section(f'columns  ({len(instance_cols)} total)')
+    for (inc,) in instance_cols:
+        print(f'  - {inc}')
 
     # schema eval library names
     lib_count = execute_query(
@@ -173,7 +142,7 @@ def analyze_data(con, schema_table, instance_table) -> None:
     for lib, n in lib_count:
         print(f'  {str(lib):<42} {n:>8,}')
 
-    # scheme source metadata
+    # schema source metadata
     src_counts = execute_query(
         con,
         f"""
@@ -210,55 +179,56 @@ def analyze_data(con, schema_table, instance_table) -> None:
 
 
 def main():
+    repo_id = 'evaleval/EEE_datastore'
+    folder_path = 'viewer_parquets'
+
+    HUGGING_FACE_DATASTORE = f'datasets/{repo_id}/{folder_path}/**/*.parquet'
+    print(f'\n{SEP}')
+    print('EVERY EVAL EVER STATS')
+    print(f'DATASTORE: {HUGGING_FACE_DATASTORE}')
+    print(SUB)
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--table', default='eee', help='Table name for database'
     )
 
     args = parser.parse_args()
-    table_name = args.table
+    if not re.fullmatch(r'[A-Za-z_][A-Za-z0-9_]*', args.table):
+        parser.error('--table must be a valid SQL identifier')
 
-    datastore = HUGGING_FACE_DATASTORE
+    table_name = args.table
+    schema_table = f'{table_name}_schema'
+    instance_table = f'{table_name}_instances'
 
     with duckdb.connect(':memory:') as con:
-        con.execute('INSTALL httpfs; LOAD httpfs;')
-        data_urls = read_data(datastore)
+        schema_loaded = False
+        instance_loaded = False
 
-        if not data_urls:
-            sys.exit(1)
+        try:
+            con.execute('LOAD httpfs;')
+        except duckdb.Error:
+            con.execute('INSTALL httpfs;')
+            con.execute('LOAD httpfs;')
 
-        schema_urls, instance_urls = data_urls
-        print_startup_summary(
-            datastore=datastore,
-            table_name=table_name,
-            schema_urls=schema_urls,
-            instance_urls=instance_urls,
-        )
-
+        schema_urls, instance_urls = read_data(HUGGING_FACE_DATASTORE)
         if not schema_urls and not instance_urls:
+            print('No parquet files found')
             sys.exit(1)
 
         if schema_urls:
             con.execute(
                 f"""
-                CREATE OR REPLACE TABLE {table_name}_schema AS
+                CREATE OR REPLACE TABLE {schema_table} AS
                 SELECT * FROM read_parquet(?, union_by_name=true, filename=true)
             """,
                 [schema_urls],
             )
-            schema_row_count = execute_query(
-                con, f'SELECT COUNT(*) FROM {table_name}_schema;'
-            )[0][0]
-            print_table_ready(
-                name=f'{table_name}_schema',
-                row_count=schema_row_count,
-                file_count=len(schema_urls),
-            )
+            schema_loaded = True
 
         if instance_urls:
             con.execute(
                 f"""
-                CREATE OR REPLACE TABLE {table_name}_instances (
+                CREATE OR REPLACE TABLE {instance_table} (
                     schema_version VARCHAR NOT NULL,
                     evaluation_id VARCHAR NOT NULL,
                     model_id VARCHAR NOT NULL,
@@ -280,6 +250,11 @@ def main():
                 )
                 """
             )
+            # we load instance parquet files one by one because duckdb
+            # can fail when unioning files with mixed nested optional column types (an issue on duckdbs side)
+            # (struct in one file, NULL-type in another for the same column).
+            # so we check each file's columns first and fill missing ones with NULL before insert.
+            # will look implement similar convention for schema level data to future proof it
             for url in tqdm(
                 instance_urls,
                 desc='Loading instance parquet files',
@@ -291,24 +266,20 @@ def main():
                 )
                 con.execute(
                     f"""
-                    INSERT INTO {table_name}_instances
+                    INSERT INTO {instance_table}
                     SELECT
                         {instance_select_sql}
                     FROM read_parquet(?, filename=true)
                     """,
                     [url],
                 )
+            instance_loaded = True
 
-            instance_row_count = execute_query(
-                con, f'SELECT COUNT(*) FROM {table_name}_instances;'
-            )[0][0]
-            print_table_ready(
-                name=f'{table_name}_instances',
-                row_count=instance_row_count,
-                file_count=len(instance_urls),
-            )
+        if not schema_loaded or not instance_loaded:
+            print('Skipping combined analysis: one table was not loaded.')
+            sys.exit(1)
 
-        analyze_data(con, f'{table_name}_schema', f'{table_name}_instances')
+        analyze_data(con, schema_table, instance_table)
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "datamodel-code-generator[ruff]>=0.52.2",
+    "duckdb>=1.5.2",
     "huggingface-hub>=0.36.0,<1.0.0",
     "jsonschema>=4.26.0,<5.0.0",
     "pydantic>=2.12.5,<3.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -173,6 +173,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -730,11 +739,41 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/66/744b4931b799a42f8cb9bc7a6f169e7b8e51195b62b246db407fd90bf15f/duckdb-1.5.2.tar.gz", hash = "sha256:638da0d5102b6cb6f7d47f83d0600708ac1d3cb46c5e9aaabc845f9ba4d69246", size = 18017166, upload-time = "2026-04-13T11:30:09.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/de/ebe66bbe78125fc610f4fd415447a65349d94245950f3b3dfb31d028af02/duckdb-1.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e6495b00cad16888384119842797c49316a96ae1cb132bb03856d980d95afee1", size = 30064950, upload-time = "2026-04-13T11:29:11.468Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d72b8856b1839d35648f38301b058f6232f4d36b463fe4dc8f4d3fdff2df1a2e", size = 15969113, upload-time = "2026-04-13T11:29:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a1de4f4d454b8c97aec546c82003fc834d3422ce4bc6a19902f3462ef293bed", size = 14224774, upload-time = "2026-04-13T11:29:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2f/a7f0de9509d1cef35608aeb382919041cdd70f58c173865c3da6a0d87979/duckdb-1.5.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce0b8141a10d37ecef729c45bc41d334854013f4389f1488bd6035c5579aaac1", size = 19313510, upload-time = "2026-04-13T11:29:19.574Z" },
+    { url = "https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99ef73a277c8921bc0a1f16dee38d924484251d9cfd20951748c20fcd5ed855", size = 21429692, upload-time = "2026-04-13T11:29:22.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/12/05b0c47d14839925c5e35b79081d918ca82e3f236bb724a6f58409dd5291/duckdb-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:8d599758b4e48bf12e18c9b960cf491d219f0c4972d19a45489c05cc5ab36f83", size = 13107594, upload-time = "2026-04-13T11:29:25.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2c/80558a82b236e044330e84a154b96aacddb343316b479f3d49be03ea11cb/duckdb-1.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:fc85a5dbcbe6eccac1113c72370d1d3aacfdd49198d63950bdf7d8638a307f00", size = 13927537, upload-time = "2026-04-13T11:29:27.842Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f2/e3d742808f138d374be4bb516fade3d1f33749b813650810ab7885cdc363/duckdb-1.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4420b3f47027a7849d0e1815532007f377fa95ee5810b47ea717d35525c12f79", size = 30064879, upload-time = "2026-04-13T11:29:30.763Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/f3dc1cf97e1267ca15e4307d456f96ce583961f0703fd75e62b2ad8d64fa/duckdb-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bb42e6ed543902e14eae647850da24103a89f0bc2587dec5601b1c1f213bd2ed", size = 15969327, upload-time = "2026-04-13T11:29:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e0/d5418def53ae4e05a63075705ff44ed5af5a1a5932627eb2b600c5df1c93/duckdb-1.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98c0535cd6d901f61a5ea3c2e26a1fd28482953d794deb183daf568e3aa5dda6", size = 14225107, upload-time = "2026-04-13T11:29:35.882Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a7/15aaa59dbecc35e9711980fcdbf525b32a52470b32d18ef678193a146213/duckdb-1.5.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:486c862bf7f163c0110b6d85b3e5c031d224a671cca468f12ebb1d3a348f6b39", size = 19313433, upload-time = "2026-04-13T11:29:38.367Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/21/d903cc63a5140c822b7b62b373a87dc557e60c29b321dfb435061c5e67cf/duckdb-1.5.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70631c847ca918ee710ec874241b00cf9d2e5be90762cbb2a0389f17823c08f7", size = 21429837, upload-time = "2026-04-13T11:29:41.135Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/0a/b770d1f60c70597302130d6247f418549b7094251a02348fbaf1c7e147ae/duckdb-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:52a21823f3fbb52f0f0e5425e20b07391ad882464b955879499b5ff0b45a376b", size = 13107699, upload-time = "2026-04-13T11:29:43.905Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cf/e200fe431d700962d1a908d2ce89f53ccee1cc8db260174ae663ba09686b/duckdb-1.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:411ad438bd4140f189a10e7f515781335962c5d18bd07837dc6d202e3985253d", size = 13927646, upload-time = "2026-04-13T11:29:46.598Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a1/f6286c67726cc1ea60a6e3c0d9fbc66527dde24ae089a51bbe298b13ca78/duckdb-1.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6b0fe75c148000f060aa1a27b293cacc0ea08cc1cad724fbf2143d56070a3785", size = 30078598, upload-time = "2026-04-13T11:29:49.828Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/59febb02f21a4a5c6b0b0099ef7c965fdd5e61e4904cf813809bb792e35f/duckdb-1.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:35579b8e3a064b5eaf15b0eafc558056a13f79a0a62e34cc4baf57119daecfec", size = 15975120, upload-time = "2026-04-13T11:29:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/09/70/ce750854d37bb5a45cccbb2c3cb04df4af56aea8fc30a2499bb643b4a9c0/duckdb-1.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea58ff5b0880593a280cf5511734b17711b32ee1f58b47d726e8600848358160", size = 14227762, upload-time = "2026-04-13T11:29:55.564Z" },
+    { url = "https://files.pythonhosted.org/packages/28/dc/ad45ac3c0b6c4687dc649e8f6cf01af1c8b0443932a39b2abb4ebcb3babd/duckdb-1.5.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef461bca07313412dc09961c4a4757a851f56b95ac01c58fac6007632b7b94f2", size = 19315668, upload-time = "2026-04-13T11:29:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b1/1464f468d2e5813f5808de95df9d3113a645a5bfa2ffcaecbc542ddae272/duckdb-1.5.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be37680ddb380015cb37318e378c53511c45c4f0d8fac5599d22b7d092b9217a", size = 21434056, upload-time = "2026-04-13T11:30:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/32/6673607e024722473fa7aafdd29c0e3dd231dd528f6cd8b5797fbeeb229d/duckdb-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:0b291786014df1133f8f18b9df4d004484613146e858d71a21791e0fcca16cf4", size = 13633667, upload-time = "2026-04-13T11:30:04.05Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e3/9d34173ec068631faea3ea6e73050700729363e7e33306a9a3218e5cdc61/duckdb-1.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:c9f3e0b71b8a50fccfb42794899285d9d318ce2503782b9dd54868e5ecd0ad31", size = 14402513, upload-time = "2026-04-13T11:30:06.609Z" },
+]
+
+[[package]]
 name = "every-eval-ever"
 version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "datamodel-code-generator", extra = ["ruff"] },
+    { name = "duckdb" },
     { name = "huggingface-hub" },
     { name = "jsonschema" },
     { name = "pydantic" },
@@ -746,9 +785,11 @@ dependencies = [
 all = [
     { name = "crfm-helm" },
     { name = "inspect-ai" },
+    { name = "typer" },
 ]
 helm = [
     { name = "crfm-helm" },
+    { name = "typer" },
 ]
 inspect = [
     { name = "inspect-ai" },
@@ -765,6 +806,7 @@ dev = [
 requires-dist = [
     { name = "crfm-helm", marker = "extra == 'helm'", specifier = ">=0.5.12" },
     { name = "datamodel-code-generator", extras = ["ruff"], specifier = ">=0.52.2" },
+    { name = "duckdb", specifier = ">=1.5.2" },
     { name = "every-eval-ever", extras = ["helm"], marker = "extra == 'all'" },
     { name = "every-eval-ever", extras = ["inspect"], marker = "extra == 'all'" },
     { name = "huggingface-hub", specifier = ">=0.36.0,<1.0.0" },
@@ -773,6 +815,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5,<3.0.0" },
     { name = "requests", specifier = ">=2.32.5,<3.0.0" },
     { name = "rich", specifier = ">=14.0.0,<15.0.0" },
+    { name = "typer", marker = "extra == 'helm'", specifier = ">=0.12,<1.0" },
 ]
 provides-extras = ["inspect", "helm", "all"]
 
@@ -2913,6 +2956,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "shortuuid"
 version = "1.0.13"
 source = { registry = "https://pypi.org/simple" }
@@ -3388,6 +3440,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/68/71c1a15b5f65f40e91b65da23b8224dad41349894535a97f63a52e462196/typeguard-4.4.4.tar.gz", hash = "sha256:3a7fd2dffb705d4d0efaed4306a704c89b9dee850b688f060a8b1615a79e5f74", size = 75203, upload-time = "2025-06-18T09:56:07.624Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/a9/e3aee762739c1d7528da1c3e06d518503f8b6c439c35549b53735ba52ead/typeguard-4.4.4-py3-none-any.whl", hash = "sha256:b5f562281b6bfa1f5492470464730ef001646128b180769880468bd84b68b09e", size = 34874, upload-time = "2025-06-18T09:56:05.999Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- reads from files in `viewer_parquets/` in hugging face repo
- creates in memory database instance with duckdb
- creates a table from all parquet files in `viewer_parquet/`
- prints statistics from created table

Future commits will include visualizations.