### PR TITLE
feat: add Mercor-Eval adapter

### DIFF
--- a/tests/data/mercor_eval/api_payload.json
+++ b/tests/data/mercor_eval/api_payload.json
@@ -1,0 +1,74 @@
+{
+  "benchmarks": {
+    "schemaVersion": "1.0",
+    "benchmarks": [
+      {
+        "benchmarkId": "camp_test",
+        "benchmarkName": "APEX-Agents",
+        "domains": [
+          "Investment Banking",
+          "Law"
+        ],
+        "numTasks": 480
+      }
+    ],
+    "dataAsOf": "2026-06-30T20:32:54Z"
+  },
+  "leaderboards": {
+    "schemaVersion": "1.0",
+    "rows": [
+      {
+        "evaluationId": "batch_test",
+        "evaluatedAt": "2026-01-08T04:10:41Z",
+        "benchmark": {
+          "id": "camp_test",
+          "name": "APEX-Agents"
+        },
+        "model": {
+          "id": "model_test",
+          "name": "gemini-3-flash-preview",
+          "config": {
+            "provider": "gemini",
+            "model": "gemini-3-flash-preview",
+            "reasoningEffort": "high",
+            "verbosity": "medium",
+            "temperature": 1.0,
+            "agentName": "ReAct Toolbelt Agent",
+            "agentConfigId": "react_toolbelt_agent",
+            "maxSteps": 250,
+            "timeoutSec": 10800,
+            "maxTokens": 65536,
+            "summary": "gemini-3-flash-preview react_toolbelt_agent"
+          }
+        },
+        "metrics": {
+          "passAt1": {
+            "value": 0.24,
+            "ci95": {
+              "lower": 0.208,
+              "upper": 0.273
+            }
+          },
+          "passAt8": {
+            "value": 0.367,
+            "ci95": {
+              "lower": 0.327,
+              "upper": 0.413
+            }
+          },
+          "passHat8": 0.134,
+          "meanScore": 0.422,
+          "perDomainPassAt1": {
+            "Investment Banking": 0.267,
+            "Law": 0.259
+          }
+        },
+        "numTrials": 3840
+      }
+    ],
+    "total": 1,
+    "limit": 100,
+    "offset": 0,
+    "dataAsOf": "2026-06-30T20:32:54Z"
+  }
+}

