### PR TITLE
Add OpenEval adapter

### DIFF
--- a/tests/test_openeval_adapter.py
+++ b/tests/test_openeval_adapter.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from every_eval_ever.eval_types import EvaluationLog
+from every_eval_ever.validate import validate_file
+from utils.openeval import adapter
+
+
+def sample_payload() -> dict:
+    return {
+        'bench': [
+            {
+                'benchmark_name': 'ifeval',
+                'benchmark_version': 'v1',
+                'paper_url': 'https://arxiv.org/abs/2311.07911',
+                'dataset_url': 'https://huggingface.co/datasets/google/IFEval',
+                'benchmark_tags': ['instruction following'],
+            },
+            {
+                'benchmark_name': 'mmlu_pro',
+                'benchmark_version': '',
+                'paper_url': 'https://neurips.cc/virtual/2024/poster/97435',
+                'dataset_url': 'https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro',
+                'benchmark_tags': ['knowledge', 'multiple_choice'],
+            },
+        ],
+        'response': [
+            {
+                'response_id': 'ifeval_20260305T211125Z_0_gemma-2b-it_0',
+                'model': {
+                    'name': 'gemma-2b-it',
+                    'size': '2b',
+                    'model_adaptation': {
+                        'generation_parameters': (
+                            '{"temperature": 0.0, "top_p": 1, '
+                            '"top_k": 1, "max_tokens": 4096, '
+                            '"do_sample": false}'
+                        )
+                    },
+                },
+                'scores': {
+                    'metric': [{'name': 'ifeval_strict_accuracy'}],
+                    'value': [0.0],
+                },
+            },
+            {
+                'response_id': 'ifeval_20260305T211125Z_1_gemma-2b-it_0',
+                'model': {
+                    'name': 'gemma-2b-it',
+                    'size': '2b',
+                    'model_adaptation': {
+                        'generation_parameters': (
+                            '{"temperature": 0.0, "top_p": 1, '
+                            '"top_k": 1, "max_tokens": 4096, '
+                            '"do_sample": false}'
+                        )
+                    },
+                },
+                'scores': {
+                    'metric': [{'name': 'ifeval_strict_accuracy'}],
+                    'value': [1.0],
+                },
+            },
+            {
+                'response_id': 'mmlu-pro_20260305T211125Z_0_gpt-4o_0',
+                'model': {
+                    'name': 'gpt-4o',
+                    'model_adaptation': {
+                        'generation_parameters': '{"temperature": 0.0}'
+                    },
+                },
+                'scores': {
+                    'metric': [
+                        {
+                            'name': 'accuracy',
+                            'models': ['judge-model'],
+                            'extra_artifacts': {'type': ['judge_trace']},
+                        },
+                        {'name': 'macro_f1'},
+                    ],
+                    'value': [0.75, 0.6],
+                },
+            },
+        ],
+    }
+
+
+def logs_by_model() -> dict[str, EvaluationLog]:
+    bundles = adapter.make_logs(
+        sample_payload(),
+        retrieved_timestamp='1234567890.0',
+        revision='test-revision',
+    )
+    return {bundle.log.model_info.name: bundle.log for bundle in bundles}
+
+
+def test_make_logs_validate_against_schema():
+    logs = logs_by_model()
+
+    assert set(logs) == {'gemma-2b-it', 'gpt-4o'}
+    for log in logs.values():
+        validated = EvaluationLog.model_validate(log.model_dump())
+        assert validated.schema_version == '0.2.2'
+        assert validated.source_metadata.source_name == 'OpenEval'
+        assert validated.source_metadata.source_type.value == 'evaluation_run'
+        assert (
+            validated.source_metadata.source_organization_name
+            == 'Human-Centered Eval'
+        )
+        assert (
+            validated.source_metadata.additional_details['hf_repo']
+            == 'human-centered-eval/OpenEval'
+        )
+        assert (
+            validated.source_metadata.additional_details['partial_export']
+            == 'false'
+        )
+
+
+def test_scores_are_aggregated_by_model_benchmark_and_metric():
+    gemma = logs_by_model()['gemma-2b-it']
+
+    assert gemma.model_info.developer == 'google'
+    assert gemma.model_info.id == 'google/gemma-2b-it'
+    assert len(gemma.evaluation_results) == 1
+
+    result = gemma.evaluation_results[0]
+    assert result.evaluation_name == 'openeval.ifeval.ifeval-strict-accuracy'
+    assert result.metric_config.metric_id == (
+        'openeval.ifeval.ifeval-strict-accuracy'
+    )
+    assert result.score_details.score == 0.5
+    assert result.score_details.uncertainty.num_samples == 2
+    assert result.metric_config.min_score == 0.0
+    assert result.metric_config.max_score == 1.0
+    assert result.source_data.source_type == 'hf_dataset'
+    assert result.source_data.hf_repo == 'human-centered-eval/OpenEval'
+    assert result.source_data.dataset_name == 'ifeval'
+
+
+def test_benchmark_prefix_matching_handles_underscores():
+    gpt = logs_by_model()['gpt-4o']
+
+    assert len(gpt.evaluation_results) == 2
+    names = {result.evaluation_name for result in gpt.evaluation_results}
+    assert names == {
+        'openeval.mmlu-pro.accuracy',
+        'openeval.mmlu-pro.macro-f1',
+    }
+    for result in gpt.evaluation_results:
+        assert result.source_data.dataset_name == 'mmlu_pro'
+
+    accuracy = {
+        result.metric_config.metric_name: result
+        for result in gpt.evaluation_results
+    }['accuracy']
+    assert (
+        accuracy.metric_config.additional_details['metric_models_json']
+        == '["judge-model"]'
+    )
+    assert (
+        accuracy.metric_config.additional_details['extra_artifact_types_json']
+        == '["judge_trace"]'
+    )
+
+
+def test_generation_config_hash_is_preserved():
+    log = logs_by_model()['gemma-2b-it']
+
+    assert '/default/' not in log.evaluation_id
+    result = log.evaluation_results[0]
+    assert result.generation_config.additional_details['generation_config_hash']
+
+
+def test_extract_collection_accepts_hf_rows_shape():
+    rows = {
+        'rows': [
+            {'row_idx': 0, 'row': {'benchmark_name': 'ifeval'}},
+            {'row_idx': 1, 'row': {'benchmark_name': 'mmlu_pro'}},
+        ]
+    }
+
+    assert adapter.extract_collection(rows, 'bench') == [
+        {'benchmark_name': 'ifeval'},
+        {'benchmark_name': 'mmlu_pro'},
+    ]
+
+
+def test_partial_exports_are_marked_in_source_metadata():
+    payload = sample_payload() | {
+        'source_metadata': {
+            'hf_commit': 'abc123',
+            'downloaded_response_shards': 1,
+            'total_response_shards': 13,
+        }
+    }
+
+    bundles = adapter.make_logs(
+        payload,
+        retrieved_timestamp='1234567890.0',
+    )
+
+    details = bundles[0].log.source_metadata.additional_details
+    assert details['hf_commit'] == 'abc123'
+    assert details['partial_export'] == 'true'
+    assert details['downloaded_response_shards'] == '1'
+    assert details['total_response_shards'] == '13'
+
+
+def test_unknown_benchmark_ids_raise_by_default():
+    payload = {
+        'bench': [{'benchmark_name': 'ifeval'}],
+        'response': [
+            {
+                'response_id': 'newbench_20260305T211125Z_0_gpt-4o_0',
+                'model': {'name': 'gpt-4o'},
+                'scores': {
+                    'metric': [{'name': 'accuracy'}],
+                    'value': [1.0],
+                },
+            }
+        ],
+    }
+
+    try:
+        adapter.make_logs(payload, retrieved_timestamp='1234567890.0')
+    except ValueError as exc:
+        assert 'Could not match OpenEval response_id' in str(exc)
+    else:
+        raise AssertionError('Expected unmatched benchmark to raise')
+
+
+def test_export_paths_follow_datastore_layout(tmp_path: Path):
+    output_dir = tmp_path / 'data' / 'openeval'
+    bundles = adapter.make_logs(
+        sample_payload(), retrieved_timestamp='1234567890.0'
+    )
+    paths = adapter.export_logs(bundles, output_dir)
+
+    assert len(paths) == 2
+    for path in paths:
+        assert path.suffix == '.json'
+        assert path.parent.parent.parent == output_dir
+        report = validate_file(path)
+        assert report.valid, report.errors
+
+    assert (output_dir / 'google' / 'gemma-2b-it').is_dir()
+    assert (output_dir / 'openai' / 'gpt-4o').is_dir()

--- a/tests/test_openeval_adapter.py
+++ b/tests/test_openeval_adapter.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from every_eval_ever.eval_types import EvaluationLog
+from every_eval_ever.instance_level_types import InstanceLevelEvaluationLog
 from every_eval_ever.validate import validate_file
 from utils.openeval import adapter
 
@@ -25,6 +27,35 @@ def sample_payload() -> dict:
                 'benchmark_tags': ['knowledge', 'multiple_choice'],
             },
         ],
