### PR TITLE
[Issue #152] Fix README documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > [EvalEval Coalition](https://evalevalai.com) — "We are a researcher community developing scientifically grounded research outputs and robust deployment infrastructure for broader impact evaluations."
 
-📖 **[Documentation](https://evalevalai.com/projects/every-eval-ever/)**
+📖 **[Documentation](https://evalevalai.com/projects/every-eval-ever/docs/)**
 
 **Every Eval Ever** is a shared schema and crowdsourced eval database. It defines a standardized metadata format for storing AI evaluation results — from leaderboard scrapes and research papers to local evaluation runs — so that results from different frameworks can be compared, reproduced, and reused. The three components that make it work:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > [EvalEval Coalition](https://evalevalai.com) — "We are a researcher community developing scientifically grounded research outputs and robust deployment infrastructure for broader impact evaluations."
 
-📖 **[Documentation](https://evalevalai.com/every_eval_ever/)**
+📖 **[Documentation](https://evalevalai.com/projects/every-eval-ever/)**
 
 **Every Eval Ever** is a shared schema and crowdsourced eval database. It defines a standardized metadata format for storing AI evaluation results — from leaderboard scrapes and research papers to local evaluation runs — so that results from different frameworks can be compared, reproduced, and reused. The three components that make it work:
 

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ color_scheme: light
 
 source: docs
 
-baseurl: "/every_eval_ever"
+baseurl: "/projects/every-eval-ever/docs"
 url: "https://evalevalai.com"
 repository: evaleval/every_eval_ever
 


### PR DESCRIPTION
## Summary
- update the README documentation link to the current Every Eval Ever project page
- replace the stale `/every_eval_ever/` URL with the live `/projects/every-eval-ever/` path

Closes #152

## Validation
- verified the target project page exists on evalevalai.com
- no automated checks were run because this is a single-link README change and the repo has no pre-commit config for markdown-only validation