### PR TITLE
Helm stress test fixes

### DIFF
--- a/every_eval_ever/converters/helm/adapter.py
+++ b/every_eval_ever/converters/helm/adapter.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Tuple
 
 _HELM_IMPORT_ERROR: Exception | None = None
 try:
+    from dacite import Config as DaciteConfig
     from dacite import from_dict
     from helm.benchmark.adaptation.scenario_state import (
         AdapterSpec,
@@ -28,7 +29,7 @@ except (
     Exception
 ) as ex:  # pragma: no cover - exercised only when optional deps missing
     _HELM_IMPORT_ERROR = ex
-    from_dict = None  # type: ignore[assignment]
+    DaciteConfig = from_dict = None  # type: ignore[assignment]
     PerInstanceStats = AdapterSpec = RequestState = ScenarioState = Stat = (
         RunSpec
     ) = Any  # type: ignore[assignment]
@@ -346,9 +347,23 @@ class HELMAdapter(BaseEvaluationAdapter):
         self, raw_data: Dict, metadata_args: Dict[str, Any]
     ) -> Tuple[EvaluationLog, List[InstanceLevelEvaluationLog]]:
         run_spec = from_dict(data_class=RunSpec, data=raw_data['run_spec_dict'])
-        scenario_state = from_dict(
-            data_class=ScenarioState, data=raw_data['scenario_state_dict']
-        )
+        # cast=[str] coerces int instance IDs to str; newer HELM versions
+        # (e.g. long-context suite) store instance.id as int in the JSON.
+        try:
+            scenario_state = from_dict(
+                data_class=ScenarioState,
+                data=raw_data['scenario_state_dict'],
+                config=DaciteConfig(cast=[str]),
+            )
+        except AssertionError as exc:
+            # MediaObject.__post_init__ asserts that local media files exist.
+            # Speech/audio/vision benchmarks store media as local paths; if the
+            # asset files were not downloaded alongside the run JSON, this fires.
+            raise FileNotFoundError(
+                f'Run requires local media assets that are not present on this '
+                f'machine. Download the benchmark media files alongside the run '
+                f'directory and retry. Original assertion: {exc}'
+            ) from exc
         scenario_dict = raw_data['scenario_dict']
         stats_raw = [
             from_dict(data_class=Stat, data=s)

--- a/every_eval_ever/converters/helm/adapter.py
+++ b/every_eval_ever/converters/helm/adapter.py
@@ -18,7 +18,10 @@ try:
     )
     from helm.benchmark.metrics.metric import PerInstanceStats
     from helm.benchmark.metrics.statistic import Stat