--- a/tests/test_mercor_eval_adapter.py
+++ b/tests/test_mercor_eval_adapter.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from every_eval_ever.eval_types import EvaluationLog
+from every_eval_ever.validate import validate_file
+from utils.mercor_eval import adapter
+
+FIXTURE_PATH = (
+    Path(__file__).parent / 'data' / 'mercor_eval' / 'api_payload.json'
+)
+
+
+def fixture_payload() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding='utf-8'))
+
+
+def make_fixture_bundles():
+    return adapter.make_bundles(
+        fixture_payload(),
+        retrieved_timestamp='1234567890.0',
+        base_url=adapter.DEFAULT_BASE_URL,
+    )
+
+
+def test_make_bundles_maps_all_metrics_and_validates():
+    bundles = make_fixture_bundles()
+
+    assert len(bundles) == 1
+    log = bundles[0].log
+    EvaluationLog.model_validate(log.model_dump())
+    assert log.model_info.id == 'google/gemini-3-flash-preview'
+    assert log.model_info.additional_details['mercor_model_id'] == 'model_test'
+    assert log.evaluation_timestamp == '2026-01-08T04:10:41Z'
+    assert len(log.evaluation_results) == 6
+
+    def find_result(
+        evaluation_name: str,
+        metric_id: str,
+        metric_parameters: dict | None = None,
+    ):
+        return next(
+            result
+            for result in log.evaluation_results
+            if result.evaluation_name == evaluation_name
+            and result.metric_config.metric_id == metric_id
+            and result.metric_config.metric_parameters == metric_parameters
+        )
+
+    pass_at_1 = find_result('Overall', 'pass_at_k', {'k': 1})
+    assert pass_at_1.score_details.score == 0.24
+    assert pass_at_1.score_details.uncertainty.num_samples == 480
+    assert (
+        pass_at_1.score_details.uncertainty.confidence_interval.lower == 0.208
+    )
+    pass_at_8 = find_result('Overall', 'pass_at_k', {'k': 8})
+    assert pass_at_8.score_details.score == 0.367
+    assert (
+        find_result(
+            'Overall',
+            'pass_hat_k',
+            {'k': 8, 'estimator': 'naive'},
+        ).score_details.score
+        == 0.134
+    )
+    assert find_result('Overall', 'mean_score').score_details.score == 0.422
+    assert (
+        find_result(
+            'Investment Banking',
+            'pass_at_k',
+            {'k': 1},
+        ).score_details.score
+        == 0.267
+    )
+    assert (
+        find_result('Law', 'pass_at_k', {'k': 1}).score_details.score == 0.259
+    )
+
+
+def test_make_bundles_preserves_run_configuration():
+    bundle = make_fixture_bundles()[0]
+    result = bundle.log.evaluation_results[0]
+    args = result.generation_config.generation_args
+
+    assert args.temperature == 1.0
+    assert args.max_tokens == 65536
+    assert args.eval_limits.time_limit == 10800
+    assert args.eval_limits.message_limit == 250
+    assert (
+        args.agentic_eval_config.additional_details['agent_name']
+        == 'ReAct Toolbelt Agent'
+    )
+    assert (
+        args.agentic_eval_config.additional_details['agent_config_id']
+        == 'react_toolbelt_agent'
+    )
+    assert (
+        result.generation_config.additional_details['reasoning_effort']
+        == 'high'
+    )
+    assert result.generation_config.additional_details['verbosity'] == 'medium'
+
+
+def test_source_and_evaluation_metadata_are_preserved():
+    log = make_fixture_bundles()[0].log
+
+    assert log.evaluation_id == (
+        'apex-agents/google_gemini-3-flash-preview/1234567890.0'
+    )
+    assert log.source_metadata.source_type.value == 'evaluation_run'
+    assert log.source_metadata.source_name == 'Mercor APEX-Agents Leaderboard'
+    assert log.source_metadata.source_organization_name == 'Mercor'
+    assert (
+        log.source_metadata.source_organization_url == 'https://www.mercor.com'
+    )
+    assert log.source_metadata.evaluator_relationship.value == 'first_party'
+    assert (
+        log.source_metadata.additional_details['data_as_of']
+        == '2026-06-30T20:32:54Z'
+    )
+    assert log.eval_library.name == 'Mercor Evaluation Exports API'
+    assert log.eval_library.version == '1.0'
+
+    source_data = log.evaluation_results[0].source_data
+    assert source_data.dataset_name == 'apex-agents'
+    assert source_data.source_type == 'hf_dataset'
+    assert source_data.hf_repo == 'mercor/apex-agents'
+    assert source_data.additional_details['benchmark_id'] == 'camp_test'
+    assert source_data.additional_details['num_tasks'] == '480'
+    assert source_data.additional_details['api_url'] == (
+        f'{adapter.DEFAULT_BASE_URL}/leaderboards?benchmarkId=camp_test'
+    )
+
+
+def test_provider_namespace_falls_back_to_sanitized_provider():
+    assert adapter.canonical_developer('Mystery Provider') == 'mystery-provider'
+    assert adapter.canonical_developer('gemini') == 'google'
+    assert adapter.canonical_developer('moonshotai') == 'moonshot'
+
+
+def test_namespaced_model_uses_model_developer_not_inference_provider():
+    payload = fixture_payload()
+    model = payload['leaderboards']['rows'][0]['model']
+    model['name'] = 'openai/gpt-oss-120b'
+    model['config']['model'] = 'openai/gpt-oss-120b'
+    model['config']['provider'] = 'baseten'
+
+    bundle = adapter.make_bundles(
+        payload,
+        retrieved_timestamp='123',
+    )[0]
+
+    assert bundle.log.model_info.name == 'openai/gpt-oss-120b'
+    assert bundle.log.model_info.id == 'openai/gpt-oss-120b'
+    assert bundle.log.model_info.developer == 'openai'
+    assert bundle.log.model_info.inference_platform == 'baseten'
+    assert bundle.developer == 'openai'
+    assert bundle.model == 'gpt-oss-120b'
+    assert bundle.benchmark_slug == 'apex-agents'
+
+
+def test_namespaced_moonshot_model_uses_datastore_slug():
+    payload = fixture_payload()
+    model = payload['leaderboards']['rows'][0]['model']
+    model['name'] = 'moonshotai/Kimi-K2-Thinking'
+    model['config']['model'] = 'moonshotai/Kimi-K2-Thinking'
+    model['config']['provider'] = 'baseten'
+
+    bundle = adapter.make_bundles(
+        payload,
+        retrieved_timestamp='123',
+    )[0]
+
+    assert bundle.log.model_info.name == 'moonshotai/Kimi-K2-Thinking'
+    assert bundle.log.model_info.id == 'moonshot/Kimi-K2-Thinking'
+    assert bundle.log.model_info.developer == 'moonshot'
+    assert bundle.log.model_info.inference_platform == 'baseten'
+    assert bundle.developer == 'moonshot'
+    assert bundle.model == 'kimi-k2-thinking'
+
+
+def test_unknown_benchmark_reference_fails():
+    payload = fixture_payload()
+    payload['leaderboards']['rows'][0]['benchmark']['id'] = 'camp_missing'
+
+    with pytest.raises(ValueError, match='camp_missing'):
+        adapter.make_bundles(payload, retrieved_timestamp='123')
+
+
+def test_unsupported_schema_version_fails():
+    payload = fixture_payload()
+    payload['benchmarks']['schemaVersion'] = '2.0'
+
+    with pytest.raises(ValueError, match='schemaVersion'):
+        adapter.make_bundles(payload, retrieved_timestamp='123')
+
+
+def test_empty_leaderboard_fails():
+    payload = fixture_payload()
+    payload['leaderboards']['rows'] = []
+    payload['leaderboards']['total'] = 0
+
+    with pytest.raises(ValueError, match='leaderboard'):
+        adapter.make_bundles(payload, retrieved_timestamp='123')
+
+
+def test_load_payload_requires_an_object(tmp_path: Path):
+    payload_path = tmp_path / 'payload.json'
+    payload_path.write_text('[]', encoding='utf-8')
+
+    with pytest.raises(ValueError, match='JSON object'):
+        adapter.load_payload(payload_path)
+
+
+def test_export_paths_validate(tmp_path: Path):
+    output_dir = tmp_path / 'data'
+    paths = adapter.export_bundles(make_fixture_bundles(), output_dir)
+
+    assert len(paths) == 1
+    assert paths[0].parent.parent.parent.parent == output_dir
+    assert paths[0].parent == (
+        output_dir / 'apex-agents' / 'google' / 'gemini-3-flash-preview'
+    )
+    assert validate_file(paths[0]).valid
+
+
+def test_fetch_payload_authenticates_and_paginates():
+    calls = []
+    responses = [
+        {
+            'schemaVersion': '1.0',
+            'benchmarks': fixture_payload()['benchmarks']['benchmarks'],
+            'dataAsOf': '2026-06-30T20:32:54Z',
+        },
+        {
+            'schemaVersion': '1.0',
+            'rows': [{'evaluationId': 'first'}],
+            'total': 2,
+            'limit': 1,
+            'offset': 0,
+            'dataAsOf': '2026-06-30T20:32:54Z',
+        },
+        {
+            'schemaVersion': '1.0',
+            'rows': [{'evaluationId': 'second'}],
+            'total': 2,
+            'limit': 1,
+            'offset': 1,
+            'dataAsOf': '2026-06-30T20:32:54Z',
+        },
+    ]
+
+    def fake_fetch(url, *, headers, params=None, timeout):
+        calls.append((url, headers, params, timeout))
+        return responses.pop(0)
+
+    payload = adapter.fetch_payload(
+        'secret',
+        base_url='https://example.test/v1',
+        page_size=1,
+        fetch_page=fake_fetch,
+    )
+
+    assert [call[2] for call in calls[1:]] == [
+        {'limit': 1, 'offset': 0},
+        {'limit': 1, 'offset': 1},
+    ]
+    assert all(call[1] == {'X-API-Key': 'secret'} for call in calls)
+    assert len(payload['leaderboards']['rows']) == 2
+    assert payload['leaderboards']['dataAsOf'] == '2026-06-30T20:32:54Z'
+
+
+def test_fetch_payload_rejects_empty_page_before_total():
+    responses = [
+        {
+            'schemaVersion': '1.0',
+            'benchmarks': fixture_payload()['benchmarks']['benchmarks'],
+            'dataAsOf': '2026-06-30T20:32:54Z',
+        },
+        {
+            'schemaVersion': '1.0',
+            'rows': [],
+            'total': 1,
+            'limit': 1,
+            'offset': 0,
+            'dataAsOf': '2026-06-30T20:32:54Z',
+        },
+    ]
+
+    def fake_fetch(_url, **_kwargs):
+        return responses.pop(0)
+
+    with pytest.raises(ValueError, match='before total'):
+        adapter.fetch_payload(
+            'secret',
+            base_url='https://example.test/v1',
+            page_size=1,
+            fetch_page=fake_fetch,
+        )
+
+
+def test_resolve_api_key_prefers_explicit_value(monkeypatch):
+    monkeypatch.setenv(adapter.API_KEY_ENV, 'environment-key')
+
+    assert adapter.resolve_api_key('explicit-key') == 'explicit-key'
+
+
+def test_resolve_api_key_reads_environment(monkeypatch):
+    monkeypatch.setenv(adapter.API_KEY_ENV, 'environment-key')
+
+    assert adapter.resolve_api_key(None) == 'environment-key'
+
+
+def test_resolve_api_key_fails_when_missing(monkeypatch):
+    monkeypatch.delenv(adapter.API_KEY_ENV, raising=False)
+
+    with pytest.raises(ValueError, match=adapter.API_KEY_ENV):
+        adapter.resolve_api_key(None)