+        'item': [
+            {
+                'item_id': 'ifeval_20260305T211125Z_0',
+                'schema_version': '1.0',
+                'item_metadata': {'source': 'ifeval'},
+                'item_content': {
+                    'input': ['Write one sentence.'],
+                    'references': ['{"output":{"text":"A sentence."}}'],
+                },
+            },
+            {
+                'item_id': 'ifeval_20260305T211125Z_1',
+                'schema_version': '1.0',
+                'item_metadata': {'source': 'ifeval'},
+                'item_content': {
+                    'input': ['Write two words.'],
+                    'references': ['{"output":{"text":"two words"}}'],
+                },
+            },
+            {
+                'item_id': 'mmlu-pro_20260305T211125Z_0',
+                'schema_version': '1.0',
+                'item_metadata': {'source': 'mmlu_pro'},
+                'item_content': {
+                    'input': ['Which answer is correct?'],
+                    'references': ['{"output":{"text":"B"}}'],
+                },
+            },
+        ],
         'response': [
             {
                 'response_id': 'ifeval_20260305T211125Z_0_gemma-2b-it_0',
@@ -43,6 +74,8 @@ def sample_payload() -> dict:
                     'metric': [{'name': 'ifeval_strict_accuracy'}],
                     'value': [0.0],
                 },
+                'response_content': ['{"text":"One sentence."}'],
+                'item_adaptation': {'request_input': ['Write one sentence.']},
             },
             {
                 'response_id': 'ifeval_20260305T211125Z_1_gemma-2b-it_0',
@@ -61,6 +94,8 @@ def sample_payload() -> dict:
                     'metric': [{'name': 'ifeval_strict_accuracy'}],
                     'value': [1.0],
                 },
+                'response_content': ['two words'],
+                'item_adaptation': {'request_input': ['Write two words.']},
             },
             {
                 'response_id': 'mmlu-pro_20260305T211125Z_0_gpt-4o_0',
@@ -80,6 +115,10 @@ def sample_payload() -> dict:
                         {'name': 'macro_f1'},
                     ],
                     'value': [0.75, 0.6],
+                },
+                'response_content': ['B'],
+                'item_adaptation': {
+                    'request_input': ['Which answer is correct?']
                 },
             },
         ],
@@ -134,6 +173,11 @@ def test_scores_are_aggregated_by_model_benchmark_and_metric():
     assert result.score_details.uncertainty.num_samples == 2
     assert result.metric_config.min_score == 0.0
     assert result.metric_config.max_score == 1.0
+    assert result.metric_config.metric_unit == 'proportion'
+    assert (
+        result.metric_config.additional_details['score_values_are_binary']
+        == 'true'
+    )
     assert result.source_data.source_type == 'hf_dataset'
     assert result.source_data.hf_repo == 'human-centered-eval/OpenEval'
     assert result.source_data.dataset_name == 'ifeval'
@@ -162,6 +206,14 @@ def test_benchmark_prefix_matching_handles_underscores():
     assert (
         accuracy.metric_config.additional_details['extra_artifact_types_json']
         == '["judge_trace"]'
+    )
+    assert accuracy.metric_config.metric_unit == 'score'
+    assert (
+        accuracy.metric_config.additional_details['score_values_are_binary']
+        == 'false'
+    )
+    assert accuracy.metric_config.additional_details['bounds_source'] == (
+        'normalized_observed_values'
     )
 
 
@@ -247,3 +299,131 @@ def test_export_paths_follow_datastore_layout(tmp_path: Path):
 
     assert (output_dir / 'google' / 'gemma-2b-it').is_dir()
     assert (output_dir / 'openai' / 'gpt-4o').is_dir()
+
+
+def test_include_instances_writes_valid_jsonl_sidecar(tmp_path: Path):
+    output_dir = tmp_path / 'data' / 'openeval'
+    bundles = adapter.make_logs(
+        sample_payload(),
+        retrieved_timestamp='1234567890.0',
+        include_instances=True,
+    )
+
+    gemma_bundle = next(
+        bundle
+        for bundle in bundles
+        if bundle.log.model_info.name == 'gemma-2b-it'
+    )
+    assert gemma_bundle.instance_count == 2
+    assert gemma_bundle.instance_path is not None
+    assert (
+        gemma_bundle.log.source_metadata.additional_details['include_instances']
+        == 'true'
+    )
+    first = adapter.pending_instance_from_json(
+        gemma_bundle.instance_path.read_text(encoding='utf-8').splitlines()[0]
+    )
+    first_log = adapter.make_instance_log(
+        first,
+        gemma_bundle.log.evaluation_id,
+        gemma_bundle.log.model_info.id,
+        gemma_bundle.binary_result_ids,
+    )
+    assert first_log.evaluation_id == gemma_bundle.log.evaluation_id
+    assert first_log.evaluation_result_id == 'ifeval::ifeval-strict-accuracy'
+    assert first_log.evaluation.is_correct is False
+    assert first_log.metadata['is_correct_applicable'] == 'true'
+    assert first.sample_id == 'ifeval_20260305T211125Z_0'
+    assert first.raw_input == 'Write one sentence.'
+    assert first.references == ['A sentence.']
+    assert first.output == ['One sentence.']
+
+    paths = adapter.export_logs([gemma_bundle], output_dir)
+    aggregate_path = paths[0]
+    sample_path = aggregate_path.with_name(
+        f'{aggregate_path.stem}_samples.jsonl'
+    )
+    assert sample_path.exists()
+
+    aggregate = EvaluationLog.model_validate(
+        json.loads(aggregate_path.read_text(encoding='utf-8'))
+    )
+    assert aggregate.detailed_evaluation_results is not None
+    assert aggregate.detailed_evaluation_results.total_rows == 2
+    assert aggregate.detailed_evaluation_results.format.value == 'jsonl'
+    assert aggregate.detailed_evaluation_results.file_path == sample_path.name
+    assert aggregate.detailed_evaluation_results.checksum
+
+    report = validate_file(sample_path)
+    assert report.valid, report.errors
+    rows = [
+        InstanceLevelEvaluationLog.model_validate(json.loads(line))
+        for line in sample_path.read_text(encoding='utf-8').splitlines()
+    ]
+    assert {row.evaluation_id for row in rows} == {aggregate.evaluation_id}
+
+
+def test_include_instances_requires_item_records():
+    payload = sample_payload()
+    payload.pop('item')
+
+    try:
+        adapter.make_logs(
+            payload,
+            retrieved_timestamp='1234567890.0',
+            include_instances=True,
+        )
+    except ValueError as exc:
+        assert 'requires item records' in str(exc)
+    else:
+        raise AssertionError('Expected missing item records to raise')
+
+
+def test_duplicate_response_metrics_are_deduped():
+    payload = sample_payload()
+    payload['response'].append(dict(payload['response'][0]))
+
+    bundles = adapter.make_logs(
+        payload,
+        retrieved_timestamp='1234567890.0',
+        include_instances=True,
+    )
+    gemma_bundle = next(
+        bundle
+        for bundle in bundles
+        if bundle.log.model_info.name == 'gemma-2b-it'
+    )
+
+    assert gemma_bundle.instance_count == 2
+    result = gemma_bundle.log.evaluation_results[0]
+    assert result.score_details.uncertainty.num_samples == 2
+    assert result.source_data.samples_number == 2
+
+
+def test_non_binary_instance_scores_do_not_claim_correctness():
+    bundles = adapter.make_logs(
+        sample_payload(),
+        retrieved_timestamp='1234567890.0',
+        include_instances=True,
+    )
+    gpt_bundle = next(
+        bundle for bundle in bundles if bundle.log.model_info.name == 'gpt-4o'
+    )
+    rows = [
+        adapter.pending_instance_from_json(line)
+        for line in gpt_bundle.instance_path.read_text(
+            encoding='utf-8'
+        ).splitlines()
+    ]
+    accuracy = next(row for row in rows if row.metric_name == 'accuracy')
+
+    instance = adapter.make_instance_log(
+        accuracy,
+        gpt_bundle.log.evaluation_id,
+        gpt_bundle.log.model_info.id,
+        gpt_bundle.binary_result_ids,
+    )
+
+    assert instance.evaluation.score == 0.75
+    assert instance.evaluation.is_correct is False
+    assert instance.metadata['is_correct_applicable'] == 'false'

--- a/utils/README.md
+++ b/utils/README.md
@@ -18,6 +18,7 @@ Each adapter is run with `uv run python -m utils.<name>.adapter`.
 | `hfopenllm_v2` | HuggingFace Spaces API | Fetches the Open LLM Leaderboard v2 (4576+ models). |
 | `helm` | HELM leaderboard | Converts HELM leaderboard data. Supports `--leaderboard_name` for Capabilities/Lite/Classic/Instruct/MMLU. |
 | `llm_stats` | LLM Stats API | Converts LLM Stats model, benchmark, and score API data into `data/llm-stats/`. |
+| `openeval` | HuggingFace | Converts OpenEval aggregate response scores from `human-centered-eval/OpenEval` into `data/openeval/`. |
 | `rewardbench` | HuggingFace | Fetches RewardBench v1 (CSV) and RewardBench v2 (JSON) leaderboard data. |
 | `terminal_bench_2` | tbench.ai | Fetches Terminal-Bench 2.0 agentic coding benchmark results. |
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -18,7 +18,7 @@ Each adapter is run with `uv run python -m utils.<name>.adapter`.
 | `hfopenllm_v2` | HuggingFace Spaces API | Fetches the Open LLM Leaderboard v2 (4576+ models). |
 | `helm` | HELM leaderboard | Converts HELM leaderboard data. Supports `--leaderboard_name` for Capabilities/Lite/Classic/Instruct/MMLU. |
 | `llm_stats` | LLM Stats API | Converts LLM Stats model, benchmark, and score API data into `data/llm-stats/`. |
