### PR TITLE
Add descriptive dataset statistics plots

### DIFF
--- a/every_eval_ever/helpers/dataset_statistics.py
+++ b/every_eval_ever/helpers/dataset_statistics.py
@@ -1,0 +1,671 @@
+"""Descriptive and uncertainty-aware summaries for Every Eval Ever."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import re
+import statistics
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+SEP = '=' * 72
+SUB = '-' * 72
+
+REPO_ID = 'evaleval/EEE_datastore'
+FOLDER_PATH = 'viewer_parquets'
+HUGGING_FACE_DATASTORE = f'datasets/{REPO_ID}/{FOLDER_PATH}/**/*.parquet'
+
+CONTINUOUS_SCORE_TYPE = 'continuous'
+STABILIZATION_WEIGHT = 5.0
+BOOTSTRAP_ITERATIONS = 400
+RANDOM_SEED = 20260429
+
+
+def read_data(datastore: str) -> list[str]:
+    from huggingface_hub import HfFileSystem
+
+    hffs = HfFileSystem()
+    files = hffs.glob(datastore)
+    return [f'hf://{f}' for f in files if f.endswith('dataset.parquet')]
+
+
+def load_schema_table(con: Any, table: str) -> None:
+    schema_urls = read_data(HUGGING_FACE_DATASTORE)
+    if not schema_urls:
+        raise RuntimeError('No schema parquet files found')
+    con.execute(
+        f"""
+        CREATE OR REPLACE TABLE {table} AS
+        SELECT * FROM read_parquet(?, union_by_name=true, filename=true)
+        """,
+        [schema_urls],
+    )
+
+
+def extract_result_rows(
+    con: Any, schema_table: str
+) -> list[dict[str, Any]]:
+    rows = con.execute(
+        f"""
+        SELECT
+            schema_version,
+            evaluation_id,
+            model_info.id AS model_id,
+            model_info.developer AS model_developer,
+            er.evaluation_name AS evaluation_name,
+            er.source_data.dataset_name AS benchmark,
+            er.metric_config.score_type AS score_type,
+            er.metric_config.lower_is_better AS lower_is_better,
+            TRY_CAST(er.metric_config.min_score AS DOUBLE) AS min_score,
+            TRY_CAST(er.metric_config.max_score AS DOUBLE) AS max_score,
+            TRY_CAST(er.score_details.score AS DOUBLE) AS score,
+            er.score_details.uncertainty IS NOT NULL AS has_uncertainty,
+            er.metric_config.metric_id AS metric_id,
+            er.metric_config.metric_name AS metric_name,
+            er.metric_config.metric_kind AS metric_kind,
+            er.metric_config.metric_unit AS metric_unit,
+            source_metadata.source_organization_name AS source_organization
+        FROM {schema_table},
+        LATERAL UNNEST(evaluation_results) AS t(er)
+        """
+    ).fetchall()
+    columns = [
+        'schema_version',
+        'evaluation_id',
+        'model_id',
+        'model_developer',
+        'evaluation_name',
+        'benchmark',
+        'score_type',
+        'lower_is_better',
+        'min_score',
+        'max_score',
+        'score',
+        'has_uncertainty',
+        'metric_id',
+        'metric_name',
+        'metric_kind',
+        'metric_unit',
+        'source_organization',
+    ]
+    return [dict(zip(columns, row)) for row in rows]
+
+
+def normalize_score(
+    score: float,
+    min_score: float,
+    max_score: float,
+    lower_is_better: bool,
+) -> float:
+    normalized = (score - min_score) / (max_score - min_score)
+    if lower_is_better:
+        normalized = 1.0 - normalized
+    return normalized
+
+
+def percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = (len(ordered) - 1) * pct
+    lower = math.floor(index)
+    upper = math.ceil(index)
+    if lower == upper:
+        return ordered[int(index)]
+    weight = index - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def numeric_summary(values: Iterable[float]) -> dict[str, float | int | None]:
+    vals = [v for v in values if v is not None and math.isfinite(v)]
+    if not vals:
+        return {
+            'count': 0,
+            'min': None,
+            'median': None,
+            'mean': None,
+            'max': None,
+            'stddev': None,
+        }
+    return {
+        'count': len(vals),
+        'min': min(vals),
+        'median': statistics.median(vals),
+        'mean': statistics.mean(vals),
+        'max': max(vals),
+        'stddev': statistics.stdev(vals) if len(vals) > 1 else 0.0,
+    }
+
+
+def shared_evaluation_key(row: dict[str, Any]) -> str:
+    parts = [
+        row.get('benchmark'),
+        row.get('evaluation_name'),
+        row.get('score_type'),
+        row.get('min_score'),
+        row.get('max_score'),
+        bool(row.get('lower_is_better')),
+    ]
+    return json.dumps(parts, sort_keys=False, separators=(',', ':'))
+
+
+def quality_counts(rows: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {
+        'total_result_rows': len(rows),
+        'missing_score': 0,
+        'missing_bounds': 0,
+        'zero_width_bounds': 0,
+        'incompatible_score_type': 0,
+        'out_of_range': 0,
+        'missing_metadata': 0,
+        'has_uncertainty': 0,
+    }
+    for row in rows:
+        score = row.get('score')
+        min_score = row.get('min_score')
+        max_score = row.get('max_score')
+        if score is None:
+            counts['missing_score'] += 1
+        if min_score is None or max_score is None:
+            counts['missing_bounds'] += 1
+        elif min_score == max_score:
+            counts['zero_width_bounds'] += 1
+        elif score is not None and not min_score <= score <= max_score:
+            counts['out_of_range'] += 1
+        if row.get('score_type') != CONTINUOUS_SCORE_TYPE:
+            counts['incompatible_score_type'] += 1
+        if not row.get('model_id') or not row.get('benchmark'):
+            counts['missing_metadata'] += 1
+        if row.get('has_uncertainty'):
+            counts['has_uncertainty'] += 1
+    return counts
+
+
+def valid_normalized_rows(
+    rows: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    valid = []
+    exclusions = {
+        'missing_score': 0,
+        'missing_bounds': 0,
+        'zero_width_bounds': 0,
+        'incompatible_score_type': 0,
+        'out_of_range': 0,
+    }
+    for row in rows:
+        score = row.get('score')
+        min_score = row.get('min_score')
+        max_score = row.get('max_score')
+        if score is None:
+            exclusions['missing_score'] += 1
+            continue
+        if min_score is None or max_score is None:
+            exclusions['missing_bounds'] += 1
+            continue
+        if min_score == max_score:
+            exclusions['zero_width_bounds'] += 1
+            continue
+        if row.get('score_type') != CONTINUOUS_SCORE_TYPE:
+            exclusions['incompatible_score_type'] += 1
+            continue
+        if not min_score <= score <= max_score:
+            exclusions['out_of_range'] += 1
+            continue
+        normalized = normalize_score(
+            float(score),
+            float(min_score),
+            float(max_score),
+            bool(row.get('lower_is_better')),
+        )
+        valid_row = dict(row)
+        valid_row['normalized_score'] = normalized
+        valid_row['shared_evaluation_key'] = shared_evaluation_key(row)
+        valid.append(valid_row)
+    return valid, exclusions
+
+
+def distinct_count(rows: list[dict[str, Any]], key: str) -> int:
+    return len({row.get(key) for row in rows if row.get(key) is not None})
+
+
+def count_values(
+    rows: list[dict[str, Any]], key: str
+) -> list[dict[str, int | str]]:
+    counts = Counter(str(row.get(key)) for row in rows if row.get(key) is not None)
+    return [
+        {'value': value, 'count': count}
+        for value, count in counts.most_common()
+    ]
+
+
+def grouped_summaries(
+    rows: list[dict[str, Any]],
+    value_key: str,
+    group_keys: tuple[str, ...],
+    limit: int,
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[Any, ...], list[float]] = defaultdict(list)
+    for row in rows:
+        value = row.get(value_key)
+        if value is None:
+            continue
+        grouped[tuple(row.get(key) for key in group_keys)].append(float(value))
+
+    summaries = []
+    for group, values in grouped.items():
+        item = {key: group[index] for index, key in enumerate(group_keys)}
+        item.update(numeric_summary(values))
+        summaries.append(item)
+    summaries.sort(key=lambda item: (-int(item['count']), str(item)))
+    return summaries[:limit]
+
+
+def bootstrap_interval_and_support(
+    values: list[float],
+    threshold: float,
+    iterations: int = BOOTSTRAP_ITERATIONS,
+) -> tuple[list[float | None], float | None]:
+    if not values:
+        return [None, None], None
+    rng = random.Random(RANDOM_SEED + len(values))
+    estimates = []
+    for _ in range(iterations):
+        sample = [values[rng.randrange(len(values))] for _ in values]
+        estimates.append(statistics.mean(sample))
+    return [
+        percentile(estimates, 0.025),
+        percentile(estimates, 0.975),
+    ], sum(estimate > threshold for estimate in estimates) / len(estimates)
+
+
+def stabilized_estimate(
+    mean_score: float,
+    count: int,
+    corpus_mean: float,
+    weight: float = STABILIZATION_WEIGHT,
+) -> float:
+    return (count * mean_score + weight * corpus_mean) / (count + weight)
+
+
+def coverage_aware_model_summaries(
+    rows: list[dict[str, Any]], limit: int
+) -> list[dict[str, Any]]:
+    if not rows:
+        return []
+    corpus_mean = statistics.mean(row['normalized_score'] for row in rows)
+    key_means = {
+        key: statistics.mean(item['normalized_score'] for item in items)
+        for key, items in _group_rows(rows, 'shared_evaluation_key').items()
+    }
+
+    summaries = []
+    for model_id, items in _group_rows(rows, 'model_id').items():
+        scores = [item['normalized_score'] for item in items]
+        centered_scores = [
+            item['normalized_score']
+            - key_means[item['shared_evaluation_key']]
+            + corpus_mean
+            for item in items
+        ]
+        raw_mean = statistics.mean(scores)
+        centered_mean = statistics.mean(centered_scores)
+        stabilized = stabilized_estimate(raw_mean, len(scores), corpus_mean)
+        rng = random.Random(RANDOM_SEED + len(scores))
+        bootstrap_scores = []
+        for _ in range(BOOTSTRAP_ITERATIONS):
+            sample = [scores[rng.randrange(len(scores))] for _ in scores]
+            bootstrap_scores.append(
+                stabilized_estimate(
+                    statistics.mean(sample), len(sample), corpus_mean
+                )
+            )
+        interval = [
+            percentile(bootstrap_scores, 0.025),
+            percentile(bootstrap_scores, 0.975),
+        ]
+        support = (
+            sum(score > corpus_mean for score in bootstrap_scores)
+            / len(bootstrap_scores)
+        )
+        summaries.append(
+            {
+                'model_id': model_id,
+                'result_count': len(items),
+                'benchmark_count': distinct_count(items, 'benchmark'),
+                'evaluation_count': distinct_count(items, 'shared_evaluation_key'),
+                'mean_normalized_score': raw_mean,
+                'benchmark_centered_score': centered_mean,
+                'stabilized_score': stabilized,
+                'uncertainty_interval': interval,
+                'support_above_corpus_average': support,
+            }
+        )
+    summaries.sort(
+        key=lambda item: (
+            -float(item['stabilized_score']),
+            -int(item['evaluation_count']),
+            str(item['model_id']),
+        )
+    )
+    return summaries[:limit]
+
+
+def pairwise_model_comparisons(
+    rows: list[dict[str, Any]],
+    min_shared_evals: int,
+    top_model_limit: int,
+    comparison_limit: int,
+) -> list[dict[str, Any]]:
+    by_model_key: dict[str, dict[str, list[float]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    model_counts = Counter(row['model_id'] for row in rows if row.get('model_id'))
+    top_models = {
+        model
+        for model, _ in model_counts.most_common(top_model_limit)
+        if model is not None
+    }
+    for row in rows:
+        model_id = row.get('model_id')
+        if model_id not in top_models:
+            continue
+        by_model_key[model_id][row['shared_evaluation_key']].append(
+            row['normalized_score']
+        )
+
+    model_scores = {
+        model: {
+            key: statistics.mean(values)
+            for key, values in scores_by_key.items()
+        }
+        for model, scores_by_key in by_model_key.items()
+    }
+    models = sorted(model_scores)
+    comparisons = []
+    rng = random.Random(RANDOM_SEED)
+    for index, model_a in enumerate(models):
+        for model_b in models[index + 1 :]:
+            shared_keys = sorted(
+                set(model_scores[model_a]) & set(model_scores[model_b])
+            )
+            if len(shared_keys) < min_shared_evals:
+                continue
+            diffs = [
+                model_scores[model_a][key] - model_scores[model_b][key]
+                for key in shared_keys
+            ]
+            boot_means = []
+            for _ in range(BOOTSTRAP_ITERATIONS):
+                sample = [diffs[rng.randrange(len(diffs))] for _ in diffs]
+                boot_means.append(statistics.mean(sample))
+            comparisons.append(
+                {
+                    'model_a': model_a,
+                    'model_b': model_b,
+                    'shared_evaluation_count': len(shared_keys),
+                    'mean_paired_difference': statistics.mean(diffs),
+                    'uncertainty_interval': [
+                        percentile(boot_means, 0.025),
+                        percentile(boot_means, 0.975),
+                    ],
+                    'support_model_a_higher': sum(
+                        value > 0 for value in boot_means
+                    )
+                    / len(boot_means),
+                }
+            )
+    comparisons.sort(
+        key=lambda item: (
+            -int(item['shared_evaluation_count']),
+            -abs(float(item['mean_paired_difference'])),
+            str(item['model_a']),
+            str(item['model_b']),
+        )
+    )
+    return comparisons[:comparison_limit]
+
+
+def descriptive_statistics(
+    rows: list[dict[str, Any]], summary_limit: int
+) -> dict[str, Any]:
+    valid_rows, exclusions = valid_normalized_rows(rows)
+    return {
+        'counts': {
+            'result_rows': len(rows),
+            'unique_models': distinct_count(rows, 'model_id'),
+            'unique_developers': distinct_count(rows, 'model_developer'),
+            'unique_benchmarks': distinct_count(rows, 'benchmark'),
+            'unique_evaluations': distinct_count(rows, 'evaluation_name'),
+        },
+        'schema_versions': count_values(rows, 'schema_version'),
+        'quality': quality_counts(rows),
+        'normalization_exclusions': exclusions,
+        'score_summaries': grouped_summaries(
+            rows,
+            'score',
+            ('benchmark', 'evaluation_name'),
+            summary_limit,
+        ),
+        'normalized_score_summaries': grouped_summaries(
+            valid_rows,
+            'normalized_score',
+            ('benchmark', 'evaluation_name'),
+            summary_limit,
+        ),
+    }
+
+
+def build_statistics_report(
+    rows: list[dict[str, Any]],
+    summary_limit: int,
+    comparison_limit: int,
+    top_model_limit: int,
+    min_shared_evals: int,
+    descriptive_only: bool,
+) -> dict[str, Any]:
+    valid_rows, exclusions = valid_normalized_rows(rows)
+    report = {
+        'descriptive': descriptive_statistics(rows, summary_limit),
+        'observational': {
+            'valid_normalized_rows': len(valid_rows),
+            'exclusions': exclusions,
+        },
+    }
+    if descriptive_only:
+        return report
+    report['observational'].update(
+        {
+            'coverage_aware_model_summaries': coverage_aware_model_summaries(
+                valid_rows, top_model_limit
+            ),
+            'pairwise_model_comparisons': pairwise_model_comparisons(
+                valid_rows,
+                min_shared_evals,
+                top_model_limit,
+                comparison_limit,
+            ),
+        }
+    )
+    return report
+
+
+def _group_rows(
+    rows: list[dict[str, Any]], key: str
+) -> dict[Any, list[dict[str, Any]]]:
+    grouped: dict[Any, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[row.get(key)].append(row)
+    return grouped
+
+
+def section(title: str) -> None:
+    print(f'\n{SEP}')
+    print(f'  {title.upper()}')
+    print(SUB)
+
+
+def print_table(items: list[dict[str, Any]], columns: list[str]) -> None:
+    for item in items:
+        parts = []
+        for column in columns:
+            value = item.get(column)
+            if isinstance(value, float):
+                value = f'{value:.4f}'
+            parts.append(f'{column}={value}')
+        print('  ' + '  '.join(parts))
+
+
+def print_report(report: dict[str, Any], descriptive_only: bool) -> None:
+    descriptive = report['descriptive']
+    section('dataset counts')
+    for key, value in descriptive['counts'].items():
+        print(f'  {key:<32} {value:>10,}')
+
+    section('quality diagnostics')
+    for key, value in descriptive['quality'].items():
+        print(f'  {key:<32} {value:>10,}')
+
+    section('normalization exclusions')
+    for key, value in report['observational']['exclusions'].items():
+        print(f'  {key:<32} {value:>10,}')
+
+    section('score summaries')
+    print_table(
+        descriptive['score_summaries'],
+        ['benchmark', 'evaluation_name', 'count', 'mean', 'median', 'stddev'],
+    )
+
+    section('normalized score summaries')
+    print_table(
+        descriptive['normalized_score_summaries'],
+        ['benchmark', 'evaluation_name', 'count', 'mean', 'median', 'stddev'],
+    )
+
+    if descriptive_only:
+        return
+
+    section('coverage-aware model summaries')
+    print_table(
+        report['observational']['coverage_aware_model_summaries'],
+        [
+            'model_id',
+            'evaluation_count',
+            'stabilized_score',
+            'benchmark_centered_score',
+            'support_above_corpus_average',
+        ],
+    )
+
+    section('pairwise model comparisons')
+    print_table(
+        report['observational']['pairwise_model_comparisons'],
+        [
+            'model_a',
+            'model_b',
+            'shared_evaluation_count',
+            'mean_paired_difference',
+            'support_model_a_higher',
+        ],
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Generate Every Eval Ever dataset statistics.'
+    )
+    parser.add_argument(
+        '--table', default='eee', help='Table name for the in-memory database'
+    )
+    parser.add_argument(
+        '--stats-output',
+        type=Path,
+        help='Optional JSON output path for the statistics report',
+    )
+    parser.add_argument(
+        '--summary-limit',
+        default=10,
+        type=int,
+        help='Number of descriptive summary rows to print',
+    )
+    parser.add_argument(
+        '--comparison-limit',
+        default=50,
+        type=int,
+        help='Number of pairwise comparison rows to print',
+    )
+    parser.add_argument(
+        '--top-model-limit',
+        default=50,
+        type=int,
+        help='Number of most-covered models to include in comparisons',
+    )
+    parser.add_argument(
+        '--min-shared-evals',
+        default=5,
+        type=int,
+        help='Minimum shared evaluation keys for pairwise comparisons',
+    )
+    parser.add_argument(
+        '--descriptive-only',
+        action='store_true',
+        help='Skip observational comparison summaries',
+    )
+    args = parser.parse_args(argv)
+    if not re.fullmatch(r'[A-Za-z_][A-Za-z0-9_]*', args.table):
+        parser.error('--table must be a valid SQL identifier')
+    if args.summary_limit < 1:
+        parser.error('--summary-limit must be at least 1')
+    if args.comparison_limit < 1:
+        parser.error('--comparison-limit must be at least 1')
+    if args.top_model_limit < 1:
+        parser.error('--top-model-limit must be at least 1')
+    if args.min_shared_evals < 1:
+        parser.error('--min-shared-evals must be at least 1')
+    return args
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    import duckdb
+
+    schema_table = f'{args.table}_schema'
+    with duckdb.connect(':memory:') as con:
+        try:
+            con.execute('LOAD httpfs;')
+        except duckdb.Error:
+            con.execute('INSTALL httpfs;')
+            con.execute('LOAD httpfs;')
+
+        load_schema_table(con, schema_table)
+        rows = extract_result_rows(con, schema_table)
+
+    report = build_statistics_report(
+        rows,
+        summary_limit=args.summary_limit,
+        comparison_limit=args.comparison_limit,
+        top_model_limit=args.top_model_limit,
+        min_shared_evals=args.min_shared_evals,
+        descriptive_only=args.descriptive_only,
+    )
+    print_report(report, args.descriptive_only)
+
+    if args.stats_output:
+        args.stats_output.parent.mkdir(parents=True, exist_ok=True)
+        args.stats_output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + '\n',
+            encoding='utf-8',
+        )
+        print(f'\nWrote statistics JSON to {args.stats_output}')
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)

--- a/every_eval_ever/helpers/dataset_statistics.py
+++ b/every_eval_ever/helpers/dataset_statistics.py
@@ -47,9 +47,7 @@ def load_schema_table(con: Any, table: str) -> None:
     )
 
 
-def extract_result_rows(
-    con: Any, schema_table: str
-) -> list[dict[str, Any]]:
+def extract_result_rows(con: Any, schema_table: str) -> list[dict[str, Any]]:
     rows = con.execute(
         f"""
         SELECT