--- a/utils/README.md
+++ b/utils/README.md
@@ -19,12 +19,38 @@ Each adapter is run with `uv run python -m utils.<name>.adapter`.
 | `hfopenllm_v2` | HuggingFace Spaces API | Fetches the Open LLM Leaderboard v2 (4576+ models). |
 | `helm` | HELM leaderboard | Converts HELM leaderboard data. Supports `--leaderboard_name` for Capabilities/Lite/Classic/Instruct/MMLU. |
 | `llm_stats` | LLM Stats API | Converts LLM Stats model, benchmark, and score API data into `data/llm-stats/`. |
+| `mercor_eval` | Mercor Evaluation Exports API | Fetches authenticated Mercor benchmark leaderboards and writes aggregate EEE records. |
 | `mt_bench` | LMSYS / FastChat | Converts MT-Bench GPT-4 single-answer judgments into `data/mt-bench/`. Emits overall, turn-1, and turn-2 means per model. |
 | `openeval` | HuggingFace | Converts OpenEval response scores from `human-centered-eval/OpenEval` into `data/openeval/`; pass `--include-instances` to also write `*_samples.jsonl` sidecars. |
 | `rewardbench` | HuggingFace | Fetches RewardBench v1 (CSV) and RewardBench v2 (JSON) leaderboard data. |
 | `terminal_bench_2` | tbench.ai | Fetches Terminal-Bench 2.0 agentic coding benchmark results. |
 | `hle` | Scale SEAL leaderboard | Converts the Scale SEAL Humanity's Last Exam leaderboard into `data/hle/`. Emits per-model accuracy (with 95% CI) and calibration error. |
 | `mmlu_pro` | TIGER-Lab leaderboard CSV | Converts the MMLU-Pro leaderboard (`TIGER-Lab/mmlu_pro_leaderboard_submission`) into `data/mmlu-pro/`. Emits per-model overall + 14 per-subject accuracies. |