-| `openeval` | HuggingFace | Converts OpenEval aggregate response scores from `human-centered-eval/OpenEval` into `data/openeval/`. |
+| `openeval` | HuggingFace | Converts OpenEval response scores from `human-centered-eval/OpenEval` into `data/openeval/`; pass `--include-instances` to also write `*_samples.jsonl` sidecars. |
 | `rewardbench` | HuggingFace | Fetches RewardBench v1 (CSV) and RewardBench v2 (JSON) leaderboard data. |
 | `terminal_bench_2` | tbench.ai | Fetches Terminal-Bench 2.0 agentic coding benchmark results. |
 

--- a/utils/openeval/__init__.py
+++ b/utils/openeval/__init__.py
@@ -1,0 +1,1 @@
+"""OpenEval adapter utilities."""

--- a/utils/openeval/adapter.py
+++ b/utils/openeval/adapter.py
@@ -6,6 +6,7 @@ Data source:
 
 Usage:
     uv run python -m utils.openeval.adapter --output-dir data/openeval
+    uv run python -m utils.openeval.adapter --include-instances
     uv run python -m utils.openeval.adapter --input-json sample.json
 
 The offline JSON payload shape is:
@@ -14,6 +15,8 @@ The offline JSON payload shape is:
       "response": [...]
     }
 where rows match the Hugging Face ``bench`` and ``response`` table rows.
+Pass ``--include-instances`` with an ``item`` collection to write sibling
+``*_samples.jsonl`` files.
 """
 
 from __future__ import annotations
@@ -23,18 +26,22 @@ import hashlib
 import json
 import math
 import re
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, TextIO
 
 from every_eval_ever.eval_types import (
+    DetailedEvaluationResults,
     EvalLibrary,
     EvaluationLog,
     EvaluationResult,
     EvaluatorRelationship,
+    Format,
     GenerationArgs,
     GenerationConfig,
+    HashAlgorithm,
     MetricConfig,
     ModelInfo,
     ScoreDetails,
@@ -50,6 +57,14 @@ from every_eval_ever.helpers import (
     get_model_id,
     sanitize_filename,
     save_evaluation_log,
+)
+from every_eval_ever.instance_level_types import (
+    AnswerAttributionItem,
+    Evaluation,
+    Input,
+    InstanceLevelEvaluationLog,
+    InteractionType,
+    Output,
 )
 
 HF_REPO_ID = 'human-centered-eval/OpenEval'
@@ -67,6 +82,9 @@ class LogBundle:
     log: EvaluationLog
     developer: str
     model: str
+    instance_path: Path | None = None
+    instance_count: int = 0
+    binary_result_ids: set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -77,12 +95,16 @@ class MetricAccumulator:
     response_ids: list[str] = field(default_factory=list)
     metric_models: set[str] = field(default_factory=set)
     extra_artifact_types: set[str] = field(default_factory=set)
+    sample_ids: list[str] = field(default_factory=list)
 
     def add(
         self, value: float, response_id: str, metric: dict[str, Any]
     ) -> None:
         self.values.append(value)
         self.response_ids.append(response_id)
+        sample_id = response_item_id(response_id)
+        if sample_id is not None:
+            self.sample_ids.append(sample_id)
         models = metric.get('models')
         if isinstance(models, list):
             self.metric_models.update(str(model) for model in models if model)
@@ -99,6 +121,22 @@ class MetricAccumulator:
 class ModelGroup:
     generation_params: dict[str, Any]
     metrics: dict[str, MetricAccumulator] = field(default_factory=dict)
+    instance_path: Path | None = None
+    instance_handle: TextIO | None = None
+    instance_count: int = 0
+
+
+@dataclass(frozen=True)
+class PendingInstance:
+    response_id: str
+    sample_id: str
+    benchmark: dict[str, Any]
+    metric_name: str
+    score: float
+    raw_input: str
+    references: list[str]
+    output: list[str]
+    metadata: dict[str, str]
 
 
 def parse_args() -> argparse.Namespace:
@@ -135,6 +173,11 @@ def parse_args() -> argparse.Namespace:
         '--allow-unknown-benchmark',
         action='store_true',
         help='Keep responses whose benchmark cannot be matched from response_id.',
+    )
+    parser.add_argument(
+        '--include-instances',
+        action='store_true',
+        help='Also write instance-level *_samples.jsonl files.',
     )
     return parser.parse_args()
 
@@ -219,6 +262,13 @@ def validate_payload(
     return benches, responses
 
 
+def item_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    item_payload = payload.get('item') or payload.get('items')
+    if item_payload is None:
+        return []
+    return extract_collection(item_payload, 'item')
+
+
 def build_index(
     rows: list[dict[str, Any]], key: str
 ) -> dict[str, dict[str, Any]]:
@@ -244,6 +294,7 @@ def build_benchmark_index(
 def fetch_payload(
     revision: str = HF_REVISION,
     max_response_shards: int | None = None,
+    include_instances: bool = False,
 ) -> dict[str, Any]:
     """Download public OpenEval parquet shards and aggregate them to rows.
 
@@ -265,6 +316,7 @@ def fetch_payload(
         HF_REPO_ID, repo_type='dataset', revision=revision
     )
     bench_files = [path for path in files if path.startswith('bench/')]
+    item_files = sorted(path for path in files if path.startswith('item/'))
     response_files = sorted(
         path for path in files if path.startswith('response/')
     )