@@ -57,6 +55,7 @@ def extract_result_rows(
             evaluation_id,
             model_info.id AS model_id,
             model_info.developer AS model_developer,
+            model_info.inference_platform AS inference_engine,
             er.evaluation_name AS evaluation_name,
             er.source_data.dataset_name AS benchmark,
             er.metric_config.score_type AS score_type,
@@ -79,6 +78,7 @@ def extract_result_rows(
         'evaluation_id',
         'model_id',
         'model_developer',
+        'inference_engine',
         'evaluation_name',
         'benchmark',
         'score_type',
@@ -236,11 +236,53 @@ def distinct_count(rows: list[dict[str, Any]], key: str) -> int:
 def count_values(
     rows: list[dict[str, Any]], key: str
 ) -> list[dict[str, int | str]]:
-    counts = Counter(str(row.get(key)) for row in rows if row.get(key) is not None)
+    counts = Counter(
+        str(row.get(key)) for row in rows if row.get(key) is not None
+    )
     return [
         {'value': value, 'count': count}
         for value, count in counts.most_common()
     ]
+
+
+def count_values_with_unknown(
+    rows: list[dict[str, Any]], key: str, unknown: str = 'unknown'
+) -> list[dict[str, int | str]]:
+    counts = Counter()
+    for row in rows:
+        value = row.get(key)
+        normalized = unknown if value is None else str(value).strip()
+        counts[normalized or unknown] += 1
+    return [
+        {'value': value, 'count': count}
+        for value, count in counts.most_common()
+    ]
+
+
+def models_per_benchmark(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        benchmark = row.get('benchmark')
+        if benchmark is not None:
+            grouped[str(benchmark)].append(row)
+
+    summaries = []
+    for benchmark, items in grouped.items():
+        summaries.append(
+            {
+                'benchmark': benchmark,
+                'unique_models': distinct_count(items, 'model_id'),
+                'result_rows': len(items),
+            }
+        )
+    summaries.sort(
+        key=lambda item: (
+            -int(item['unique_models']),
+            -int(item['result_rows']),
+            str(item['benchmark']),
+        )
+    )
+    return summaries
 
 
 def grouped_summaries(
@@ -328,16 +370,17 @@ def coverage_aware_model_summaries(
             percentile(bootstrap_scores, 0.025),
             percentile(bootstrap_scores, 0.975),
         ]
-        support = (
-            sum(score > corpus_mean for score in bootstrap_scores)
-            / len(bootstrap_scores)
+        support = sum(score > corpus_mean for score in bootstrap_scores) / len(
+            bootstrap_scores
         )
         summaries.append(
             {
                 'model_id': model_id,
                 'result_count': len(items),
                 'benchmark_count': distinct_count(items, 'benchmark'),
-                'evaluation_count': distinct_count(items, 'shared_evaluation_key'),
+                'evaluation_count': distinct_count(
+                    items, 'shared_evaluation_key'
+                ),
                 'mean_normalized_score': raw_mean,
                 'benchmark_centered_score': centered_mean,
                 'stabilized_score': stabilized,
@@ -364,7 +407,9 @@ def pairwise_model_comparisons(
     by_model_key: dict[str, dict[str, list[float]]] = defaultdict(
         lambda: defaultdict(list)
     )
-    model_counts = Counter(row['model_id'] for row in rows if row.get('model_id'))
+    model_counts = Counter(
+        row['model_id'] for row in rows if row.get('model_id')
+    )
     top_models = {
         model
         for model, _ in model_counts.most_common(top_model_limit)
@@ -443,6 +488,10 @@ def descriptive_statistics(
             'unique_evaluations': distinct_count(rows, 'evaluation_name'),
         },
         'schema_versions': count_values(rows, 'schema_version'),
+        'inference_engines': count_values_with_unknown(
+            rows, 'inference_engine'
+        ),
+        'models_per_benchmark': models_per_benchmark(rows),
         'quality': quality_counts(rows),
         'normalization_exclusions': exclusions,
         'score_summaries': grouped_summaries(
@@ -533,6 +582,18 @@ def print_report(report: dict[str, Any], descriptive_only: bool) -> None:
     section('normalization exclusions')
     for key, value in report['observational']['exclusions'].items():
         print(f'  {key:<32} {value:>10,}')
+
+    section('inference engines')
+    print_table(
+        descriptive['inference_engines'][:10],
+        ['value', 'count'],
+    )
+
+    section('models per benchmark')
+    print_table(
+        descriptive['models_per_benchmark'][:10],
+        ['benchmark', 'unique_models', 'result_rows'],
+    )
 
     section('score summaries')
     print_table(

--- a/scripts/plot_dataset_statistics.py
+++ b/scripts/plot_dataset_statistics.py
@@ -1,0 +1,432 @@
+"""Generate PDF plots and a narrative summary from dataset statistics JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import textwrap
+from pathlib import Path
+from typing import Any
+
+PLOT_FILES = {
+    'coverage': 'coverage_counts.pdf',
+    'quality': 'normalization_quality.pdf',
+    'top_coverage': 'top_evaluation_coverage.pdf',
+    'mean': 'normalized_score_mean_by_eval.pdf',
+    'variability': 'normalized_score_variability.pdf',
+    'range': 'score_range_by_eval.pdf',
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Generate dataset-statistics PDF plots and summary.'
+    )
+    parser.add_argument(
+        '--input',
+        type=Path,
+        default=Path('audit/dataset_statistics.json'),
+        help='Path to dataset_statistics.json.',
+    )
+    parser.add_argument(
+        '--output-dir',
+        type=Path,
+        default=Path('audit/dataset_statistics_plots'),
+        help='Directory for generated PDF plots.',
+    )
+    parser.add_argument(
+        '--summary-output',
+        type=Path,
+        default=Path('audit/dataset_statistics_summary.md'),
+        help='Path for generated Markdown summary.',
+    )
+    parser.add_argument(
+        '--top-n',
+        type=int,
+        default=25,
+        help='Number of evaluation rows to show in ranked plots.',
+    )
+    return parser.parse_args()
+
+
+def load_statistics(path: Path) -> dict[str, Any]:
+    with path.open(encoding='utf-8') as handle:
+        return json.load(handle)
+
+
+def import_plotting() -> tuple[Any, Any | None]:
+    try:
+        import matplotlib.pyplot as plt
+    except ModuleNotFoundError as exc:
+        raise SystemExit(
+            'matplotlib is required to generate plots. Install matplotlib '
+            'or seaborn in the active environment and rerun this script.'
+        ) from exc
+
+    try:
+        import seaborn as sns
+    except ModuleNotFoundError:
+        sns = None
+
+    if sns is not None:
+        sns.set_theme(style='whitegrid', context='talk')
+    else:
+        plt.style.use('ggplot')
+    return plt, sns
+
+
+def label(row: dict[str, Any]) -> str:
+    benchmark = str(row['benchmark'])
+    evaluation = str(row['evaluation_name'])
+    if benchmark == evaluation:
+        return benchmark
+    return f'{benchmark}: {evaluation}'
+
+
+def short_label(value: str, width: int = 46) -> str:
+    return textwrap.shorten(value, width=width, placeholder='...')
+
+
+def columns(
+    rows: list[dict[str, Any]], keys: tuple[str, ...]
+) -> dict[str, list[Any]]:
+    return {key: [row[key] for row in rows] for key in keys}
+
+
+def save(fig: Any, path: Path) -> None:
+    fig.tight_layout()
+    fig.savefig(path, format='pdf', bbox_inches='tight')
+
+
+def plot_coverage_counts(
+    stats: dict[str, Any], output_dir: Path, plt: Any, sns: Any | None
+) -> Path:
+    counts = stats['descriptive']['counts']
+    order = [
+        'result_rows',
+        'unique_models',
+        'unique_developers',
+        'unique_evaluations',
+        'unique_benchmarks',
+    ]
+    rows = [
+        {'metric': key.replace('_', ' ').title(), 'count': counts[key]}
+        for key in order
+    ]
+
+    fig, ax = plt.subplots(figsize=(10, 5.5))
+    if sns is not None:
+        sns.barplot(
+            data=columns(rows, ('metric', 'count')),
+            x='metric',
+            y='count',
+            hue='metric',
+            ax=ax,
+            legend=False,
+        )
+    else:
+        ax.bar([row['metric'] for row in rows], [row['count'] for row in rows])
+    ax.set_yscale('log')
+    ax.set_xlabel('')
+    ax.set_ylabel('Count, log scale')
+    ax.set_title('Dataset Coverage')
+    ax.tick_params(axis='x', rotation=25)
+    for index, row in enumerate(rows):
+        ax.text(
+            index, row['count'], f'{row["count"]:,}', ha='center', va='bottom'
+        )
+
+    path = output_dir / PLOT_FILES['coverage']
+    save(fig, path)
+    plt.close(fig)
+    return path
+
+
+def plot_normalization_quality(
+    stats: dict[str, Any], output_dir: Path, plt: Any, sns: Any | None
+) -> Path:
+    valid = stats['observational']['valid_normalized_rows']
+    exclusions = stats['observational']['exclusions']
+    rows = [{'category': 'valid normalized rows', 'count': valid}] + [
+        {'category': key.replace('_', ' '), 'count': value}
+        for key, value in exclusions.items()
+    ]
+
+    fig, ax = plt.subplots(figsize=(11, 5.5))
+    if sns is not None:
+        sns.barplot(
+            data=columns(rows, ('category', 'count')),
+            x='category',
+            y='count',
+            hue='category',
+            ax=ax,
+            legend=False,
+        )
+    else:
+        ax.bar(
+            [row['category'] for row in rows], [row['count'] for row in rows]
+        )
+    ax.set_yscale('symlog', linthresh=1)
+    ax.set_xlabel('')
+    ax.set_ylabel('Rows, symmetric log scale')
+    ax.set_title('Normalization Quality')
+    ax.tick_params(axis='x', rotation=25)
+    for index, row in enumerate(rows):
+        ax.text(
+            index,
+            max(row['count'], 1),
+            f'{row["count"]:,}',
+            ha='center',
+            va='bottom',
+        )
+
+    path = output_dir / PLOT_FILES['quality']
+    save(fig, path)
+    plt.close(fig)
+    return path
+
+
+def top_rows(
+    rows: list[dict[str, Any]], key: str, limit: int
+) -> list[dict[str, Any]]:
+    return sorted(rows, key=lambda row: (-float(row[key]), label(row)))[:limit]
+
+
+def plot_top_evaluation_coverage(
+    rows: list[dict[str, Any]],
+    output_dir: Path,
+    plt: Any,
+    sns: Any | None,
+    top_n: int,
+) -> Path:
+    selected = list(reversed(top_rows(rows, 'count', top_n)))
+    labels = [short_label(label(row), 58) for row in selected]
+    counts = [row['count'] for row in selected]
+
+    fig, ax = plt.subplots(figsize=(11, max(6, top_n * 0.35)))
+    if sns is not None:
+        sns.barplot(x=counts, y=labels, hue=labels, ax=ax, legend=False)
+    else:
+        ax.barh(labels, counts)
+    ax.set_xlabel('Normalized result rows')
+    ax.set_ylabel('')
+    ax.set_title(f'Top {len(selected)} Evaluations By Coverage')
+
+    path = output_dir / PLOT_FILES['top_coverage']
+    save(fig, path)
+    plt.close(fig)
+    return path
+
+
+def plot_normalized_score_means(
+    rows: list[dict[str, Any]],
+    output_dir: Path,
+    plt: Any,
+    sns: Any | None,
+    top_n: int,
+) -> Path:
+    selected = sorted(rows, key=lambda row: (float(row['mean']), label(row)))[
+        :top_n
+    ]
+    labels = [short_label(label(row), 58) for row in selected]
+    means = [row['mean'] for row in selected]
+
+    fig, ax = plt.subplots(figsize=(11, max(6, top_n * 0.35)))
+    if sns is not None:
+        sns.barplot(x=means, y=labels, hue=labels, ax=ax, legend=False)
+    else:
+        ax.barh(labels, means)
+    ax.set_xlim(0, 1)
+    ax.set_xlabel('Mean normalized score')
+    ax.set_ylabel('')
+    ax.set_title(f'Lowest {len(selected)} Mean Normalized Scores')
+
+    path = output_dir / PLOT_FILES['mean']
+    save(fig, path)
+    plt.close(fig)
+    return path
+
+
+def plot_score_variability(
+    rows: list[dict[str, Any]], output_dir: Path, plt: Any, sns: Any | None
+) -> Path:
+    plot_rows = [
+        {
+            'mean': row['mean'],
+            'stddev': row['stddev'] or 0.0,
+            'count': row['count'],
+            'label': label(row),
+        }
+        for row in rows
+    ]
+    max_count = max(row['count'] for row in plot_rows)
+    sizes = [
+        45 + 455 * math.sqrt(row['count'] / max_count) for row in plot_rows
+    ]
+
+    fig, ax = plt.subplots(figsize=(10, 7))
+    if sns is not None:
+        sns.scatterplot(
+            data=columns(plot_rows, ('mean', 'stddev', 'count')),
+            x='mean',
+            y='stddev',
+            size='count',
+            sizes=(45, 500),
+            alpha=0.75,
+            legend=False,
+            ax=ax,
+        )
+    else:
+        ax.scatter(
+            [row['mean'] for row in plot_rows],
+            [row['stddev'] for row in plot_rows],
+            s=sizes,
+            alpha=0.75,
+        )
+    ax.set_xlim(0, 1)
+    ax.set_xlabel('Mean normalized score')
+    ax.set_ylabel('Standard deviation')
+    ax.set_title('Normalized Score Level vs. Variability')
+
+    notable = sorted(
+        plot_rows,
+        key=lambda row: (row['stddev'], abs(row['mean'] - 0.5)),
+        reverse=True,
+    )[:8]
+    for row in notable:
+        ax.annotate(
+            short_label(row['label'], 24),
+            (row['mean'], row['stddev']),
+            xytext=(5, 4),
+            textcoords='offset points',
+            fontsize=8,
+        )
+
+    path = output_dir / PLOT_FILES['variability']
+    save(fig, path)
+    plt.close(fig)
+    return path
+
+
+def plot_score_ranges(
+    rows: list[dict[str, Any]],
+    output_dir: Path,
+    plt: Any,
+    top_n: int,
+) -> Path:
+    selected = sorted(
+        rows,
+        key=lambda row: (float(row['max']) - float(row['min']), label(row)),
+    )[-top_n:]
+    labels = [short_label(label(row), 58) for row in selected]
+    mins = [row['min'] for row in selected]
+    maxes = [row['max'] for row in selected]
+    means = [row['mean'] for row in selected]
+    ypos = list(range(len(selected)))
+
+    fig, ax = plt.subplots(figsize=(11, max(6, top_n * 0.35)))
+    for y, low, high in zip(ypos, mins, maxes, strict=True):
+        ax.hlines(y, low, high, color='#5b6770', linewidth=2.0, alpha=0.9)
+    ax.scatter(means, ypos, color='#0072b2', s=32, zorder=3, label='mean')
+    ax.set_yticks(ypos)
+    ax.set_yticklabels(labels)
+    ax.set_xlim(0, 1)
+    ax.set_xlabel('Normalized score range')
+    ax.set_ylabel('')
+    ax.set_title(f'Widest {len(selected)} Normalized Score Ranges')
+    ax.legend(loc='lower right')
+
+    path = output_dir / PLOT_FILES['range']
+    save(fig, path)
+    plt.close(fig)
+    return path
+
+
+def pct(part: int, total: int) -> float:
+    return 100.0 * part / total if total else 0.0
+
+
+def write_summary(
+    stats: dict[str, Any],
+    rows: list[dict[str, Any]],
+    plot_paths: dict[str, Path],
+    output_path: Path,
+) -> None:
+    counts = stats['descriptive']['counts']
+    quality = stats['descriptive']['quality']
+    valid = stats['observational']['valid_normalized_rows']
+    exclusions = stats['observational']['exclusions']
+    out_of_range = exclusions.get('out_of_range', 0)
+    most_covered = top_rows(rows, 'count', 6)
+    highest_variance = sorted(
+        rows, key=lambda row: float(row['stddev'] or 0.0), reverse=True
+    )[:4]
+    hardest = sorted(rows, key=lambda row: float(row['mean']))[:4]
+    easiest = sorted(rows, key=lambda row: float(row['mean']), reverse=True)[:4]
+
+    def names(items: list[dict[str, Any]]) -> str:
+        return ', '.join(label(item) for item in items)
+
+    relative_plots = {
+        name: path.relative_to(output_path.parent)
+        if path.is_relative_to(output_path.parent)
+        else path
+        for name, path in plot_paths.items()
+    }
+    text = f"""# Dataset Statistics Summary
+
+This report summarizes the latest Every Eval Ever datastore snapshot represented by `dataset_statistics.json`. The corpus contains {counts['result_rows']:,} result rows across {counts['unique_benchmarks']:,} benchmarks, {counts['unique_evaluations']:,} evaluation names, {counts['unique_developers']:,} developers, and {counts['unique_models']:,} models. The coverage plot (`{relative_plots['coverage']}`) shows that the datastore is broad in model count but still highly concentrated in a small number of repeated evaluation families.
+
+Normalization quality is strong for this snapshot. Of {quality['total_result_rows']:,} result rows, {valid:,} rows can be converted onto the shared zero-to-one scale, or {pct(valid, quality['total_result_rows']):.1f}% of the dataset. The only observed normalization exclusion is {out_of_range:,} out-of-range rows; missing scores, missing bounds, zero-width bounds, and incompatible score types are all zero. This makes the normalized summaries a useful cross-benchmark view, while still leaving the raw score summaries available for scale-specific inspection.
+
+Coverage is uneven by design. The most-covered normalized summaries are {names(most_covered)}. These heavily represented evaluations dominate aggregate descriptive patterns, so the top-coverage chart (`{relative_plots['top_coverage']}`) should be read alongside any mean-score chart. A benchmark with thousands of rows provides a much steadier estimate than a niche evaluation with dozens or hundreds of rows, even if both appear as one row in the summary table.
+
+Mean normalized scores vary sharply across tasks. The lowest means include {names(hardest)}, while the highest means include {names(easiest)}. These values should not be interpreted as a leaderboard: they summarize all available submitted model results within each benchmark/evaluation pair, not matched model cohorts. They are best used to spot which evaluations are generally difficult, saturated, or mixed across the collected model population.
+
+The variability plots add the most diagnostic texture. High-standard-deviation evaluations such as {names(highest_variance)} indicate tasks where model results span a wide range, often because the benchmark separates weak and strong systems clearly or because the source data combines distinct regimes. The range plot (`{relative_plots['range']}`) highlights the same issue from min-to-max spread, while the mean-versus-standard-deviation scatter (`{relative_plots['variability']}`) separates broad, high-confidence coverage from sparse or volatile summaries.
+
+The PDF figures are meant to be inspected together rather than as standalone claims. The count and quality charts answer whether the data is large and clean enough to trust; the mean, variability, and range charts answer where the benchmark landscape is concentrated, sparse, easy, hard, or discriminative. That division keeps coverage questions separate from score interpretation.
+
+Overall, the datastore is large, mostly normalization-ready, and informative for benchmark-level descriptive analysis. The main caveat is comparability: normalized scores put different metrics on a common scale, but they do not control for which models appear in each benchmark. Use these figures as a map of datastore coverage and score distribution, then rely on paired or coverage-aware analyses for direct model comparisons.
+"""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(text, encoding='utf-8')
+
+
+def main() -> None:
+    args = parse_args()
+    if args.top_n < 1:
+        raise SystemExit('--top-n must be at least 1')
+
+    stats = load_statistics(args.input)
+    rows = stats['descriptive']['normalized_score_summaries']
+    if not rows:
+        raise SystemExit(
+            'No normalized_score_summaries found in statistics JSON.'
+        )
+
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    plt, sns = import_plotting()
+
+    plot_paths = {
+        'coverage': plot_coverage_counts(stats, output_dir, plt, sns),
+        'quality': plot_normalization_quality(stats, output_dir, plt, sns),
+        'top_coverage': plot_top_evaluation_coverage(
+            rows, output_dir, plt, sns, args.top_n
+        ),
+        'mean': plot_normalized_score_means(
+            rows, output_dir, plt, sns, args.top_n
+        ),
+        'variability': plot_score_variability(rows, output_dir, plt, sns),
+        'range': plot_score_ranges(rows, output_dir, plt, args.top_n),
+    }
+    write_summary(stats, rows, plot_paths, args.summary_output)
+
+    print(f'Wrote {len(plot_paths)} PDF plots to {output_dir}')
+    print(f'Wrote Markdown summary to {args.summary_output}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/plot_dataset_statistics.py
+++ b/scripts/plot_dataset_statistics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import statistics
 import textwrap
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,8 @@ PLOT_FILES = {
     'mean': 'normalized_score_mean_by_eval.pdf',
     'variability': 'normalized_score_variability.pdf',
     'range': 'score_range_by_eval.pdf',
+    'models_per_dataset': 'models_per_dataset_histogram.pdf',
+    'engine_spread': 'inference_engine_spread.pdf',
 }
 
 
@@ -343,6 +346,93 @@ def plot_score_ranges(
     return path
 
 
+def plot_models_per_dataset_histogram(
+    stats: dict[str, Any], output_dir: Path, plt: Any, sns: Any | None
+) -> Path:
+    rows = stats['descriptive'].get('models_per_benchmark', [])
+    values = [row['unique_models'] for row in rows if row['unique_models'] > 0]
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    if values:
+        bins = min(30, max(8, len(set(values))))
+        if sns is not None:
+            sns.histplot(values, bins=bins, ax=ax, color='#0072b2')
+        else:
+            ax.hist(values, bins=bins, color='#0072b2', edgecolor='white')
+        median_value = statistics.median(values)
+        ax.axvline(
+            median_value,
+            color='#d55e00',
+            linestyle='--',
+            linewidth=2,
+            label=f'median={median_value:g}',
+        )
+        ax.legend()
+    else:
+        ax.text(
+            0.5,
+            0.5,
+            'No model-per-dataset summary available',
+            ha='center',
+            va='center',
+            transform=ax.transAxes,
+        )
+    ax.set_xlabel('Unique models per dataset')
+    ax.set_ylabel('Datasets')
+    ax.set_title('Distribution Of Unique Models Per Dataset')
+
+    path = output_dir / PLOT_FILES['models_per_dataset']
+    save(fig, path)
+    plt.close(fig)
+    return path
+
+
+def plot_inference_engine_spread(
+    stats: dict[str, Any],
+    output_dir: Path,
+    plt: Any,
+    sns: Any | None,
+    top_n: int,
+) -> Path:
+    rows = stats['descriptive'].get('inference_engines', [])
+    selected = rows[:top_n]
+    remaining = rows[top_n:]
+    if remaining:
+        selected = selected + [
+            {
+                'value': 'other',
+                'count': sum(int(row['count']) for row in remaining),
+            }
+        ]
+    selected = list(reversed(selected))
+    labels = [short_label(str(row['value']), 48) for row in selected]
+    counts = [row['count'] for row in selected]
+
+    fig, ax = plt.subplots(figsize=(10, max(5, len(selected) * 0.45)))
+    if selected:
+        if sns is not None:
+            sns.barplot(x=counts, y=labels, hue=labels, ax=ax, legend=False)
+        else:
+            ax.barh(labels, counts)
+    else:
+        ax.text(
+            0.5,
+            0.5,
+            'No inference-engine summary available',
+            ha='center',
+            va='center',
+            transform=ax.transAxes,
+        )
+    ax.set_xlabel('Result rows')
+    ax.set_ylabel('')
+    ax.set_title('Recorded Inference Engine/Platform Spread')
+
+    path = output_dir / PLOT_FILES['engine_spread']
+    save(fig, path)
+    plt.close(fig)
+    return path
+
+
 def pct(part: int, total: int) -> float:
     return 100.0 * part / total if total else 0.0
 
@@ -353,20 +443,53 @@ def write_summary(
     plot_paths: dict[str, Path],
     output_path: Path,
 ) -> None:
+    descriptive = stats['descriptive']
     counts = stats['descriptive']['counts']
     quality = stats['descriptive']['quality']
     valid = stats['observational']['valid_normalized_rows']
     exclusions = stats['observational']['exclusions']
     out_of_range = exclusions.get('out_of_range', 0)
+    models_per_benchmark = descriptive.get('models_per_benchmark', [])
+    inference_engines = descriptive.get('inference_engines', [])
     most_covered = top_rows(rows, 'count', 6)
     highest_variance = sorted(
         rows, key=lambda row: float(row['stddev'] or 0.0), reverse=True
     )[:4]
     hardest = sorted(rows, key=lambda row: float(row['mean']))[:4]
     easiest = sorted(rows, key=lambda row: float(row['mean']), reverse=True)[:4]
+    model_counts = [
+        int(row['unique_models'])
+        for row in models_per_benchmark
+        if int(row['unique_models']) > 0
+    ]
+    median_models = statistics.median(model_counts) if model_counts else 0
+    max_models = max(model_counts) if model_counts else 0
+    top_model_datasets = models_per_benchmark[:6]
+    known_engine_rows = sum(
+        int(row['count'])
+        for row in inference_engines
+        if str(row['value']).strip().lower() != 'unknown'
+    )
+    unknown_engine_rows = sum(
+        int(row['count'])
+        for row in inference_engines
+        if str(row['value']).strip().lower() == 'unknown'
+    )
+    top_engines = inference_engines[:6]
 
     def names(items: list[dict[str, Any]]) -> str:
         return ', '.join(label(item) for item in items)
+
+    def benchmark_model_names(items: list[dict[str, Any]]) -> str:
+        return ', '.join(
+            f'{item["benchmark"]} ({int(item["unique_models"]):,})'
+            for item in items
+        )
+
+    def engine_names(items: list[dict[str, Any]]) -> str:
+        return ', '.join(
+            f'{item["value"]} ({int(item["count"]):,})' for item in items
+        )
 
     relative_plots = {
         name: path.relative_to(output_path.parent)
@@ -376,19 +499,23 @@ def write_summary(
     }
     text = f"""# Dataset Statistics Summary
 
-This report summarizes the latest Every Eval Ever datastore snapshot represented by `dataset_statistics.json`. The corpus contains {counts['result_rows']:,} result rows across {counts['unique_benchmarks']:,} benchmarks, {counts['unique_evaluations']:,} evaluation names, {counts['unique_developers']:,} developers, and {counts['unique_models']:,} models. The coverage plot (`{relative_plots['coverage']}`) shows that the datastore is broad in model count but still highly concentrated in a small number of repeated evaluation families.
+This report summarizes the latest Every Eval Ever datastore snapshot represented by `dataset_statistics.json`. In the statistics file, “dataset” is represented by the `benchmark` field, which comes from `evaluation_results[].source_data.dataset_name`. That naming is worth keeping in mind when reading the figures: a benchmark is the dataset or leaderboard family that supplied the result rows, while an evaluation name is the finer slice or metric label inside that benchmark. The corpus contains {counts['result_rows']:,} result rows across {counts['unique_benchmarks']:,} datasets, {counts['unique_evaluations']:,} evaluation names, {counts['unique_developers']:,} developers, and {counts['unique_models']:,} models. The coverage plot (`{relative_plots['coverage']}`) gives the first scale check: the datastore is broad in model count, but its row-level mass is still concentrated in a smaller number of repeated evaluation families.
 
-Normalization quality is strong for this snapshot. Of {quality['total_result_rows']:,} result rows, {valid:,} rows can be converted onto the shared zero-to-one scale, or {pct(valid, quality['total_result_rows']):.1f}% of the dataset. The only observed normalization exclusion is {out_of_range:,} out-of-range rows; missing scores, missing bounds, zero-width bounds, and incompatible score types are all zero. This makes the normalized summaries a useful cross-benchmark view, while still leaving the raw score summaries available for scale-specific inspection.
+Normalization quality is strong for this snapshot. Of {quality['total_result_rows']:,} result rows, {valid:,} rows can be converted onto the shared zero-to-one scale, or {pct(valid, quality['total_result_rows']):.1f}% of the dataset. The only observed normalization exclusion is {out_of_range:,} out-of-range rows; missing scores, missing bounds, zero-width bounds, and incompatible score types are all zero. This means the normalized score summaries are a reasonable map of cross-benchmark score distributions. It does not make all metrics semantically identical, but it does put the numeric ranges on a common axis so that difficulty, saturation, and spread are easier to compare. The normalization quality plot (`{relative_plots['quality']}`) is therefore a guardrail figure: it says whether the rest of the normalized-score visuals are based on most of the corpus or on a narrow filtered subset.
 
-Coverage is uneven by design. The most-covered normalized summaries are {names(most_covered)}. These heavily represented evaluations dominate aggregate descriptive patterns, so the top-coverage chart (`{relative_plots['top_coverage']}`) should be read alongside any mean-score chart. A benchmark with thousands of rows provides a much steadier estimate than a niche evaluation with dozens or hundreds of rows, even if both appear as one row in the summary table.
+Coverage is uneven by design. The most-covered normalized summaries are {names(most_covered)}. These heavily represented evaluations dominate aggregate descriptive patterns, so the top-coverage chart (`{relative_plots['top_coverage']}`) should be read alongside any mean-score chart. A benchmark with thousands of rows provides a much steadier estimate than a niche evaluation with dozens or hundreds of rows, even if both appear as one row in the summary table. High row coverage can mean a benchmark has broad model participation, multiple reported submetrics, repeated submissions, or some combination of the three. The plot is intentionally row-count oriented, because the descriptive JSON is primarily row-oriented; it should not be read as a direct measure of benchmark popularity without checking model coverage separately.
 
-Mean normalized scores vary sharply across tasks. The lowest means include {names(hardest)}, while the highest means include {names(easiest)}. These values should not be interpreted as a leaderboard: they summarize all available submitted model results within each benchmark/evaluation pair, not matched model cohorts. They are best used to spot which evaluations are generally difficult, saturated, or mixed across the collected model population.
+The new model-per-dataset histogram (`{relative_plots['models_per_dataset']}`) adds that missing model-coverage view. Across datasets, the median number of unique models is {median_models:g}, and the largest dataset-level model count is {max_models:,}. The highest-coverage datasets by unique model count are {benchmark_model_names(top_model_datasets)}. This distribution is important because a dataset with many models tells us more about the breadth of the ecosystem than a dataset with many rows from a smaller model set. A heavy right tail in this histogram means a few datasets act as common comparison hubs, while many others remain specialized or sparsely covered. That is not necessarily bad; specialized datasets are often where the datastore gets its texture. But it does mean corpus-wide summaries should avoid treating every benchmark as equally well sampled.
 
-The variability plots add the most diagnostic texture. High-standard-deviation evaluations such as {names(highest_variance)} indicate tasks where model results span a wide range, often because the benchmark separates weak and strong systems clearly or because the source data combines distinct regimes. The range plot (`{relative_plots['range']}`) highlights the same issue from min-to-max spread, while the mean-versus-standard-deviation scatter (`{relative_plots['variability']}`) separates broad, high-confidence coverage from sparse or volatile summaries.
+The inference-engine spread plot (`{relative_plots['engine_spread']}`) describes how result rows are distributed across recorded running engines or inference platforms, depending on which runtime metadata is present in the datastore export. The leading runtime labels are {engine_names(top_engines)}. In this snapshot, {known_engine_rows:,} rows have a named runtime field and {unknown_engine_rows:,} rows fall under `unknown`. The `unknown` bucket is expected whenever source records report model identity but not the serving/runtime layer. Runtime spread should therefore be read as an observability diagnostic, not just as a usage ranking. A large `unknown` bucket says that many results are still useful for model and benchmark analysis, but they cannot support claims about vLLM, Ollama, hosted APIs, or other runtime-specific execution paths. Where runtime names are present, the chart gives a quick view of which execution backends are represented strongly enough for follow-up slicing.
 
-The PDF figures are meant to be inspected together rather than as standalone claims. The count and quality charts answer whether the data is large and clean enough to trust; the mean, variability, and range charts answer where the benchmark landscape is concentrated, sparse, easy, hard, or discriminative. That division keeps coverage questions separate from score interpretation.
+Mean normalized scores vary sharply across tasks. The lowest means include {names(hardest)}, while the highest means include {names(easiest)}. These values should not be interpreted as a leaderboard: they summarize all available submitted model results within each benchmark/evaluation pair, not matched model cohorts. They are best used to spot which evaluations are generally difficult, saturated, or mixed across the collected model population. A low mean can indicate a hard benchmark, a benchmark with many older or weaker systems, or a metric whose upper range is rarely reached. A high mean can indicate an easier task, a saturated benchmark, a curated set of strong submissions, or a metric where the lower-performing tail is missing. The summary plots do not decide among those explanations, but they point to where a closer paired analysis would be valuable.
 
-Overall, the datastore is large, mostly normalization-ready, and informative for benchmark-level descriptive analysis. The main caveat is comparability: normalized scores put different metrics on a common scale, but they do not control for which models appear in each benchmark. Use these figures as a map of datastore coverage and score distribution, then rely on paired or coverage-aware analyses for direct model comparisons.
+The variability plots add the most diagnostic texture. High-standard-deviation evaluations such as {names(highest_variance)} indicate tasks where model results span a wide range, often because the benchmark separates weak and strong systems clearly or because the source data combines distinct regimes. The range plot (`{relative_plots['range']}`) highlights the same issue from min-to-max spread, while the mean-versus-standard-deviation scatter (`{relative_plots['variability']}`) separates broad, high-confidence coverage from sparse or volatile summaries. Evaluations with both substantial coverage and high spread are especially useful for model comparison because they appear to discriminate among systems rather than clustering everyone near the same score. Evaluations with low spread can still matter, but they may be better suited for pass/fail checks, regression testing, or detecting severe failures than for fine-grained ranking.
+
+The PDF figures are meant to be inspected together rather than as standalone claims. The count and quality charts answer whether the data is large and clean enough to trust. The top-coverage and model-per-dataset charts separate result-row volume from unique-model breadth. The engine chart shows whether runtime metadata is available and how concentrated it is. The mean, variability, and range charts then answer where the benchmark landscape is concentrated, sparse, easy, hard, or discriminative. Keeping those questions separate avoids a common mistake: treating a high row count as evidence of broad participation, or treating a normalized mean as a direct model-quality claim.
+
+Overall, the datastore is large, mostly normalization-ready, and informative for benchmark-level descriptive analysis. The main caveat is comparability: normalized scores put different metrics on a common scale, but they do not control for which models appear in each benchmark. Use these figures as a map of datastore coverage, runtime observability, and score distribution, then rely on paired or coverage-aware analyses for direct model comparisons. The descriptive plots are best thought of as a scouting layer: they reveal where the datastore is rich, where metadata is thin, and where more careful model-by-model analysis is likely to pay off.
 """
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(text, encoding='utf-8')
@@ -421,6 +548,12 @@ def main() -> None:
         ),
         'variability': plot_score_variability(rows, output_dir, plt, sns),
         'range': plot_score_ranges(rows, output_dir, plt, args.top_n),
+        'models_per_dataset': plot_models_per_dataset_histogram(
+            stats, output_dir, plt, sns
+        ),
+        'engine_spread': plot_inference_engine_spread(
+            stats, output_dir, plt, sns, args.top_n
+        ),
     }
     write_summary(stats, rows, plot_paths, args.summary_output)
 

--- a/tests/test_dataset_statistics.py
+++ b/tests/test_dataset_statistics.py
@@ -13,12 +13,14 @@ def row(
     max_score: float | None = 1.0,
     lower_is_better: bool = False,
     score_type: str | None = 'continuous',
+    inference_engine: str | None = None,
 ) -> dict:
     return {
         'schema_version': '0.2.2',
         'evaluation_id': f'{model_id}/{benchmark}/{evaluation_name}',
         'model_id': model_id,
         'model_developer': model_id.split('/')[0],
+        'inference_engine': inference_engine,
         'benchmark': benchmark,
         'evaluation_name': evaluation_name,
         'score': score,
@@ -139,8 +141,50 @@ def test_json_report_shape():
 
     assert set(report) == {'descriptive', 'observational'}
     assert report['descriptive']['counts']['result_rows'] == 2
+    assert 'inference_engines' in report['descriptive']
+    assert 'models_per_benchmark' in report['descriptive']
     assert 'coverage_aware_model_summaries' in report['observational']
     assert 'pairwise_model_comparisons' in report['observational']
+
+
+def test_models_per_benchmark_dedupes_model_counts():
+    rows = [
+        row('model/a', 'bench-one', 'eval-a', 0.9),
+        row('model/a', 'bench-one', 'eval-b', 0.8),
+        row('model/b', 'bench-one', 'eval-a', 0.7),
+        row('model/c', 'bench-two', 'eval-a', 0.6),
+    ]
+
+    summaries = stats.models_per_benchmark(rows)
+
+    assert summaries == [
+        {
+            'benchmark': 'bench-one',
+            'unique_models': 2,
+            'result_rows': 3,
+        },
+        {
+            'benchmark': 'bench-two',
+            'unique_models': 1,
+            'result_rows': 1,
+        },
+    ]
+
+
+def test_inference_engine_counts_group_missing_as_unknown():
+    rows = [
+        row('model/a', 'bench', 'eval', 0.9, inference_engine='vllm'),
+        row('model/b', 'bench', 'eval', 0.8, inference_engine=''),
+        row('model/c', 'bench', 'eval', 0.7, inference_engine=None),
+        row('model/d', 'bench', 'eval', 0.6, inference_engine='ollama'),
+        row('model/e', 'bench', 'eval', 0.5, inference_engine='vllm'),
+    ]
+
+    assert stats.count_values_with_unknown(rows, 'inference_engine') == [
+        {'value': 'vllm', 'count': 2},
+        {'value': 'unknown', 'count': 2},
+        {'value': 'ollama', 'count': 1},
+    ]
 
 
 def test_cli_help_uses_summary_limit_not_top_n(capsys):

--- a/tests/test_dataset_statistics.py
+++ b/tests/test_dataset_statistics.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from every_eval_ever.helpers import dataset_statistics as stats
+
+
+def row(
+    model_id: str,
+    benchmark: str,
+    evaluation_name: str,
+    score: float | None,
+    *,
+    min_score: float | None = 0.0,
+    max_score: float | None = 1.0,
+    lower_is_better: bool = False,
+    score_type: str | None = 'continuous',
+) -> dict:
+    return {
+        'schema_version': '0.2.2',
+        'evaluation_id': f'{model_id}/{benchmark}/{evaluation_name}',
+        'model_id': model_id,
+        'model_developer': model_id.split('/')[0],
+        'benchmark': benchmark,
+        'evaluation_name': evaluation_name,
+        'score': score,
+        'min_score': min_score,
+        'max_score': max_score,
+        'lower_is_better': lower_is_better,
+        'score_type': score_type,
+        'has_uncertainty': False,
+    }
+
+
+def test_normalization_respects_lower_is_better():
+    assert stats.normalize_score(0.8, 0.0, 1.0, False) == 0.8
+    assert stats.normalize_score(0.2, 0.0, 1.0, True) == 0.8
+
+
+def test_invalid_rows_are_excluded_and_counted():
+    rows = [
+        row('a', 'bench', 'eval', None),
+        row('a', 'bench', 'eval', 0.5, min_score=None),
+        row('a', 'bench', 'eval', 0.5, min_score=1.0, max_score=1.0),
+        row('a', 'bench', 'eval', 0.5, score_type='binary'),
+        row('a', 'bench', 'eval', 2.0),
+        row('a', 'bench', 'eval', 0.8),
+    ]
+
+    valid, exclusions = stats.valid_normalized_rows(rows)
+
+    assert len(valid) == 1
+    assert exclusions == {
+        'missing_score': 1,
+        'missing_bounds': 1,
+        'zero_width_bounds': 1,
+        'incompatible_score_type': 1,
+        'out_of_range': 1,
+    }
+
+
+def test_shared_evaluation_key_includes_score_scale_and_direction():
+    base = row('a', 'bench', 'eval', 0.8)
+    different_scale = row('a', 'bench', 'eval', 80.0, max_score=100.0)
+    different_direction = row('a', 'bench', 'eval', 0.2, lower_is_better=True)
+
+    assert stats.shared_evaluation_key(base) != stats.shared_evaluation_key(
+        different_scale
+    )
+    assert stats.shared_evaluation_key(base) != stats.shared_evaluation_key(
+        different_direction
+    )
+
+
+def test_min_shared_evals_filters_pairwise_comparisons():
+    rows = [
+        row('model/a', 'b1', 'e1', 0.9),
+        row('model/b', 'b1', 'e1', 0.7),
+        row('model/a', 'b2', 'e2', 0.8),
+        row('model/b', 'b2', 'e2', 0.6),
+    ]
+    valid, _ = stats.valid_normalized_rows(rows)
+
+    assert (
+        stats.pairwise_model_comparisons(
+            valid, min_shared_evals=3, top_model_limit=10, comparison_limit=10
+        )
+        == []
+    )
+    comparisons = stats.pairwise_model_comparisons(
+        valid, min_shared_evals=2, top_model_limit=10, comparison_limit=10
+    )
+    assert len(comparisons) == 1
+    assert comparisons[0]['shared_evaluation_count'] == 2
+
+
+def test_stabilized_estimates_move_sparse_models_toward_corpus_mean():
+    estimate = stats.stabilized_estimate(
+        mean_score=1.0, count=1, corpus_mean=0.5, weight=5.0
+    )
+
+    assert 0.5 < estimate < 1.0
+
+
+def test_probability_style_support_outputs_are_bounded():
+    rows = [
+        row('model/a', 'b1', 'e1', 0.9),
+        row('model/b', 'b1', 'e1', 0.7),
+        row('model/a', 'b2', 'e2', 0.8),
+        row('model/b', 'b2', 'e2', 0.6),
+        row('model/a', 'b3', 'e3', 0.7),
+        row('model/b', 'b3', 'e3', 0.6),
+    ]
+    valid, _ = stats.valid_normalized_rows(rows)
+
+    model_summaries = stats.coverage_aware_model_summaries(valid, limit=10)
+    comparisons = stats.pairwise_model_comparisons(
+        valid, min_shared_evals=2, top_model_limit=10, comparison_limit=10
+    )
+
+    for summary in model_summaries:
+        support = summary['support_above_corpus_average']
+        assert 0.0 <= support <= 1.0
+    assert 0.0 <= comparisons[0]['support_model_a_higher'] <= 1.0
+
+
+def test_json_report_shape():
+    rows = [
+        row('model/a', 'b1', 'e1', 0.9),
+        row('model/b', 'b1', 'e1', 0.7),
+    ]
+
+    report = stats.build_statistics_report(
+        rows,
+        summary_limit=5,
+        comparison_limit=5,
+        top_model_limit=5,
+        min_shared_evals=1,
+        descriptive_only=False,
+    )
+
+    assert set(report) == {'descriptive', 'observational'}
+    assert report['descriptive']['counts']['result_rows'] == 2
+    assert 'coverage_aware_model_summaries' in report['observational']
+    assert 'pairwise_model_comparisons' in report['observational']
+
+
+def test_cli_help_uses_summary_limit_not_top_n(capsys):
+    try:
+        stats.parse_args(['--help'])
+    except SystemExit:
+        pass
+
+    output = capsys.readouterr().out
+    assert '--summary-limit' in output
+    assert '--top-n' not in output


### PR DESCRIPTION
## Summary
- add descriptive dataset statistics helpers for model coverage by benchmark and inference-engine/runtime spread
- add PDF plots for model-per-dataset coverage and inference-engine spread
- cover the new descriptive report fields with focused tests
- remove the generated Markdown summary writer from the plotting script

## Validation
- .venv/bin/python -m pytest tests/test_dataset_statistics.py
- .venv/bin/python scripts/plot_dataset_statistics.py --help