### PR TITLE
Recolor docs accent to EvalEval blue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Every Eval Ever
 description: Documentation for the Every Eval Ever schema, CLI, and converters
 theme: just-the-docs
-color_scheme: light
+color_scheme: evaleval
 
 source: docs
 

--- a/docs/_sass/color_schemes/evaleval.scss
+++ b/docs/_sass/color_schemes/evaleval.scss
@@ -1,0 +1,11 @@
+// EvalEval color scheme — inherits the Just the Docs "light" scheme and
+// recolors the purple accents to EvalEval blue (#3b82f6), matching the
+// accent used on evalevalai.com and the Every Eval Ever project page.
+//
+// Imported after color_schemes/light, so these non-!default assignments
+// override the light scheme's $purple-000 / $purple-100 defaults.
+
+$blue-evaleval: #3b82f6;
+
+$link-color: $blue-evaleval;
+$btn-primary-color: $blue-evaleval;


### PR DESCRIPTION
## What

The Every Eval Ever docs site (https://evalevalai.com/every_eval_ever/) shipped with Just the Docs' default **light** color scheme, whose links, active sidebar nav item, and primary buttons render in purple (`#7253ed`).

This switches the accent to **EvalEval blue (`#3b82f6`)** — the accent used on evalevalai.com and the [Every Eval Ever project page](https://evalevalai.com/projects/every-eval-ever/).

## How

- Added a custom Just the Docs color scheme at `docs/_sass/color_schemes/evaleval.scss` that inherits the light scheme and overrides `$link-color` and `$btn-primary-color` to `#3b82f6`.
- Set `color_scheme: evaleval` in `_config.yml`.

Just the Docs imports a custom scheme *after* `color_schemes/light` and *before* `modules`, so the non-`!default` overrides take effect across links, sidebar/active nav, and primary buttons.

## Verification

`bundle exec jekyll build` succeeds. In the compiled `just-the-docs-default.css` (the stylesheet the pages load), the accent now resolves to `#3b82f6` everywhere it previously used purple. The only remaining `#7253ed` references are the unused `.text-purple-000` / `.bg-purple-000` palette utility classes, which the docs don't use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)