@@ -275,6 +327,8 @@ def fetch_payload(
         raise ValueError(
             f'Could not find bench/response parquet files in {HF_REPO_ID}.'
         )
+    if include_instances and not item_files:
+        raise ValueError(f'Could not find item parquet files in {HF_REPO_ID}.')
 
     local_bench = [
         hf_hub_download(
@@ -294,18 +348,37 @@ def fetch_payload(
         )
         for path in response_files
     ]
+    local_item = []
+    if include_instances:
+        local_item = [
+            hf_hub_download(
+                HF_REPO_ID,
+                path,
+                repo_type='dataset',
+                revision=revision,
+            )
+            for path in item_files
+        ]
 
     con = duckdb.connect()
     bench_cursor = con.execute('SELECT * FROM read_parquet(?)', [local_bench])
     bench_columns = [item[0] for item in bench_cursor.description]
     benches = [dict(zip(bench_columns, row)) for row in bench_cursor.fetchall()]
+    items = []
+    if include_instances:
+        item_cursor = con.execute('SELECT * FROM read_parquet(?)', [local_item])
+        item_columns = [item[0] for item in item_cursor.description]
+        items = [dict(zip(item_columns, row)) for row in item_cursor.fetchall()]
     # Keep response rows lazy. The full response table is large enough that
     # materializing it would make the adapter harder to run on ordinary laptops.
     # Payloads returned by this live fetch path are therefore consumed once by
     # make_logs().
-    responses = _response_rows_from_parquet(con, local_response)
+    responses = _response_rows_from_parquet(
+        con, local_response, include_instances=include_instances
+    )
     return {
         'bench': benches,
+        'item': items,
         'response': responses,
         'source_metadata': {
             'hf_revision': revision,
@@ -313,15 +386,21 @@ def fetch_payload(
             'downloaded_response_shards': len(response_files),
             'total_response_shards': total_response_shards,
             'max_response_shards': max_response_shards,
+            'include_instances': include_instances,
         },
     }
 
 
 def _response_rows_from_parquet(
-    con: Any, parquet_paths: list[str]
+    con: Any,
+    parquet_paths: list[str],
+    include_instances: bool = False,
 ) -> Iterable[dict[str, Any]]:
+    columns = ['response_id', 'model', 'scores']
+    if include_instances:
+        columns.extend(['item_adaptation', 'response_content'])
     query = (
-        'SELECT response_id, model, scores '
+        f'SELECT {", ".join(columns)} '
         'FROM read_parquet(?) '
         'WHERE scores IS NOT NULL'
     )
@@ -343,6 +422,13 @@ def response_benchmark_id(response_id: str) -> str | None:
     model/run suffixes after that.
     """
     match = re.match(r'^(.+?)_\d{8}T\d{6}Z_\d+(?:_|$)', response_id)
+    if match:
+        return match.group(1)
+    return None
+
+
+def response_item_id(response_id: str) -> str | None:
+    match = re.match(r'^(.+?_\d{8}T\d{6}Z_\d+)(?:_|$)', response_id)
     if match:
         return match.group(1)
     return None
@@ -496,45 +582,82 @@ def aggregate_scores(
     responses: Iterable[dict[str, Any]],
     limit_responses: int | None = None,
     allow_unknown_benchmark: bool = False,
+    items: list[dict[str, Any]] | None = None,
+    include_instances: bool = False,
 ) -> dict[tuple[str, str, str], ModelGroup]:
     benchmark_index = build_benchmark_index(benches)
+    item_index = build_index(items or [], 'item_id')
     groups: dict[tuple[str, str, str], ModelGroup] = {}
+    seen_results: set[tuple[str, str]] = set()
 
-    for count, response in enumerate(responses, start=1):
-        if limit_responses is not None and count > limit_responses:
-            break
-        response_id = str(response.get('response_id') or '')
-        if not response_id:
-            continue
+    try:
+        for count, response in enumerate(responses, start=1):
+            if limit_responses is not None and count > limit_responses:
+                break
+            response_id = str(response.get('response_id') or '')
+            if not response_id:
+                continue
 
-        benchmark = benchmark_for_response_id(response_id, benchmark_index)
-        if (
-            benchmark.get('benchmark_name') == 'unknown'
-            and not allow_unknown_benchmark
-        ):
-            raise ValueError(
-                f'Could not match OpenEval response_id {response_id!r} '
-                'to a benchmark. Pass --allow-unknown-benchmark to keep '
-                'unmatched rows under the unknown benchmark.'
+            benchmark = benchmark_for_response_id(response_id, benchmark_index)
+            if (
+                benchmark.get('benchmark_name') == 'unknown'
+                and not allow_unknown_benchmark
+            ):
+                raise ValueError(
+                    f'Could not match OpenEval response_id {response_id!r} '
+                    'to a benchmark. Pass --allow-unknown-benchmark to keep '
+                    'unmatched rows under the unknown benchmark.'
+                )
+            name = model_name(response)
+            size = model_size(response)
+            params = generation_parameters(response)
+            key = (name, size or '', generation_key(params))
+            group = groups.setdefault(
+                key,
+                ModelGroup(generation_params=params),
             )
-        name = model_name(response)
-        size = model_size(response)
-        params = generation_parameters(response)
-        key = (name, size or '', generation_key(params))
-        group = groups.setdefault(
-            key,
-            ModelGroup(generation_params=params),
-        )
 
-        for metric_name, score, metric in numeric_score_values(
-            response.get('scores')
-        ):
-            accumulator_key = result_key(benchmark, metric_name)
-            accumulator = group.metrics.setdefault(
-                accumulator_key,
-                MetricAccumulator(benchmark=benchmark, metric_name=metric_name),
-            )
-            accumulator.add(score, response_id, metric)
+            sample_id = response_item_id(response_id) or response_id
+            for metric_name, score, metric in numeric_score_values(
+                response.get('scores')
+            ):
+                seen_key = (name, response_id, metric_name)
+                if seen_key in seen_results:
+                    continue
+                seen_results.add(seen_key)
+                accumulator_key = result_key(benchmark, metric_name)
+                accumulator = group.metrics.setdefault(
+                    accumulator_key,
+                    MetricAccumulator(
+                        benchmark=benchmark, metric_name=metric_name
+                    ),
+                )
+                accumulator.add(score, response_id, metric)
+                if include_instances:
+                    item = item_index.get(sample_id)
+                    append_pending_instance(
+                        group,
+                        PendingInstance(
+                            response_id=response_id,
+                            sample_id=sample_id,
+                            benchmark=benchmark,
+                            metric_name=metric_name,
+                            score=score,
+                            raw_input=input_text(item, response),
+                            references=reference_texts(item),
+                            output=response_texts(response),
+                            metadata=instance_metadata(
+                                response_id,
+                                benchmark,
+                                metric_name,
+                                metric,
+                                item,
+                                response,
+                            ),
+                        ),
+                    )
+    finally:
+        close_instance_files(groups)
 
     return groups
 
@@ -546,15 +669,22 @@ def result_key(benchmark: dict[str, Any], metric_name: str) -> str:
     )
 
 
-def metric_bounds(values: list[float]) -> tuple[float, float, str]:
+def values_are_binary(values: list[float]) -> bool:
+    return bool(values) and all(value in {0.0, 1.0} for value in values)
+
+
+def metric_bounds(values: list[float]) -> tuple[float, float, str, str]:
+    if values_are_binary(values):
+        return 0.0, 1.0, 'proportion', 'binary_values'
     if values and all(0.0 <= value <= 1.0 for value in values):
-        return 0.0, 1.0, 'proportion'
+        return 0.0, 1.0, 'score', 'normalized_observed_values'
     observed_min = min(values) if values else 0.0
     observed_max = max(values) if values else 1.0
     return (
         min(0.0, observed_min),
         max(1.0, observed_max),
         'points',
+        'observed_values',
     )
 
 
@@ -576,14 +706,17 @@ def make_evaluation_result(
 ) -> EvaluationResult:
     values = accumulator.values
     score = sum(values) / len(values)
-    min_score, max_score, unit = metric_bounds(values)
+    min_score, max_score, unit, bounds_source = metric_bounds(values)
     benchmark = accumulator.benchmark
     bench_slug = normalize_slug(benchmark_name(benchmark))
     metric_slug = normalize_slug(accumulator.metric_name)
+    unique_sample_count = len(set(accumulator.sample_ids)) or len(values)
     stddev = None
     stderr = None
     if len(values) > 1:
-        variance = sum((value - score) ** 2 for value in values) / len(values)
+        variance = sum((value - score) ** 2 for value in values) / (
+            len(values) - 1
+        )
         stddev = math.sqrt(variance)
         stderr = stddev / math.sqrt(len(values))
 
@@ -601,7 +734,7 @@ def make_evaluation_result(
             source_type='hf_dataset',
             hf_repo=HF_REPO_ID,
             hf_split='train',
-            samples_number=len(values),
+            samples_number=unique_sample_count,
             additional_details=stringify_details(
                 {
                     'benchmark_name': benchmark_name(benchmark),
@@ -631,6 +764,9 @@ def make_evaluation_result(
                     'aggregation': 'mean',
                     'raw_metric_name': accumulator.metric_name,
                     'response_count': len(values),
+                    'unique_sample_count': unique_sample_count,
+                    'score_values_are_binary': values_are_binary(values),
+                    'bounds_source': bounds_source,
                     'metric_models_json': sorted(accumulator.metric_models),
                     'extra_artifact_types_json': sorted(
                         accumulator.extra_artifact_types
@@ -660,11 +796,230 @@ def make_evaluation_result(
     )
 
 
+def list_of_strings(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [stringify(item) for item in value if item not in (None, '')]
+    if value in (None, ''):
+        return []
+    return [stringify(value)]
+
+
+def maybe_json(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def item_content(item: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        return {}
+    content = item.get('item_content')
+    return content if isinstance(content, dict) else {}
+
+
+def input_text(item: dict[str, Any] | None, response: dict[str, Any]) -> str:
+    content = item_content(item)
+    inputs = list_of_strings(content.get('input'))
+    if inputs:
+        return '\n'.join(inputs)
+
+    adaptation = response.get('item_adaptation')
+    if isinstance(adaptation, dict):
+        request_input = list_of_strings(adaptation.get('request_input'))
+        if request_input:
+            return '\n'.join(request_input)
+    return ''
+
+
+def reference_texts(item: dict[str, Any] | None) -> list[str]:
+    content = item_content(item)
+    references = []
+    for raw in list_of_strings(content.get('references')):
+        parsed = maybe_json(raw)
+        if isinstance(parsed, dict):
+            output = parsed.get('output')
+            if isinstance(output, dict) and output.get('text') not in (
+                None,
+                '',
+            ):
+                references.append(str(output['text']))
+                continue
+        references.append(raw)
+    return references
+
+
+def response_texts(response: dict[str, Any]) -> list[str]:
+    texts = []
+    for raw in list_of_strings(response.get('response_content')):
+        parsed = maybe_json(raw)
+        if isinstance(parsed, dict) and parsed.get('text') not in (None, ''):
+            texts.append(str(parsed['text']))
+        else:
+            texts.append(raw)
+    return texts
+
+
+def sample_hash(raw_input: str, references: list[str]) -> str:
+    payload = json.dumps(
+        {'raw': raw_input, 'reference': references},
+        sort_keys=True,
+        separators=(',', ':'),
+    )
+    return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+
+
+def instance_metadata(
+    response_id: str,
+    benchmark: dict[str, Any],
+    metric_name: str,
+    metric: dict[str, Any],
+    item: dict[str, Any] | None,
+    response: dict[str, Any],
+) -> dict[str, str]:
+    item = item if isinstance(item, dict) else {}
+    item_meta = item.get('item_metadata') if isinstance(item, dict) else None
+    item_adaptation = response.get('item_adaptation')
+    metadata = {
+        'response_id': response_id,
+        'benchmark_name': benchmark_name(benchmark),
+        'metric_name': metric_name,
+        'raw_metric_name': metric.get('name'),
+        'metric_models_json': metric.get('models') or [],
+        'extra_artifact_types_json': (
+            metric.get('extra_artifacts', {}).get('type')
+            if isinstance(metric.get('extra_artifacts'), dict)
+            else []
+        ),
+        'item_schema_version': item.get('schema_version'),
+        'item_metadata_json': item_meta
+        if isinstance(item_meta, dict)
+        else None,
+        'item_adaptation_json': (
+            item_adaptation if isinstance(item_adaptation, dict) else None
+        ),
+    }
+    return stringify_details(metadata)
+
+
+def make_instance_log(
+    instance: PendingInstance,
+    evaluation_id: str,
+    model_id: str,
+    binary_result_ids: set[str] | None = None,
+) -> InstanceLevelEvaluationLog:
+    bench_slug = normalize_slug(benchmark_name(instance.benchmark))
+    metric_slug = normalize_slug(instance.metric_name)
+    evaluation_result_id = f'{bench_slug}::{metric_slug}'
+    extracted_value = instance.output[0] if instance.output else ''
+    is_binary_metric = evaluation_result_id in (binary_result_ids or set())
+    metadata = {
+        **instance.metadata,
+        'is_correct_applicable': stringify(is_binary_metric),
+        'is_correct_rule': (
+            'score == 1.0 for binary 0/1 metric'
+            if is_binary_metric
+            else 'false for non-binary metric; use evaluation.score'
+        ),
+    }
+
+    return InstanceLevelEvaluationLog(
+        schema_version=SCHEMA_VERSION,
+        evaluation_id=evaluation_id,
+        model_id=model_id,
+        evaluation_name=f'openeval.{bench_slug}.{metric_slug}',
+        evaluation_result_id=evaluation_result_id,
+        sample_id=instance.sample_id,
+        sample_hash=sample_hash(instance.raw_input, instance.references),
+        interaction_type=InteractionType.single_turn,
+        input=Input(raw=instance.raw_input, reference=instance.references),
+        output=Output(raw=instance.output),
+        answer_attribution=[
+            AnswerAttributionItem(
+                turn_idx=0,
+                source='output.raw',
+                extracted_value=extracted_value,
+                extraction_method=instance.metric_name,
+                is_terminal=True,
+            )
+        ],
+        evaluation=Evaluation(
+            score=instance.score,
+            is_correct=is_binary_metric and instance.score == 1.0,
+        ),
+        metadata=metadata,
+    )
+
+
+def pending_instance_to_json(instance: PendingInstance) -> str:
+    return json.dumps(
+        {
+            'response_id': instance.response_id,
+            'sample_id': instance.sample_id,
+            'benchmark': instance.benchmark,
+            'metric_name': instance.metric_name,
+            'score': instance.score,
+            'raw_input': instance.raw_input,
+            'references': instance.references,
+            'output': instance.output,
+            'metadata': instance.metadata,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(',', ':'),
+    )
+
+
+def pending_instance_from_json(line: str) -> PendingInstance:
+    data = json.loads(line)
+    return PendingInstance(
+        response_id=str(data['response_id']),
+        sample_id=str(data['sample_id']),
+        benchmark=data['benchmark'],
+        metric_name=str(data['metric_name']),
+        score=float(data['score']),
+        raw_input=str(data['raw_input']),
+        references=list_of_strings(data.get('references')),
+        output=list_of_strings(data.get('output')),
+        metadata=stringify_details(data.get('metadata') or {}),
+    )
+
+
+def append_pending_instance(
+    group: ModelGroup, instance: PendingInstance
+) -> None:
+    if group.instance_path is None:
+        handle = tempfile.NamedTemporaryFile(
+            mode='w',
+            encoding='utf-8',
+            prefix='openeval-instances-',
+            suffix='.jsonl',
+            delete=False,
+        )
+        group.instance_path = Path(handle.name)
+        group.instance_handle = handle
+
+    if group.instance_handle is None:
+        group.instance_handle = group.instance_path.open('a', encoding='utf-8')
+    group.instance_handle.write(pending_instance_to_json(instance) + '\n')
+    group.instance_count += 1
+
+
+def close_instance_files(
+    groups: dict[tuple[str, str, str], ModelGroup],
+) -> None:
+    for group in groups.values():
+        if group.instance_handle is not None:
+            group.instance_handle.close()
+            group.instance_handle = None
+
+
 def source_metadata(
     revision: str,
     payload_metadata: dict[str, Any] | None = None,
     limit_responses: int | None = None,
     allow_unknown_benchmark: bool = False,
+    include_instances: bool = False,
 ) -> SourceMetadata:
     payload_metadata = payload_metadata or {}
     downloaded_shards = payload_metadata.get('downloaded_response_shards')
@@ -701,6 +1056,8 @@ def source_metadata(
                     'max_response_shards'
                 ),
                 'limit_responses': limit_responses,
+                'include_instances': include_instances
+                or payload_metadata.get('include_instances'),
                 'partial_export': partial_export,
                 'allow_unknown_benchmark': allow_unknown_benchmark,
                 'source_role': 'aggregator',
@@ -715,14 +1072,23 @@ def make_logs(
     revision: str = HF_REVISION,
     limit_responses: int | None = None,
     allow_unknown_benchmark: bool = False,
+    include_instances: bool = False,
 ) -> list[LogBundle]:
     benches, responses = validate_payload(payload)
+    items = item_rows(payload) if include_instances else []
+    if include_instances and not items:
+        raise ValueError(
+            'OpenEval instance-level output requires item records. '
+            'Include an "item" collection in --input-json or use live fetch.'
+        )
     timestamp = retrieved_timestamp or str(time.time())
     groups = aggregate_scores(
         benches,
         responses,
         limit_responses,
         allow_unknown_benchmark=allow_unknown_benchmark,
+        items=items,
+        include_instances=include_instances,
     )
     payload_metadata = (
         payload.get('source_metadata')
@@ -734,6 +1100,7 @@ def make_logs(
         payload_metadata,
         limit_responses,
         allow_unknown_benchmark,
+        include_instances,
     )
 
     bundles: list[LogBundle] = []
@@ -770,24 +1137,100 @@ def make_logs(
                 results, key=lambda item: item.evaluation_result_id or ''
             ),
         )
+        binary_result_ids = {
+            result.evaluation_result_id
+            for result in results
+            if result.evaluation_result_id
+            and (result.metric_config.additional_details or {}).get(
+                'score_values_are_binary'
+            )
+            == 'true'
+        }
         bundles.append(
-            LogBundle(log=log, developer=developer, model=model_slug)
+            LogBundle(
+                log=log,
+                developer=developer,
+                model=model_slug,
+                instance_path=group.instance_path,
+                instance_count=group.instance_count,
+                binary_result_ids=binary_result_ids,
+            )
         )
 
     return bundles
 
 
+def save_instance_logs(
+    pending_path: Path | None,
+    instance_count: int,
+    aggregate_path: Path,
+    evaluation_id: str,
+    model_id: str,
+    binary_result_ids: set[str] | None = None,
+) -> DetailedEvaluationResults | None:
+    if pending_path is None or instance_count == 0:
+        return None
+
+    sample_path = aggregate_path.with_name(
+        f'{aggregate_path.stem}_samples.jsonl'
+    )
+    file_hash = hashlib.sha256()
+    with (
+        pending_path.open('r', encoding='utf-8') as pending_handle,
+        sample_path.open('w', encoding='utf-8') as handle,
+    ):
+        for line in pending_handle:
+            if not line.strip():
+                continue
+            instance = pending_instance_from_json(line)
+            instance_log = make_instance_log(
+                instance, evaluation_id, model_id, binary_result_ids
+            )
+            output_line = (
+                json.dumps(
+                    instance_log.model_dump(mode='json', exclude_none=True),
+                    ensure_ascii=False,
+                )
+                + '\n'
+            )
+            file_hash.update(output_line.encode('utf-8'))
+            handle.write(output_line)
+
+    pending_path.unlink(missing_ok=True)
+
+    return DetailedEvaluationResults(
+        format=Format.jsonl,
+        file_path=sample_path.name,
+        hash_algorithm=HashAlgorithm.sha256,
+        checksum=file_hash.hexdigest(),
+        total_rows=instance_count,
+    )
+
+
 def export_logs(bundles: list[LogBundle], output_dir: Path) -> list[Path]:
     paths = []
     for bundle in bundles:
-        paths.append(
-            save_evaluation_log(
-                bundle.log,
-                output_dir,
-                bundle.developer,
-                bundle.model,
-            )
+        path = save_evaluation_log(
+            bundle.log,
+            output_dir,
+            bundle.developer,
+            bundle.model,
         )
+        detailed = save_instance_logs(
+            bundle.instance_path,
+            bundle.instance_count,
+            path,
+            bundle.log.evaluation_id,
+            bundle.log.model_info.id,
+            bundle.binary_result_ids,
+        )
+        if detailed is not None:
+            bundle.log.detailed_evaluation_results = detailed
+            path.write_text(
+                bundle.log.model_dump_json(indent=2, exclude_none=True),
+                encoding='utf-8',
+            )
+        paths.append(path)
     return paths
 
 
@@ -798,13 +1241,18 @@ def run(args: argparse.Namespace) -> int:
         max_response_shards = args.max_response_shards
         if args.limit_responses is not None and max_response_shards is None:
             max_response_shards = 1
-        payload = fetch_payload(args.revision, max_response_shards)
+        payload = fetch_payload(
+            args.revision,
+            max_response_shards,
+            include_instances=args.include_instances,
+        )
 
     bundles = make_logs(
         payload,
         revision=args.revision,
         limit_responses=args.limit_responses,
         allow_unknown_benchmark=args.allow_unknown_benchmark,
+        include_instances=args.include_instances,
     )
     paths = export_logs(bundles, args.output_dir)
     for path in paths:

--- a/utils/openeval/adapter.py
+++ b/utils/openeval/adapter.py
@@ -1,0 +1,817 @@
+#!/usr/bin/env python3
+"""Convert OpenEval response data into Every Eval Ever aggregate records.
+
+Data source:
+- OpenEval dataset: https://huggingface.co/datasets/human-centered-eval/OpenEval
+
+Usage:
+    uv run python -m utils.openeval.adapter --output-dir data/openeval
+    uv run python -m utils.openeval.adapter --input-json sample.json
+
+The offline JSON payload shape is:
+    {
+      "bench": [...],
+      "response": [...]
+    }
+where rows match the Hugging Face ``bench`` and ``response`` table rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from every_eval_ever.eval_types import (
+    EvalLibrary,
+    EvaluationLog,
+    EvaluationResult,
+    EvaluatorRelationship,
+    GenerationArgs,
+    GenerationConfig,
+    MetricConfig,
+    ModelInfo,
+    ScoreDetails,
+    ScoreType,
+    SourceDataHf,
+    SourceMetadata,
+    StandardError,
+    Uncertainty,
+)
+from every_eval_ever.helpers import (
+    SCHEMA_VERSION,
+    get_developer,
+    get_model_id,
+    sanitize_filename,
+    save_evaluation_log,
+)
+
+HF_REPO_ID = 'human-centered-eval/OpenEval'
+HF_REVISION = 'main'
+DEFAULT_OUTPUT_DIR = 'data/openeval'
+SOURCE_NAME = 'OpenEval'
+SOURCE_ORGANIZATION = 'Human-Centered Eval'
+SOURCE_ORGANIZATION_URL = 'https://open-eval.github.io/'
+HF_DATASET_URL = f'https://huggingface.co/datasets/{HF_REPO_ID}'
+GITHUB_URL = 'https://github.com/open-eval/OpenEval'
+
+
+@dataclass(frozen=True)
+class LogBundle:
+    log: EvaluationLog
+    developer: str
+    model: str
+
+
+@dataclass
+class MetricAccumulator:
+    benchmark: dict[str, Any]
+    metric_name: str
+    values: list[float] = field(default_factory=list)
+    response_ids: list[str] = field(default_factory=list)
+    metric_models: set[str] = field(default_factory=set)
+    extra_artifact_types: set[str] = field(default_factory=set)
+
+    def add(
+        self, value: float, response_id: str, metric: dict[str, Any]
+    ) -> None:
+        self.values.append(value)
+        self.response_ids.append(response_id)
+        models = metric.get('models')
+        if isinstance(models, list):
+            self.metric_models.update(str(model) for model in models if model)
+        artifacts = metric.get('extra_artifacts')
+        if isinstance(artifacts, dict) and isinstance(
+            artifacts.get('type'), list
+        ):
+            self.extra_artifact_types.update(
+                str(kind) for kind in artifacts['type'] if kind
+            )
+
+
+@dataclass
+class ModelGroup:
+    generation_params: dict[str, Any]
+    metrics: dict[str, MetricAccumulator] = field(default_factory=dict)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Convert OpenEval HF dataset results to EEE format.'
+    )
+    parser.add_argument(
+        '--input-json',
+        type=Path,
+        help='Read an offline JSON payload instead of fetching from HF.',
+    )
+    parser.add_argument(
+        '--output-dir',
+        type=Path,
+        default=Path(DEFAULT_OUTPUT_DIR),
+        help=f'Output directory (default: {DEFAULT_OUTPUT_DIR}).',
+    )
+    parser.add_argument(
+        '--revision',
+        default=HF_REVISION,
+        help=f'Hugging Face dataset revision (default: {HF_REVISION}).',
+    )
+    parser.add_argument(
+        '--limit-responses',
+        type=int,
+        help='Limit live/offline responses for smoke runs.',
+    )
+    parser.add_argument(
+        '--max-response-shards',
+        type=int,
+        help='Limit downloaded HF response parquet shards for smoke runs.',
+    )
+    parser.add_argument(
+        '--allow-unknown-benchmark',
+        action='store_true',
+        help='Keep responses whose benchmark cannot be matched from response_id.',
+    )
+    return parser.parse_args()
+
+
+def stringify(value: Any) -> str:
+    if isinstance(value, bool):
+        return 'true' if value else 'false'
+    if value is None:
+        return 'null'
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, separators=(',', ':'))
+    return str(value)
+
+
+def stringify_details(details: dict[str, Any]) -> dict[str, str]:
+    return {
+        key: stringify(value)
+        for key, value in details.items()
+        if value not in (None, '')
+    }
+
+
+def normalize_slug(value: Any, fallback: str = 'unknown') -> str:
+    raw = str(value if value not in (None, '') else fallback).strip().lower()
+    raw = sanitize_filename(raw)
+    raw = raw.replace('&', 'and')
+    raw = re.sub(r'[\s_]+', '-', raw)
+    raw = re.sub(r'[^a-z0-9.\-]+', '-', raw)
+    raw = re.sub(r'-{2,}', '-', raw).strip('-')
+    return raw or 'unknown'
+
+
+def load_payload(input_json: Path) -> dict[str, Any]:
+    payload = json.loads(input_json.read_text(encoding='utf-8'))
+    if not isinstance(payload, dict):
+        raise ValueError('--input-json must contain a JSON object.')
+    return payload
+
+
+def extract_collection(payload: Any, name: str) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if not isinstance(payload, dict):
+        raise ValueError(f'Expected {name!r} payload to be a list or object.')
+
+    for key in (name, f'{name}s', 'data', 'rows', 'items', 'results'):
+        value = payload.get(key)
+        if isinstance(value, list):
+            rows = []
+            for item in value:
+                if isinstance(item, dict) and isinstance(item.get('row'), dict):
+                    rows.append(item['row'])
+                elif isinstance(item, dict):
+                    rows.append(item)
+            return rows
+        if (
+            isinstance(value, dict)
+            and value
+            and all(isinstance(item, dict) for item in value.values())
+        ):
+            return list(value.values())
+
+    if payload and all(isinstance(item, dict) for item in payload.values()):
+        return list(payload.values())
+
+    raise ValueError(f'Could not find a list of {name!r} records.')
+
+
+def validate_payload(
+    payload: dict[str, Any],
+) -> tuple[list[dict[str, Any]], Iterable[dict[str, Any]]]:
+    benches = extract_collection(payload.get('bench'), 'bench')
+    response_payload = payload.get('response') or payload.get('responses')
+    if isinstance(response_payload, (list, dict)):
+        responses: Iterable[dict[str, Any]] = extract_collection(
+            response_payload, 'response'
+        )
+    elif response_payload is not None:
+        responses = response_payload
+    else:
+        raise ValueError('Could not find a list of response records.')
+    return benches, responses
+
+
+def build_index(
+    rows: list[dict[str, Any]], key: str
+) -> dict[str, dict[str, Any]]:
+    index = {}
+    for row in rows:
+        value = row.get(key)
+        if value not in (None, ''):
+            index[str(value)] = row
+    return index
+
+
+def build_benchmark_index(
+    benches: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    index = build_index(benches, 'benchmark_name')
+    for benchmark in benches:
+        name = benchmark.get('benchmark_name')
+        if name not in (None, ''):
+            index[normalize_slug(name)] = benchmark
+    return index
+
+
+def fetch_payload(
+    revision: str = HF_REVISION,
+    max_response_shards: int | None = None,
+) -> dict[str, Any]:
+    """Download public OpenEval parquet shards and aggregate them to rows.
+
+    The project already depends on ``huggingface_hub`` and ``duckdb``. Using
+    parquet shards avoids a large dependency on ``datasets`` and avoids the
+    HF row API pagination path for the 500k+ response table.
+    """
+    try:
+        import duckdb
+        from huggingface_hub import HfApi, hf_hub_download
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise SystemExit(
+            'OpenEval live fetch requires huggingface_hub and duckdb.'
+        ) from exc
+
+    api = HfApi()
+    info = api.dataset_info(HF_REPO_ID, revision=revision)
+    files = api.list_repo_files(
+        HF_REPO_ID, repo_type='dataset', revision=revision
+    )
+    bench_files = [path for path in files if path.startswith('bench/')]
+    response_files = sorted(
+        path for path in files if path.startswith('response/')
+    )
+    total_response_shards = len(response_files)
+    if max_response_shards is not None:
+        response_files = response_files[:max_response_shards]
+    if not bench_files or not response_files:
+        raise ValueError(
+            f'Could not find bench/response parquet files in {HF_REPO_ID}.'
+        )
+
+    local_bench = [
+        hf_hub_download(
+            HF_REPO_ID,
+            path,
+            repo_type='dataset',
+            revision=revision,
+        )
+        for path in bench_files
+    ]
+    local_response = [
+        hf_hub_download(
+            HF_REPO_ID,
+            path,
+            repo_type='dataset',
+            revision=revision,
+        )
+        for path in response_files
+    ]
+
+    con = duckdb.connect()
+    bench_cursor = con.execute('SELECT * FROM read_parquet(?)', [local_bench])
+    bench_columns = [item[0] for item in bench_cursor.description]
+    benches = [dict(zip(bench_columns, row)) for row in bench_cursor.fetchall()]
+    # Keep response rows lazy. The full response table is large enough that
+    # materializing it would make the adapter harder to run on ordinary laptops.
+    # Payloads returned by this live fetch path are therefore consumed once by
+    # make_logs().
+    responses = _response_rows_from_parquet(con, local_response)
+    return {
+        'bench': benches,
+        'response': responses,
+        'source_metadata': {
+            'hf_revision': revision,
+            'hf_commit': getattr(info, 'sha', None),
+            'downloaded_response_shards': len(response_files),
+            'total_response_shards': total_response_shards,
+            'max_response_shards': max_response_shards,
+        },
+    }
+
+
+def _response_rows_from_parquet(
+    con: Any, parquet_paths: list[str]
+) -> Iterable[dict[str, Any]]:
+    query = (
+        'SELECT response_id, model, scores '
+        'FROM read_parquet(?) '
+        'WHERE scores IS NOT NULL'
+    )
+    cursor = con.execute(query, [parquet_paths])
+    names = [item[0] for item in cursor.description]
+    while True:
+        rows = cursor.fetchmany(10000)
+        if not rows:
+            break
+        for row in rows:
+            yield dict(zip(names, row))
+
+
+def response_benchmark_id(response_id: str) -> str | None:
+    """Extract the benchmark prefix from an OpenEval response id.
+
+    OpenEval response ids start with the item id. The item id has the shape
+    ``<benchmark>_<timestamp>_<row_index>``, while the response id appends
+    model/run suffixes after that.
+    """
+    match = re.match(r'^(.+?)_\d{8}T\d{6}Z_\d+(?:_|$)', response_id)
+    if match:
+        return match.group(1)
+    return None
+
+
+def benchmark_for_response_id(
+    response_id: str, benchmark_index: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    parsed = response_benchmark_id(response_id)
+    if parsed:
+        for candidate in (parsed, normalize_slug(parsed)):
+            if candidate in benchmark_index:
+                return benchmark_index[candidate]
+
+    for benchmark_name in sorted(benchmark_index, key=len, reverse=True):
+        if response_id.startswith(f'{benchmark_name}_'):
+            return benchmark_index[benchmark_name]
+    return {
+        'benchmark_name': 'unknown',
+        'benchmark_version': '',
+        'paper_url': None,
+        'dataset_url': HF_DATASET_URL,
+        'benchmark_tags': [],
+    }
+
+
+def numeric_score_values(
+    scores: Any,
+) -> list[tuple[str, float, dict[str, Any]]]:
+    if not isinstance(scores, dict):
+        return []
+    metrics = scores.get('metric') or []
+    values = scores.get('value') or []
+    if not isinstance(metrics, list) or not isinstance(values, list):
+        return []
+
+    pairs = []
+    for metric, value in zip(metrics, values, strict=False):
+        if not isinstance(metric, dict):
+            continue
+        name = metric.get('name')
+        if name in (None, ''):
+            continue
+        try:
+            score = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isnan(score) or math.isinf(score):
+            continue
+        pairs.append((str(name), score, metric))
+    return pairs
+
+
+def model_name(response: dict[str, Any]) -> str:
+    model = response.get('model')
+    if isinstance(model, dict):
+        value = model.get('name')
+        if value not in (None, ''):
+            return str(value)
+    return 'unknown'
+
+
+def model_size(response: dict[str, Any]) -> str | None:
+    model = response.get('model')
+    if isinstance(model, dict) and model.get('size') not in (None, ''):
+        return str(model['size'])
+    return None
+
+
+def generation_parameters(response: dict[str, Any]) -> dict[str, Any]:
+    model = response.get('model')
+    if not isinstance(model, dict):
+        return {}
+    adaptation = model.get('model_adaptation')
+    if not isinstance(adaptation, dict):
+        return {}
+    params = adaptation.get('generation_parameters')
+    if isinstance(params, dict):
+        return params
+    if isinstance(params, str) and params.strip():
+        try:
+            decoded = json.loads(params)
+        except json.JSONDecodeError:
+            return {'raw_generation_parameters': params}
+        return decoded if isinstance(decoded, dict) else {}
+    return {}
+
+
+def generation_key(params: dict[str, Any]) -> str:
+    if not params:
+        return 'default'
+    blob = json.dumps(params, sort_keys=True, separators=(',', ':'))
+    return hashlib.sha256(blob.encode('utf-8')).hexdigest()[:12]
+
+
+def make_generation_config(params: dict[str, Any]) -> GenerationConfig | None:
+    if not params:
+        return None
+
+    def maybe_float(name: str) -> float | None:
+        value = params.get(name)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def maybe_int(name: str) -> int | None:
+        value = params.get(name)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    additional = {
+        key: value
+        for key, value in params.items()
+        if key not in {'temperature', 'top_p', 'top_k', 'max_tokens'}
+    }
+    return GenerationConfig(
+        generation_args=GenerationArgs(
+            temperature=maybe_float('temperature'),
+            top_p=maybe_float('top_p'),
+            top_k=maybe_float('top_k'),
+            max_tokens=maybe_int('max_tokens'),
+        ),
+        additional_details=stringify_details(additional) or None,
+    )
+
+
+def normalize_model_info(
+    name: str, size: str | None
+) -> tuple[ModelInfo, str, str]:
+    developer = get_developer(name)
+    model_id = get_model_id(name, developer)
+    model_slug = normalize_slug(model_id.split('/', 1)[-1], name)
+    details = stringify_details({'raw_model_name': name, 'model_size': size})
+    return (
+        ModelInfo(
+            name=name,
+            id=model_id,
+            developer=developer,
+            additional_details=details,
+        ),
+        normalize_slug(developer),
+        model_slug,
+    )
+
+
+def aggregate_scores(
+    benches: list[dict[str, Any]],
+    responses: Iterable[dict[str, Any]],
+    limit_responses: int | None = None,
+    allow_unknown_benchmark: bool = False,
+) -> dict[tuple[str, str, str], ModelGroup]:
+    benchmark_index = build_benchmark_index(benches)
+    groups: dict[tuple[str, str, str], ModelGroup] = {}
+
+    for count, response in enumerate(responses, start=1):
+        if limit_responses is not None and count > limit_responses:
+            break
+        response_id = str(response.get('response_id') or '')
+        if not response_id:
+            continue
+
+        benchmark = benchmark_for_response_id(response_id, benchmark_index)
+        if (
+            benchmark.get('benchmark_name') == 'unknown'
+            and not allow_unknown_benchmark
+        ):
+            raise ValueError(
+                f'Could not match OpenEval response_id {response_id!r} '
+                'to a benchmark. Pass --allow-unknown-benchmark to keep '
+                'unmatched rows under the unknown benchmark.'
+            )
+        name = model_name(response)
+        size = model_size(response)
+        params = generation_parameters(response)
+        key = (name, size or '', generation_key(params))
+        group = groups.setdefault(
+            key,
+            ModelGroup(generation_params=params),
+        )
+
+        for metric_name, score, metric in numeric_score_values(
+            response.get('scores')
+        ):
+            accumulator_key = result_key(benchmark, metric_name)
+            accumulator = group.metrics.setdefault(
+                accumulator_key,
+                MetricAccumulator(benchmark=benchmark, metric_name=metric_name),
+            )
+            accumulator.add(score, response_id, metric)
+
+    return groups
+
+
+def result_key(benchmark: dict[str, Any], metric_name: str) -> str:
+    return (
+        f'{normalize_slug(benchmark.get("benchmark_name"))}.'
+        f'{normalize_slug(metric_name)}'
+    )
+
+
+def metric_bounds(values: list[float]) -> tuple[float, float, str]:
+    if values and all(0.0 <= value <= 1.0 for value in values):
+        return 0.0, 1.0, 'proportion'
+    observed_min = min(values) if values else 0.0
+    observed_max = max(values) if values else 1.0
+    return (
+        min(0.0, observed_min),
+        max(1.0, observed_max),
+        'points',
+    )
+
+
+def benchmark_name(benchmark: dict[str, Any]) -> str:
+    return str(benchmark.get('benchmark_name') or 'unknown')
+
+
+def benchmark_url(benchmark: dict[str, Any]) -> str | None:
+    for key in ('dataset_url', 'paper_url'):
+        value = benchmark.get(key)
+        if isinstance(value, str) and value.startswith(('http://', 'https://')):
+            return value
+    return None
+
+
+def make_evaluation_result(
+    accumulator: MetricAccumulator,
+    generation_config: GenerationConfig | None,
+) -> EvaluationResult:
+    values = accumulator.values
+    score = sum(values) / len(values)
+    min_score, max_score, unit = metric_bounds(values)
+    benchmark = accumulator.benchmark
+    bench_slug = normalize_slug(benchmark_name(benchmark))
+    metric_slug = normalize_slug(accumulator.metric_name)
+    stddev = None
+    stderr = None
+    if len(values) > 1:
+        variance = sum((value - score) ** 2 for value in values) / len(values)
+        stddev = math.sqrt(variance)
+        stderr = stddev / math.sqrt(len(values))
+
+    urls = [HF_DATASET_URL, GITHUB_URL]
+    extra_url = benchmark_url(benchmark)
+    if extra_url:
+        urls.append(extra_url)
+
+    tags = benchmark.get('benchmark_tags')
+    return EvaluationResult(
+        evaluation_result_id=f'{bench_slug}::{metric_slug}',
+        evaluation_name=f'openeval.{bench_slug}.{metric_slug}',
+        source_data=SourceDataHf(
+            dataset_name=benchmark_name(benchmark),
+            source_type='hf_dataset',
+            hf_repo=HF_REPO_ID,
+            hf_split='train',
+            samples_number=len(values),
+            additional_details=stringify_details(
+                {
+                    'benchmark_name': benchmark_name(benchmark),
+                    'benchmark_version': benchmark.get('benchmark_version'),
+                    'paper_url': benchmark.get('paper_url'),
+                    'dataset_url': benchmark.get('dataset_url'),
+                    'source_urls_json': urls,
+                }
+            ),
+        ),
+        metric_config=MetricConfig(
+            evaluation_description=(
+                f'Mean OpenEval score for {accumulator.metric_name} '
+                f'on {benchmark_name(benchmark)}.'
+            ),
+            metric_id=f'openeval.{bench_slug}.{metric_slug}',
+            metric_name=accumulator.metric_name,
+            metric_kind='benchmark_score',
+            metric_unit=unit,
+            lower_is_better=False,
+            score_type=ScoreType.continuous,
+            min_score=min_score,
+            max_score=max_score,
+            additional_details=stringify_details(
+                {
+                    'benchmark_tags_json': tags,
+                    'aggregation': 'mean',
+                    'raw_metric_name': accumulator.metric_name,
+                    'response_count': len(values),
+                    'metric_models_json': sorted(accumulator.metric_models),
+                    'extra_artifact_types_json': sorted(
+                        accumulator.extra_artifact_types
+                    ),
+                }
+            ),
+        ),
+        score_details=ScoreDetails(
+            score=score,
+            uncertainty=Uncertainty(
+                standard_error=StandardError(value=stderr, method='analytic')
+                if stderr is not None
+                else None,
+                standard_deviation=stddev,
+                num_samples=len(values),
+            ),
+            details=stringify_details(
+                {
+                    'min_instance_score': min(values),
+                    'max_instance_score': max(values),
+                    'response_count': len(values),
+                    'example_response_ids_json': accumulator.response_ids[:5],
+                }
+            ),
+        ),
+        generation_config=generation_config,
+    )
+
+
+def source_metadata(
+    revision: str,
+    payload_metadata: dict[str, Any] | None = None,
+    limit_responses: int | None = None,
+    allow_unknown_benchmark: bool = False,
+) -> SourceMetadata:
+    payload_metadata = payload_metadata or {}
+    downloaded_shards = payload_metadata.get('downloaded_response_shards')
+    total_shards = payload_metadata.get('total_response_shards')
+    partial_export = (
+        limit_responses is not None
+        or payload_metadata.get('max_response_shards') is not None
+        or (
+            isinstance(downloaded_shards, int)
+            and isinstance(total_shards, int)
+            and downloaded_shards < total_shards
+        )
+    )
+    return SourceMetadata(
+        source_name=SOURCE_NAME,
+        source_type='evaluation_run',
+        source_organization_name=SOURCE_ORGANIZATION,
+        source_organization_url=SOURCE_ORGANIZATION_URL,
+        evaluator_relationship=EvaluatorRelationship.third_party,
+        additional_details=stringify_details(
+            {
+                'hf_repo': HF_REPO_ID,
+                'hf_dataset_url': HF_DATASET_URL,
+                'github_url': GITHUB_URL,
+                'hf_revision': revision,
+                'hf_commit': payload_metadata.get('hf_commit'),
+                'downloaded_response_shards': payload_metadata.get(
+                    'downloaded_response_shards'
+                ),
+                'total_response_shards': payload_metadata.get(
+                    'total_response_shards'
+                ),
+                'max_response_shards': payload_metadata.get(
+                    'max_response_shards'
+                ),
+                'limit_responses': limit_responses,
+                'partial_export': partial_export,
+                'allow_unknown_benchmark': allow_unknown_benchmark,
+                'source_role': 'aggregator',
+            }
+        ),
+    )
+
+
+def make_logs(
+    payload: dict[str, Any],
+    retrieved_timestamp: str | None = None,
+    revision: str = HF_REVISION,
+    limit_responses: int | None = None,
+    allow_unknown_benchmark: bool = False,
+) -> list[LogBundle]:
+    benches, responses = validate_payload(payload)
+    timestamp = retrieved_timestamp or str(time.time())
+    groups = aggregate_scores(
+        benches,
+        responses,
+        limit_responses,
+        allow_unknown_benchmark=allow_unknown_benchmark,
+    )
+    payload_metadata = (
+        payload.get('source_metadata')
+        if isinstance(payload.get('source_metadata'), dict)
+        else {}
+    )
+    metadata = source_metadata(
+        revision,
+        payload_metadata,
+        limit_responses,
+        allow_unknown_benchmark,
+    )
+
+    bundles: list[LogBundle] = []
+    for (name, size, gen_key), group in sorted(groups.items()):
+        model_info, developer, model_slug = normalize_model_info(
+            name, size or None
+        )
+        generation_config = make_generation_config(group.generation_params)
+        if generation_config is not None:
+            details = generation_config.additional_details or {}
+            generation_config.additional_details = {
+                **details,
+                'generation_config_hash': gen_key,
+            }
+        results = [
+            make_evaluation_result(metric, generation_config)
+            for metric in group.metrics.values()
+            if metric.values
+        ]
+        if not results:
+            continue
+
+        sanitized_model_id = model_info.id.replace('/', '_')
+        log = EvaluationLog(
+            schema_version=SCHEMA_VERSION,
+            evaluation_id=(
+                f'openeval/{sanitized_model_id}/{gen_key}/{timestamp}'
+            ),
+            retrieved_timestamp=timestamp,
+            source_metadata=metadata,
+            eval_library=EvalLibrary(name='OpenEval', version='unknown'),
+            model_info=model_info,
+            evaluation_results=sorted(
+                results, key=lambda item: item.evaluation_result_id or ''
+            ),
+        )
+        bundles.append(
+            LogBundle(log=log, developer=developer, model=model_slug)
+        )
+
+    return bundles
+
+
+def export_logs(bundles: list[LogBundle], output_dir: Path) -> list[Path]:
+    paths = []
+    for bundle in bundles:
+        paths.append(
+            save_evaluation_log(
+                bundle.log,
+                output_dir,
+                bundle.developer,
+                bundle.model,
+            )
+        )
+    return paths
+
+
+def run(args: argparse.Namespace) -> int:
+    if args.input_json is not None:
+        payload = load_payload(args.input_json)
+    else:
+        max_response_shards = args.max_response_shards
+        if args.limit_responses is not None and max_response_shards is None:
+            max_response_shards = 1
+        payload = fetch_payload(args.revision, max_response_shards)
+
+    bundles = make_logs(
+        payload,
+        revision=args.revision,
+        limit_responses=args.limit_responses,
+        allow_unknown_benchmark=args.allow_unknown_benchmark,
+    )
+    paths = export_logs(bundles, args.output_dir)
+    for path in paths:
+        print(path)
+    return len(paths)
+
+
+if __name__ == '__main__':
+    written = run(parse_args())
+    print(f'Wrote {written} OpenEval model log(s).')


### PR DESCRIPTION
## Summary

Add a utils adapter for the public OpenEval dataset at
`human-centered-eval/OpenEval`. The adapter converts OpenEval benchmark response
scores into EEE aggregate `EvaluationLog` JSON files and can optionally emit
instance-level `_samples.jsonl` sidecars for sample traceability.

The implementation is split into two commits:

- `feat: add OpenEval adapter`
- `feat: add OpenEval instance sidecars`

## What changed

- Add `utils/openeval/adapter.py` and `utils/openeval/__init__.py`.
- Fetch OpenEval `bench`, `response`, and optionally `item` parquet shards from
  Hugging Face using existing project dependencies (`huggingface_hub`, `duckdb`).
- Aggregate response scores into one EEE `EvaluationLog` per model plus
  generation-config group.
- Preserve provenance metadata including HF repo, revision, commit, shard counts,
  benchmark URLs, raw model names, and OpenEval metric metadata.
- Add `--include-instances` to write sibling `{uuid}_samples.jsonl` files and
  link them from `detailed_evaluation_results` with SHA-256 checksums.
- Deduplicate duplicate `(model, response_id, metric)` rows before aggregation
  and sidecar emission.
- Stream instance sidecars through temporary JSONL files to avoid retaining every
  instance-level row in memory.
- Treat instance-level `is_correct` as applicable only for binary 0/1 metrics;
  non-binary metrics preserve `evaluation.score` and mark correctness as not
  applicable in metadata.
- Use sample variance for analytic standard error and publish metric bounds
  provenance in `metric_config.additional_details`.
- Document the adapter in `utils/README.md`.
- Add focused tests in `tests/test_openeval_adapter.py`.

## Verification

Focused local checks pass:

```bash
uv run ruff check utils/openeval/adapter.py tests/test_openeval_adapter.py
uv run ruff format --check utils/openeval/adapter.py tests/test_openeval_adapter.py
uv run pytest tests/test_openeval_adapter.py -q
```

Result: `12 passed`.

Smoke live exports pass schema validation:

```bash
uv run python -m utils.openeval.adapter --limit-responses 25 --output-dir "$tmp/openeval"
uv run python -m every_eval_ever validate "$tmp/openeval"

uv run python -m utils.openeval.adapter --include-instances --limit-responses 25 --output-dir "$tmp/openeval"
uv run python -m every_eval_ever validate "$tmp/openeval"
```

Result:

- aggregate-only smoke: all files passed validation
- instance smoke: aggregate JSON + `_samples.jsonl` passed validation

Full live exports were also run locally:

- aggregate-only full export: 357 aggregate JSON files; all passed validation
- full `--include-instances` export: 357 aggregate JSON files + 357 JSONL
  sidecars; 1,162,999 instance rows; all 714 files passed validation
- full instance output size was about 8.8GB and is intentionally not committed
- final full instance export peak RSS was about 5.3GB
- all aggregate `detailed_evaluation_results.total_rows` values matched actual
  JSONL line counts, and all sidecar paths were relative basenames

## Independent review

I also ran a Claude review over the PR diff. The actionable findings were folded
in before this push:

- Avoid claiming instance-level correctness for non-binary metrics.
- Distinguish binary, normalized, and observed metric bounds in metadata.
- Use unique sample counts for `source_data.samples_number`.
- Use sample variance for reported standard error.
- Keep temporary instance files open during aggregation instead of opening once
  per row.
- Store relative JSONL sidecar paths in `detailed_evaluation_results`.
- Avoid large `sample_ids` arrays in aggregate JSON.

## Known unrelated local test failures

A full local `uv run pytest -q` still fails outside this change with 13 failures:

- HELM tests fail because the installed HELM package does not expose
  `ModelDeploymentNotFoundError` from `helm.benchmark.model_deployment_registry`.
- `tests/test_inspect_adapter.py::test_convert_model_path_to_standarized_model_ids`
  expects `deepseek-ai/deepseek-r1-0528` but the current normalization returns
  `nvidia/deepseek-r1-0528`.

The OpenEval-specific tests and live validation pass.

## Notes for reviewers

The default run remains aggregate-only:

```bash
uv run python -m utils.openeval.adapter --output-dir data/openeval
```

Instance-level output is opt-in because it writes a large amount of per-sample
prompt/output data:

```bash
uv run python -m utils.openeval.adapter --include-instances --output-dir data/openeval
```

Generated `data/openeval/` files should not be committed.