+
+### Mercor Evaluation Exports
+
+Set the API key in the environment and run the adapter:
+
+```bash
+export MERCOR_EVAL_API_EVALEVAL_KEY="<your-key>"
+uv run python -m utils.mercor_eval.adapter
+```
+
+For a credential-free offline smoke run:
+
+```bash
+uv run python -m utils.mercor_eval.adapter \
+  --input-json tests/data/mercor_eval/api_payload.json \
+  --output-dir /tmp/mercor-eval-offline
+```
+
+The adapter exports aggregate leaderboard metrics only. Mercor's criterion
+results do not include the task input, model output, messages, or answer
+attribution required by the EEE instance-level schema.
+Records are generated under benchmark-specific datastore directories, for
+example `data/apex-agents/<developer>/<model>/<uuid>.json`. Generated records
+are intended for the Hugging Face datastore submission, not the GitHub adapter
+PR.
 
 ## Notes
 

--- a/utils/mercor_eval/__init__.py
+++ b/utils/mercor_eval/__init__.py
@@ -1,0 +1,1 @@
+"""Mercor Evaluation Exports adapter."""

--- a/utils/mercor_eval/adapter.py
+++ b/utils/mercor_eval/adapter.py
@@ -1,0 +1,687 @@
+#!/usr/bin/env python3
+"""Convert Mercor Evaluation Exports API leaderboards to EEE records.
+
+Usage:
+    MERCOR_EVAL_API_EVALEVAL_KEY=... \
+      uv run python -m utils.mercor_eval.adapter
+
+For deterministic offline replay:
+    uv run python -m utils.mercor_eval.adapter \
+      --input-json tests/data/mercor_eval/api_payload.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import urlencode
+
+import requests
+
+from every_eval_ever.eval_types import (
+    AgenticEvalConfig,
+    ConfidenceInterval,
+    EvalLibrary,
+    EvalLimits,
+    EvaluationLog,
+    EvaluationResult,
+    EvaluatorRelationship,
+    GenerationArgs,
+    GenerationConfig,
+    MetricConfig,
+    ModelInfo,
+    ScoreDetails,
+    ScoreType,
+    SourceDataHf,
+    SourceMetadata,
+    SourceType,
+    Uncertainty,
+)
+from every_eval_ever.helpers import (
+    SCHEMA_VERSION,
+    sanitize_filename,
+    save_evaluation_log,
+)
+
+DEFAULT_BASE_URL = 'https://coil.mercor.com/external/evals/v1'
+DEFAULT_OUTPUT_DIR = Path('data')
+API_KEY_ENV = 'MERCOR_EVAL_API_EVALEVAL_KEY'
+API_SCHEMA_VERSION = '1.0'
+DEFAULT_TIMEOUT = 60
+DEFAULT_PAGE_SIZE = 500
+
+PROVIDER_ALIASES = {
+    'anthropic': 'anthropic',
+    'gemini': 'google',
+    'google': 'google',
+    'moonshot-ai': 'moonshot',
+    'moonshotai': 'moonshot',
+    'openai': 'openai',
+    'xai': 'xai',
+}
+
+FetchPage = Callable[..., dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class LogBundle:
+    """An EEE log and its datastore path components."""
+
+    log: EvaluationLog
+    benchmark_slug: str
+    developer: str
+    model: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Convert Mercor evaluation exports to Every Eval Ever.'
+    )
+    parser.add_argument(
+        '--api-key',
+        help=f'Mercor API key. Defaults to {API_KEY_ENV}.',
+    )
+    parser.add_argument(
+        '--base-url',
+        default=DEFAULT_BASE_URL,
+        help=f'Mercor API base URL (default: {DEFAULT_BASE_URL}).',
+    )
+    parser.add_argument(
+        '--input-json',
+        type=Path,
+        help='Use an offline benchmarks/leaderboards payload.',
+    )
+    parser.add_argument(
+        '--output-dir',
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f'Output root directory (default: {DEFAULT_OUTPUT_DIR}).',
+    )
+    parser.add_argument(
+        '--page-size',
+        type=int,
+        default=DEFAULT_PAGE_SIZE,
+        help=f'Leaderboard page size (default: {DEFAULT_PAGE_SIZE}).',
+    )
+    return parser.parse_args()
+
+
+def normalize_slug(value: Any, fallback: str = 'unknown') -> str:
+    raw = str(value if value not in (None, '') else fallback).strip().lower()
+    raw = sanitize_filename(raw)
+    raw = raw.replace('&', 'and')
+    raw = re.sub(r'[\s_]+', '-', raw)
+    raw = re.sub(r'[^a-z0-9.\-]+', '-', raw)
+    raw = re.sub(r'-{2,}', '-', raw).strip('-')
+    return raw or fallback
+
+
+def stringify(value: Any) -> str:
+    if isinstance(value, bool):
+        return 'true' if value else 'false'
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, separators=(',', ':'))
+    return str(value)
+
+
+def stringify_details(details: dict[str, Any]) -> dict[str, str]:
+    return {
+        key: stringify(value)
+        for key, value in details.items()
+        if value not in (None, '')
+    }
+
+
+def optional_float(value: Any) -> float | None:
+    if value in (None, ''):
+        return None
+    return float(value)
+
+
+def optional_positive_int(value: Any) -> int | None:
+    if value in (None, ''):
+        return None
+    parsed = int(value)
+    return parsed if parsed > 0 else None
+
+
+def canonical_developer(provider: Any) -> str:
+    provider_slug = normalize_slug(provider)
+    return PROVIDER_ALIASES.get(provider_slug, provider_slug)
+
+
+def resolve_model_identity(
+    model_name: str,
+    provider: Any,
+) -> tuple[str, str, str]:
+    if '/' in model_name:
+        namespace, unqualified_name = model_name.split('/', 1)
+        if namespace and unqualified_name:
+            developer = canonical_developer(namespace)
+            return (
+                developer,
+                f'{developer}/{unqualified_name}',
+                normalize_slug(unqualified_name),
+            )
+
+    developer = canonical_developer(provider)
+    return developer, f'{developer}/{model_name}', normalize_slug(model_name)
+
+
+def resolve_api_key(explicit: str | None) -> str:
+    api_key = explicit or os.environ.get(API_KEY_ENV)
+    if not api_key:
+        raise ValueError(
+            f'Mercor API key required via --api-key or {API_KEY_ENV}.'
+        )
+    return api_key
+
+
+def validate_api_envelope(payload: Any, endpoint: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f'Mercor {endpoint} endpoint returned a non-object payload.'
+        )
+    schema_version = payload.get('schemaVersion')
+    if schema_version != API_SCHEMA_VERSION:
+        raise ValueError(
+            f'Mercor {endpoint} schemaVersion must be '
+            f'{API_SCHEMA_VERSION!r}, got {schema_version!r}.'
+        )
+    return payload
+
+
+def request_json(
+    url: str,
+    *,
+    headers: dict[str, str],
+    params: dict[str, Any] | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    try:
+        response = requests.get(
+            url,
+            headers=headers,
+            params=params,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except requests.RequestException as exc:
+        raise RuntimeError(
+            f'Failed to fetch Mercor endpoint {url}: {exc}'
+        ) from exc
+    except ValueError as exc:
+        raise RuntimeError(
+            f'Failed to parse JSON from Mercor endpoint {url}: {exc}'
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f'Mercor endpoint {url} returned a non-object payload.'
+        )
+    return payload
+
+
+def fetch_payload(
+    api_key: str,
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    page_size: int = DEFAULT_PAGE_SIZE,
+    fetch_page: FetchPage = request_json,
+) -> dict[str, Any]:
+    if not 1 <= page_size <= 500:
+        raise ValueError(
+            'Mercor leaderboard page size must be between 1 and 500.'
+        )
+
+    base_url = base_url.rstrip('/')
+    headers = {'X-API-Key': api_key}
+    benchmarks = fetch_page(
+        f'{base_url}/benchmarks',
+        headers=headers,
+        timeout=DEFAULT_TIMEOUT,
+    )
+    validate_api_envelope(benchmarks, 'benchmarks')
+
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    data_as_of = None
+    while True:
+        page = fetch_page(
+            f'{base_url}/leaderboards',
+            headers=headers,
+            params={'limit': page_size, 'offset': offset},
+            timeout=DEFAULT_TIMEOUT,
+        )
+        validate_api_envelope(page, 'leaderboards')
+        page_rows = page.get('rows')
+        total = page.get('total')
+        if not isinstance(page_rows, list) or not isinstance(total, int):
+            raise ValueError('Invalid Mercor leaderboard pagination envelope.')
+        if not page_rows and offset < total:
+            raise ValueError(
+                'Mercor leaderboard pagination stopped before total.'
+            )
+        rows.extend(page_rows)
+        data_as_of = page.get('dataAsOf') or data_as_of
+        offset += len(page_rows)
+        if offset >= total:
+            break
+
+    return {
+        'benchmarks': benchmarks,
+        'leaderboards': {
+            'schemaVersion': API_SCHEMA_VERSION,
+            'rows': rows,
+            'total': len(rows),
+            'limit': page_size,
+            'offset': 0,
+            'dataAsOf': data_as_of,
+        },
+    }
+
+
+def load_payload(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, dict):
+        raise ValueError('--input-json must contain a JSON object.')
+    return payload
+
+
+def make_source_data(
+    benchmark: dict[str, Any],
+    base_url: str,
+) -> SourceDataHf:
+    benchmark_id = str(benchmark['benchmarkId'])
+    benchmark_slug = normalize_slug(benchmark['benchmarkName'])
+    query = urlencode({'benchmarkId': benchmark_id})
+    return SourceDataHf(
+        dataset_name=benchmark_slug,
+        source_type='hf_dataset',
+        hf_repo=f'mercor/{benchmark_slug}',
+        additional_details=stringify_details(
+            {
+                'benchmark_id': benchmark_id,
+                'num_tasks': benchmark.get('numTasks'),
+                'domains': benchmark.get('domains'),
+                'access': 'authenticated_api',
+                'api_url': f'{base_url.rstrip("/")}/leaderboards?{query}',
+            }
+        ),
+    )
+
+
+def result_scope_slug(value: str) -> str:
+    return normalize_slug(value).replace('-', '_')
+
+
+def evaluation_result_id(
+    parent_evaluation_id: str,
+    evaluation_name: str,
+    metric_id: str,
+    metric_parameters: dict[str, str | float | bool | int | None] | None,
+) -> str:
+    suffix = metric_id
+    if metric_parameters:
+        parts = []
+        for key, value in sorted(metric_parameters.items()):
+            if value is not None:
+                parts.append(f'{normalize_slug(key)}_{normalize_slug(value)}')
+        if parts:
+            suffix = f'{suffix}__{"__".join(parts)}'
+    return (
+        f'{parent_evaluation_id}#{result_scope_slug(evaluation_name)}#{suffix}'
+    )
+
+
+def make_generation_config(config: dict[str, Any]) -> GenerationConfig:
+    agent_details = stringify_details(
+        {
+            'agent_name': config.get('agentName'),
+            'agent_config_id': config.get('agentConfigId'),
+        }
+    )
+    return GenerationConfig(
+        generation_args=GenerationArgs(
+            temperature=optional_float(config.get('temperature')),
+            max_tokens=optional_positive_int(config.get('maxTokens')),
+            agentic_eval_config=AgenticEvalConfig(
+                additional_details=agent_details or None,
+            ),
+            eval_limits=EvalLimits(
+                time_limit=optional_positive_int(config.get('timeoutSec')),
+                message_limit=optional_positive_int(config.get('maxSteps')),
+            ),
+        ),
+        additional_details=stringify_details(
+            {
+                'reasoning_effort': config.get('reasoningEffort'),
+                'verbosity': config.get('verbosity'),
+                'summary': config.get('summary'),
+            }
+        )
+        or None,
+    )
+
+
+def make_metric_result(
+    *,
+    benchmark: dict[str, Any],
+    row: dict[str, Any],
+    base_url: str,
+    parent_evaluation_id: str,
+    evaluation_name: str,
+    metric_id: str,
+    metric_name: str,
+    metric_kind: str,
+    value: Any,
+    metric_unit: str = 'proportion',
+    metric_parameters: dict[str, str | float | bool | int | None] | None = None,
+    ci95: dict[str, Any] | None = None,
+) -> EvaluationResult:
+    uncertainty = None
+    if ci95 is not None:
+        uncertainty = Uncertainty(
+            confidence_interval=ConfidenceInterval(
+                lower=float(ci95['lower']),
+                upper=float(ci95['upper']),
+                confidence_level=0.95,
+                method='seeded_percentile_bootstrap',
+            ),
+            num_samples=int(benchmark['numTasks']),
+        )
+
+    config = row['model'].get('config') or {}
+    return EvaluationResult(
+        evaluation_result_id=evaluation_result_id(
+            parent_evaluation_id,
+            evaluation_name,
+            metric_id,
+            metric_parameters,
+        ),
+        evaluation_name=evaluation_name,
+        source_data=make_source_data(benchmark, base_url),
+        evaluation_timestamp=row.get('evaluatedAt'),
+        metric_config=MetricConfig(
+            evaluation_description=(
+                f'{evaluation_name} {metric_name} reported by Mercor for '
+                f'{benchmark["benchmarkName"]}.'
+            ),
+            metric_id=metric_id,
+            metric_name=metric_name,
+            metric_kind=metric_kind,
+            metric_unit=metric_unit,
+            metric_parameters=metric_parameters,
+            lower_is_better=False,
+            score_type=ScoreType.continuous,
+            min_score=0.0,
+            max_score=1.0,
+            additional_details={'raw_scope': evaluation_name},
+        ),
+        score_details=ScoreDetails(
+            score=float(value),
+            details={'num_trials': str(row['numTrials'])},
+            uncertainty=uncertainty,
+        ),
+        generation_config=make_generation_config(config),
+    )
+
+
+def make_results(
+    row: dict[str, Any],
+    benchmark: dict[str, Any],
+    base_url: str,
+    parent_evaluation_id: str,
+) -> list[EvaluationResult]:
+    metrics = row.get('metrics')
+    if not isinstance(metrics, dict):
+        raise ValueError('Mercor leaderboard row is missing metrics.')
+
+    pass_at_1 = metrics.get('passAt1')
+    pass_at_8 = metrics.get('passAt8')
+    if not isinstance(pass_at_1, dict) or not isinstance(pass_at_8, dict):
+        raise ValueError('Mercor leaderboard row is missing Pass@k metrics.')
+
+    results = [
+        make_metric_result(
+            benchmark=benchmark,
+            row=row,
+            base_url=base_url,
+            parent_evaluation_id=parent_evaluation_id,
+            evaluation_name='Overall',
+            metric_id='pass_at_k',
+            metric_name='Pass@1',
+            metric_kind='pass_rate',
+            metric_parameters={'k': 1},
+            value=pass_at_1['value'],
+            ci95=pass_at_1.get('ci95'),
+        ),
+        make_metric_result(
+            benchmark=benchmark,
+            row=row,
+            base_url=base_url,
+            parent_evaluation_id=parent_evaluation_id,
+            evaluation_name='Overall',
+            metric_id='pass_at_k',
+            metric_name='Pass@8',
+            metric_kind='pass_rate',
+            metric_parameters={'k': 8},
+            value=pass_at_8['value'],
+            ci95=pass_at_8.get('ci95'),
+        ),
+        make_metric_result(
+            benchmark=benchmark,
+            row=row,
+            base_url=base_url,
+            parent_evaluation_id=parent_evaluation_id,
+            evaluation_name='Overall',
+            metric_id='pass_hat_k',
+            metric_name='Pass^8',
+            metric_kind='pass_rate',
+            metric_parameters={'k': 8, 'estimator': 'naive'},
+            value=metrics['passHat8'],
+        ),
+        make_metric_result(
+            benchmark=benchmark,
+            row=row,
+            base_url=base_url,
+            parent_evaluation_id=parent_evaluation_id,
+            evaluation_name='Overall',
+            metric_id='mean_score',
+            metric_name='Mean Score',
+            metric_kind='score',
+            value=metrics['meanScore'],
+        ),
+    ]
+
+    per_domain = metrics.get('perDomainPassAt1')
+    if not isinstance(per_domain, dict):
+        raise ValueError('Mercor leaderboard row is missing perDomainPassAt1.')
+    for domain, value in sorted(per_domain.items()):
+        results.append(
+            make_metric_result(
+                benchmark=benchmark,
+                row=row,
+                base_url=base_url,
+                parent_evaluation_id=parent_evaluation_id,
+                evaluation_name=str(domain),
+                metric_id='pass_at_k',
+                metric_name=f'Pass@1 - {domain}',
+                metric_kind='pass_rate',
+                metric_parameters={'k': 1},
+                value=value,
+            )
+        )
+    return results
+
+
+def make_bundles(
+    payload: dict[str, Any],
+    *,
+    retrieved_timestamp: str | None = None,
+    base_url: str = DEFAULT_BASE_URL,
+) -> list[LogBundle]:
+    benchmark_envelope = validate_api_envelope(
+        payload.get('benchmarks'), 'benchmarks'
+    )
+    leaderboard_envelope = validate_api_envelope(
+        payload.get('leaderboards'), 'leaderboards'
+    )
+
+    benchmarks = benchmark_envelope.get('benchmarks')
+    rows = leaderboard_envelope.get('rows')
+    if not isinstance(benchmarks, list) or not benchmarks:
+        raise ValueError('Mercor benchmarks payload contains no benchmarks.')
+    if not isinstance(rows, list) or not rows:
+        raise ValueError('Mercor leaderboard payload contains no rows.')
+
+    benchmark_index = {}
+    for benchmark in benchmarks:
+        if not isinstance(benchmark, dict) or not benchmark.get('benchmarkId'):
+            raise ValueError(
+                'Mercor benchmarks payload contains an invalid row.'
+            )
+        benchmark_index[str(benchmark['benchmarkId'])] = benchmark
+
+    retrieved_timestamp = retrieved_timestamp or str(time.time())
+    api_data_as_of = leaderboard_envelope.get(
+        'dataAsOf'
+    ) or benchmark_envelope.get('dataAsOf')
+    bundles = []
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ValueError(
+                'Mercor leaderboard payload contains an invalid row.'
+            )
+        benchmark_ref = row.get('benchmark')
+        if not isinstance(benchmark_ref, dict):
+            raise ValueError('Mercor leaderboard row is missing benchmark.')
+        benchmark_id = str(benchmark_ref.get('id') or '')
+        benchmark = benchmark_index.get(benchmark_id)
+        if benchmark is None:
+            raise ValueError(
+                f'Mercor leaderboard references unknown benchmark {benchmark_id!r}.'
+            )
+
+        model = row.get('model')
+        if not isinstance(model, dict):
+            raise ValueError('Mercor leaderboard row is missing model.')
+        config = model.get('config') or {}
+        if not isinstance(config, dict):
+            raise ValueError('Mercor model config must be an object.')
+        provider = config.get('provider') or 'unknown'
+        model_name = str(model.get('name') or config.get('model') or 'unknown')
+        developer, model_id, output_model_name = resolve_model_identity(
+            model_name,
+            provider,
+        )
+        mercor_model_id = str(model.get('id') or 'unknown')
+        evaluation_id = str(row.get('evaluationId') or 'unknown')
+        benchmark_slug = normalize_slug(benchmark['benchmarkName'])
+        log_evaluation_id = (
+            f'{benchmark_slug}/{developer}_{output_model_name}/'
+            f'{retrieved_timestamp}'
+        )
+
+        log = EvaluationLog(
+            schema_version=SCHEMA_VERSION,
+            evaluation_id=log_evaluation_id,
+            evaluation_timestamp=row.get('evaluatedAt'),
+            retrieved_timestamp=retrieved_timestamp,
+            source_metadata=SourceMetadata(
+                source_name=(
+                    f'Mercor {benchmark["benchmarkName"]} Leaderboard'
+                ),
+                source_type=SourceType.evaluation_run,
+                source_organization_name='Mercor',
+                source_organization_url='https://www.mercor.com',
+                evaluator_relationship=EvaluatorRelationship.first_party,
+                additional_details=stringify_details(
+                    {
+                        'benchmark_id': benchmark_id,
+                        'benchmark_name': benchmark.get('benchmarkName'),
+                        'evaluation_id': evaluation_id,
+                        'api_schema_version': API_SCHEMA_VERSION,
+                        'data_as_of': api_data_as_of,
+                    }
+                ),
+            ),
+            eval_library=EvalLibrary(
+                name='Mercor Evaluation Exports API',
+                version=API_SCHEMA_VERSION,
+            ),
+            model_info=ModelInfo(
+                name=model_name,
+                id=model_id,
+                developer=developer,
+                inference_platform=str(provider),
+                additional_details=stringify_details(
+                    {
+                        'mercor_model_id': mercor_model_id,
+                        'provider': provider,
+                        'run_config': config,
+                    }
+                ),
+            ),
+            evaluation_results=make_results(
+                row,
+                benchmark,
+                base_url,
+                log_evaluation_id,
+            ),
+        )
+        bundles.append(
+            LogBundle(
+                log=log,
+                benchmark_slug=benchmark_slug,
+                developer=developer,
+                model=output_model_name,
+            )
+        )
+    return bundles
+
+
+def export_bundles(
+    bundles: list[LogBundle],
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+) -> list[Path]:
+    paths = []
+    for bundle in bundles:
+        paths.append(
+            save_evaluation_log(
+                bundle.log,
+                Path(output_dir) / bundle.benchmark_slug,
+                bundle.developer,
+                bundle.model,
+            )
+        )
+    return paths
+
+
+def main() -> None:
+    args = parse_args()
+    if args.input_json:
+        payload = load_payload(args.input_json)
+    else:
+        payload = fetch_payload(
+            resolve_api_key(args.api_key),
+            base_url=args.base_url,
+            page_size=args.page_size,
+        )
+
+    bundles = make_bundles(payload, base_url=args.base_url)
+    paths = export_bundles(bundles, args.output_dir)
+    for path in paths:
+        print(f'Saved: {path}')
+    print(f'Done! Generated {len(paths)} Mercor evaluation record(s).')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Adds an adapter for the Mercor Evaluation Exports API.

## Data handling

The adapter generates records under benchmark-specific datastore paths, e.g. `data/apex-agents/...`, matching the existing Hugging Face datastore layout. The HF datastore already contains Mercor APEX Agents data under [`data/apex-agents/`](https://huggingface.co/datasets/evaleval/EEE_datastore/tree/main/data/apex-agents), and I verified that this adapter generates analogous records for that existing structure (expected differences in generated output are limited to API-backed provenance and richer metadata).

## Validation

Ran:
- `python -m pytest tests/test_mercor_eval_adapter.py -q`
- `python -m pytest -q`
- `python -m ruff check utils/mercor_eval tests/test_mercor_eval_adapter.py`
- `python -m ruff format --check utils/mercor_eval tests/test_mercor_eval_adapter.py`
- offline adapter smoke test with `--input-json`
- schema validation on the generated HF data copy
