### PR TITLE
fix(lm_eval): handle 'N/A' stderr from non-bootstrapped metrics

### DIFF
--- a/every_eval_ever/converters/lm_eval/adapter.py
+++ b/every_eval_ever/converters/lm_eval/adapter.py
@@ -242,6 +242,11 @@ class LMEvalAdapter(BaseEvaluationAdapter):
 
             stderr_key = f'{metric_name}_stderr,{filter_name}'
             stderr_val = task_results.get(stderr_key)
+            # lm-eval emits the string 'N/A' for stderr when it is not bootstrapped
+            # (e.g. aggregated or custom metrics). Treat any non-numeric value as
+            # absent so the StandardError (which requires a float) is simply omitted.
+            if not isinstance(stderr_val, (int, float)):
+                stderr_val = None
 
             is_higher_better = higher_is_better.get(metric_name, True)
 

--- a/tests/test_lm_eval_adapter.py
+++ b/tests/test_lm_eval_adapter.py
@@ -274,3 +274,21 @@ def test_instance_level_transform_and_save_no_output_dir():
         output_dir=None,
     )
     assert result is None
+
+
+def test_na_stderr_treated_as_absent():
+    """lm-eval reports stderr as the string 'N/A' for non-bootstrapped metrics
+    (aggregated/grouped or custom metrics, e.g. ECLeKTic). Conversion must not
+    crash, and the StandardError (which requires a float) must be omitted rather
+    than coerced to 0."""
+    adapter = LMEvalAdapter()
+    raw_data = {
+        'results': {'mytask': {'acc,none': 0.5, 'acc_stderr,none': 'N/A'}},
+        'n-samples': {'mytask': {'effective': 100}},
+    }
+    results = adapter._build_evaluation_results(raw_data, 'mytask')
+    assert len(results) == 1
+    uncertainty = results[0].score_details.uncertainty
+    assert uncertainty is not None
+    assert uncertainty.standard_error is None
+    assert uncertainty.num_samples == 100


### PR DESCRIPTION
## Problem
`lm-eval` reports a metric's standard error as the string `"N/A"` whenever it isn't bootstrapped (aggregated/grouped metrics, or custom metrics such as ECLeKTic), e.g.:

```json
"eclektic_transfer,none": 0.057,
"eclektic_transfer_stderr,none": "N/A"
```

In `converters/lm_eval/adapter.py`, `_build_evaluation_results` guards only on `stderr_val is not None`, so `"N/A"` is treated as present and passed to `StandardError(value="N/A", ...)`. Since `StandardError.value` is a required `float`, this raises a `pydantic.ValidationError` and aborts the **entire** conversion of that run.

## Fix
Coerce any non-numeric stderr to `None` at parse time, mirroring the existing `isinstance(value, (int, float))` guard already used for the metric value a few lines above. The existing `is not None` checks then omit the `StandardError` (dropped by `exclude_none`).

Semantics: "stderr unavailable" -> the `standard_error` field is omitted, not set to `0` (which would assert false precision). `num_samples` is preserved.

## Test
Adds `test_na_stderr_treated_as_absent` to `tests/test_lm_eval_adapter.py`: a results dict with `*_stderr,none: "N/A"` now converts successfully, with `uncertainty.standard_error is None` and `num_samples` intact. Existing lm-eval adapter tests still pass.