-    from helm.benchmark.model_deployment_registry import get_model_deployment
+    from helm.benchmark.model_deployment_registry import (
+        ModelDeploymentNotFoundError,
+        get_model_deployment,
+    )
     from helm.benchmark.run_spec import RunSpec
     from helm.common.codec import from_json
 except (
@@ -32,6 +35,7 @@ except (
     get_model_deployment = register_builtin_configs_from_helm_package = (
         from_json
     ) = None  # type: ignore[assignment]
+    ModelDeploymentNotFoundError = Exception  # type: ignore[assignment]
 
 from every_eval_ever.converters import SCHEMA_VERSION
 from every_eval_ever.converters.common.adapter import (
@@ -118,9 +122,49 @@ class HELMAdapter(BaseEvaluationAdapter):
 
         return False
 
-    def _extract_model_info(self, model_deployment_name: str) -> ModelInfo:
-        """Extracts model metadata from the HELM deployment registry."""
-        deployment = get_model_deployment(model_deployment_name)
+    def _split_model_id(self, model_id: str | None) -> tuple[str, str]:
+        """Split a model id into developer/name pieces safely."""
+        model_id = (model_id or '').strip()
+        if not model_id:
+            return ('unknown', 'unknown')
+        if '/' in model_id:
+            return tuple(model_id.split('/', 1))
+        return ('unknown', model_id)
+
+    def _extract_model_info(self, adapter_spec: AdapterSpec) -> ModelInfo:
+        """Extracts model metadata from HELM, tolerating missing deployments."""
+        fallback_model_name = getattr(adapter_spec, 'model', None)
+        model_deployment_name = (
+            getattr(adapter_spec, 'model_deployment', None) or ''
+        ).strip()
+
+        if not model_deployment_name:
+            model_name = fallback_model_name or 'unknown'
+            developer, _ = self._split_model_id(model_name)
+            return ModelInfo(
+                name=model_name,
+                id=model_name,
+                developer=developer,
+                inference_platform='unknown',
+            )
+
+        try:
+            deployment = get_model_deployment(model_deployment_name)
+        except ModelDeploymentNotFoundError:
+            model_name = fallback_model_name or model_deployment_name
+            developer, _ = self._split_model_id(model_name)
+            inference_platform = (
+                model_deployment_name.split('/', 1)[0]
+                if '/' in model_deployment_name
+                else 'unknown'
+            )
+            return ModelInfo(
+                name=model_name,
+                id=model_name,
+                developer=developer,
+                inference_platform=inference_platform,
+            )
+
         client_args = getattr(deployment.client_spec, 'args', None)
 
         if 'huggingface' in deployment.name or not client_args:
@@ -130,10 +174,11 @@ class HELMAdapter(BaseEvaluationAdapter):
                 'pretrained_model_name_or_path', deployment.model_name
             )
 
+        developer, _ = self._split_model_id(deployment.model_name)
         return ModelInfo(
             name=deployment.model_name,
             id=model_id,
-            developer=deployment.model_name.split('/', 1)[0],
+            developer=developer,
             inference_platform=deployment.name.split('/', 1)[0],
         )
 
@@ -315,7 +360,7 @@ class HELMAdapter(BaseEvaluationAdapter):
             self._extract_evaluation_time(request_states) or retrieved_timestamp
         )
 
-        model_info = self._extract_model_info(adapter_spec.model_deployment)
+        model_info = self._extract_model_info(adapter_spec)
 
         dataset_name = self._extract_dataset_name(
             run_spec.name, scenario_dict.get('name') if scenario_dict else None
@@ -416,7 +461,7 @@ class HELMAdapter(BaseEvaluationAdapter):
         if request_states:
             parent_eval_output_dir = metadata_args.get('parent_eval_output_dir')
             detailed_results_id = f'{metadata_args.get("file_uuid")}_samples'
-            model_dev, model_name = model_info.id.split('/', 1)
+            model_dev, model_name = self._split_model_id(model_info.id)
             evaluation_dir = f'{parent_eval_output_dir}/{source_data.dataset_name}/{model_dev}/{model_name}'
 
             instance_level_log_path, instance_level_rows_number = (

--- a/every_eval_ever/converters/helm/adapter.py
+++ b/every_eval_ever/converters/helm/adapter.py
@@ -283,6 +283,10 @@ class HELMAdapter(BaseEvaluationAdapter):
         max_tokens = req.max_tokens if req.max_tokens is not None else getattr(
             adapter_spec, 'max_tokens', None
         )
+        # multiple_choice_separate_* methods score by log-prob and set max_tokens=0;
+        # GenerationArgs requires max_tokens >= 1, so treat 0 as None (not applicable)
+        if max_tokens == 0:
+            max_tokens = None
         top_p = req.top_p if req.top_p is not None else getattr(
             adapter_spec, 'top_p', None
         )

--- a/every_eval_ever/converters/helm/instance_level_adapter.py
+++ b/every_eval_ever/converters/helm/instance_level_adapter.py
@@ -163,7 +163,7 @@ class HELMInstanceLevelDataAdapter:
                     evaluation_name=evaluation_name,
                     sample_id=str(state.instance.id),
                     sample_hash=sha256_string(
-                        state.request.prompt + correct_refs[0]
+                        state.request.prompt + (correct_refs[0] if correct_refs else '')
                     ),  # TODO use all references
                     interaction_type=InteractionType.single_turn,
                     input=Input(

--- a/every_eval_ever/converters/helm/utils.py
+++ b/every_eval_ever/converters/helm/utils.py
@@ -23,8 +23,11 @@ def extract_all_reasonings(request_state: RequestState) -> List[str] | None:
     if not (request_state.result and request_state.result.completions):
         return None
 
-    return [
+    traces = [
         getattr(getattr(c, 'thinking', None), 'text', None)
         for c in request_state.result.completions
         if getattr(c, 'thinking', None) is not None
     ]
+    # thinking.text can itself be None; drop those to satisfy list[str] schema
+    traces = [t for t in traces if t is not None]
+    return traces if traces else None

--- a/tests/test_helm_adapter.py
+++ b/tests/test_helm_adapter.py
@@ -155,3 +155,39 @@ def test_narrativeqa_eval():
     assert converted_eval.detailed_evaluation_results is not None
     assert converted_eval.detailed_evaluation_results.format is not None
     assert converted_eval.detailed_evaluation_results.total_rows == 5
+
+
+def test_missing_model_deployment_falls_back_to_model():
+    """
+    Copies a helm data item and explicitly removes a field to test robustness
+    to model_deployment missing. Regression test for #112
+    """
+    import shutil
+    import json
+    src = Path(
+        'tests/data/helm/'
+        'mmlu:subject=philosophy,method=multiple_choice_joint,model=openai_gpt2'
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        dst = tmpdir / src.name
+        shutil.copytree(src, dst)
+
+        run_spec_fpath = dst / 'run_spec.json'
+        run_spec = json.loads(run_spec_fpath.read_text())
+        run_spec['adapter_spec'].pop('model_deployment', None)
+        run_spec_fpath.write_text(json.dumps(run_spec))
+
+        adapter = HELMAdapter()
+        metadata_args = {
+            'source_organization_name': 'TestOrg',
+            'evaluator_relationship': EvaluatorRelationship.first_party,
+        }
+
+        converted_eval = _load_eval(adapter, dst, metadata_args)
+
+    assert converted_eval.model_info.name == 'openai/gpt2'
+    assert converted_eval.model_info.id == 'openai/gpt2'
+    assert converted_eval.model_info.developer == 'openai'
+    assert converted_eval.model_info.inference_platform == 'unknown'


### PR DESCRIPTION
I'm converting all of the existing HELM results, and I ran into several errors. 

Summary of issues / fixes:

(1) Some scenarios have no reference answers, so correct_refs[0] could raise IndexError; the converter now uses an empty fallback when no references are present.

(2) Some completions contain thinking objects with text=None; since reasoning_trace is typed as list[str], the converter now drops None entries and returns None if no reasoning text remains.

(3) HELM multiple_choice_separate_* runs can set max_tokens=0 because they score by log-prob rather than generation; since EEE requires max_tokens >= 1, the converter now maps 0 to None to represent “not applicable.”

This PR is based on an older one, so the diff is muddled. It can likely be separated out as needed. I don't have tests in yet.

Benchmarks that caused the issues (has my root disk prefix, but they can be mapped to public URLs): 

Bug 1 — IndexError (correct_refs empty)
Benchmark: ifeval and wildbench, capabilities suite v1.12.0. Minimal reproducer:


/data/crfm-helm-public/capabilities/benchmark_output/runs/v1.12.0/ifeval:model=amazon_nova-premier-v1:0
Bug 2 — ValidationError (reasoning_trace None entry)
Benchmark: gpqa with a chain-of-thought qwen3 model, capabilities v1.12.0:


/data/crfm-helm-public/capabilities/benchmark_output/runs/v1.12.0/gpqa:subset=gpqa_main,use_chain_of_thought=true,use_few_shot=false,model=qwen_qwen3-235b-a22b-instruct-2507-fp8
Bug 3 — ValidationError (max_tokens=0)
Benchmark: bbq and blimp with multiple_choice_separate_* methods, classic v0.2.2:


/data/crfm-helm-public/classic/benchmark_output/runs/v0.2.2/bbq:subject=all,method=multiple_choice_separate_calibrated,model=anthropic_stanford-online-all-v4-s3,groups=ablation_multiple_choice