### PR TITLE
fix: represent unbounded metric bounds as the JSON string "Infinity"

### DIFF
--- a/every_eval_ever/cli.py
+++ b/every_eval_ever/cli.py
@@ -105,6 +105,24 @@ def _cmd_convert_lm_eval(args: argparse.Namespace) -> int:
         print(_write_log(log, output_dir, eval_uuid=eval_uuid))
 
     print(f'Converted {len(logs)} evaluation log(s).')
+
+    # Skips are otherwise only a stderr warning per metric; report the tally here
+    # so the loss is visible in the run's summary rather than silent (some metrics
+    # are dropped for lack of known bounds; a log can end up with no results).
+    skipped = adapter.get_skipped_metrics()
+    if skipped:
+        names = ', '.join(sorted({metric for _, metric in skipped}))
+        print(
+            f'Skipped {len(skipped)} metric result(s) with no known bounds '
+            f'({names}); add them to KNOWN_METRIC_BOUNDS to include.',
+            file=sys.stderr,
+        )
+    empty = sum(1 for log in logs if not log.evaluation_results)
+    if empty:
+        print(
+            f'{empty} of {len(logs)} log(s) have no results after skips.',
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/every_eval_ever/converters/lm_eval/adapter.py
+++ b/every_eval_ever/converters/lm_eval/adapter.py
@@ -1,6 +1,7 @@
 """Adapter for converting lm-evaluation-harness output to every_eval_ever format."""
 
 import json
+import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -251,8 +252,18 @@ class LMEvalAdapter(BaseEvaluationAdapter):
             is_higher_better = higher_is_better.get(metric_name, True)
 
             bounds = KNOWN_METRIC_BOUNDS.get(metric_name)
-            min_score = bounds[0] if bounds else None
-            max_score = bounds[1] if bounds else None
+            if bounds is None:
+                # Unknown bounds: a continuous metric_config requires numeric
+                # min/max, so this would be invalid. Skip rather than emit a bad
+                # record. To include the metric, add it to KNOWN_METRIC_BOUNDS
+                # (use float('inf') for an unbounded side).
+                warnings.warn(
+                    f'lm_eval: skipping metric {metric_name!r} on task '
+                    f'{task_name!r} -- no known bounds in KNOWN_METRIC_BOUNDS',
+                    stacklevel=2,
+                )
+                continue
+            min_score, max_score = bounds
 
             description = metric_name
             if filter_name != 'none':

--- a/every_eval_ever/converters/lm_eval/adapter.py
+++ b/every_eval_ever/converters/lm_eval/adapter.py
@@ -48,10 +48,23 @@ class LMEvalAdapter(BaseEvaluationAdapter):
         # Stores per-log metadata so callers can find sample files after transform.
         # Keyed by evaluation_id -> {"parent_dir": str, "task_name": str}
         self._eval_metadata = {}
+        # (task_name, metric_name) pairs dropped for lack of known bounds, so a
+        # caller can report the loss instead of it being silent. Accumulates over
+        # the adapter's lifetime (one instance per convert run); see get_skipped_metrics.
+        self._skipped_metrics: List[tuple] = []
 
     def get_eval_metadata(self, evaluation_id: str) -> Dict[str, Any]:
         """Return stored metadata for a given evaluation_id."""
         return self._eval_metadata.get(evaluation_id, {})
+
+    def get_skipped_metrics(self) -> List[tuple]:
+        """(task_name, metric_name) pairs skipped for lack of known bounds.
+
+        Each entry is a metric that was silently dropped from the output because
+        KNOWN_METRIC_BOUNDS had no range for it (a continuous MetricConfig needs
+        finite/typed min+max). Callers surface this so the drop is visible.
+        """
+        return list(self._skipped_metrics)
 
     @property
     def metadata(self) -> AdapterMetadata:
@@ -257,6 +270,7 @@ class LMEvalAdapter(BaseEvaluationAdapter):
                 # min/max, so this would be invalid. Skip rather than emit a bad
                 # record. To include the metric, add it to KNOWN_METRIC_BOUNDS
                 # (use float('inf') for an unbounded side).
+                self._skipped_metrics.append((task_name, metric_name))
                 warnings.warn(
                     f'lm_eval: skipping metric {metric_name!r} on task '
                     f'{task_name!r} -- no known bounds in KNOWN_METRIC_BOUNDS',

--- a/every_eval_ever/converters/lm_eval/utils.py
+++ b/every_eval_ever/converters/lm_eval/utils.py
@@ -55,8 +55,11 @@ MODEL_TYPE_TO_INFERENCE_ENGINE = {
     'gguf': 'llama.cpp',
 }
 
-# Known metric bounds: metric_name -> (min_score, max_score)
-# max_score of None means unbounded
+# Known metric bounds: metric_name -> (min_score, max_score).
+# Use float('inf')/-inf for an unbounded side (it serializes as the JSON string
+# "Infinity"/"-Infinity"). A metric absent from this table has unknown bounds and
+# is skipped by the adapter rather than emitted with null bounds, which a
+# continuous metric_config forbids.
 KNOWN_METRIC_BOUNDS = {
     'acc': (0.0, 1.0),
     'acc_norm': (0.0, 1.0),
@@ -71,6 +74,6 @@ KNOWN_METRIC_BOUNDS = {
     'rouge2': (0.0, 1.0),
     'rougeL': (0.0, 1.0),
     'rougeLsum': (0.0, 1.0),
-    'ter': (0.0, None),
+    'ter': (0.0, float('inf')),
     'brier_score': (0.0, 1.0),
 }

--- a/every_eval_ever/eval_types.py
+++ b/every_eval_ever/eval_types.py
@@ -14,6 +14,7 @@ from pydantic import (
     Field,
     confloat,
     conint,
+    field_serializer,
     model_validator,
 )
 
@@ -428,10 +429,12 @@ class MetricConfig(BaseModel):
         description='Indicates whether there is an Unknown Level - if True, then a score of -1 will be treated as Unknown',
     )
     min_score: float | None = Field(
-        None, description='Minimum possible score for continuous metric'
+        None,
+        description='Minimum possible score for a continuous metric. Use -inf if unbounded below (serialized as the string "-Infinity"). null means "not provided", NOT unbounded.',
     )
     max_score: float | None = Field(
-        None, description='Maximum possible score for continuous metric'
+        None,
+        description='Maximum possible score for a continuous metric. Use inf if unbounded above, e.g. PSNR or perplexity (serialized as the string "Infinity"). null means "not provided", NOT unbounded.',
     )
     llm_scoring: LlmScoring | None = Field(
         None, description='Configuration when LLM is used as scorer/judge'
@@ -457,7 +460,27 @@ class MetricConfig(BaseModel):
                 raise ValueError("score_type 'continuous' requires min_score")
             if self.max_score is None:
                 raise ValueError("score_type 'continuous' requires max_score")
+        # A NaN bound is never meaningful (and NaN != NaN breaks comparisons).
+        # inf/-inf are allowed (unbounded); null is handled above per score_type.
+        for _name in ('min_score', 'max_score'):
+            _v = getattr(self, _name)
+            if _v is not None and _v != _v:
+                raise ValueError(f'{_name} must not be NaN')
         return self
+
+    @field_serializer('min_score', 'max_score', when_used='json')
+    def _serialize_bound(self, value):
+        # An unbounded bound is +/-inf; emit it as the JSON string
+        # "Infinity"/"-Infinity" (valid JSON that reads back to a float) rather
+        # than pydantic's default null or the non-standard bare Infinity token.
+        # when_used='json' covers BOTH model_dump_json() and
+        # model_dump(mode='json'); mode='python' keeps the native float. null
+        # stays null (reserved for "not provided", never unbounded).
+        if value == float('inf'):
+            return 'Infinity'
+        if value == float('-inf'):
+            return '-Infinity'
+        return value
 
 
 class EvaluationResult(BaseModel):

--- a/every_eval_ever/schemas/eval.schema.json
+++ b/every_eval_ever/schemas/eval.schema.json
@@ -219,13 +219,18 @@
                                 "description": "Indicates whether there is an Unknown Level - if True, then a score of -1 will be treated as Unknown"
                             },
                             "min_score": {
-                                "type": "number",
-                 
-                                "description": "Minimum possible score for continuous metric"
+                                "oneOf": [
+                                    { "type": "number" },
+                                    { "type": "string", "enum": ["Infinity", "-Infinity"] }
+                                ],
+                                "description": "Minimum possible score for a continuous metric. A number, or the string \"-Infinity\" if unbounded below (float('-inf'); reads back to a float). Absence/null means \"not provided\", NOT unbounded."
                             },
                             "max_score": {
-                                "type": "number",
-                                "description": "Maximum possible score for continuous metric"
+                                "oneOf": [
+                                    { "type": "number" },
+                                    { "type": "string", "enum": ["Infinity", "-Infinity"] }
+                                ],
+                                "description": "Maximum possible score for a continuous metric. A number, or the string \"Infinity\" if unbounded above, e.g. PSNR or perplexity (float('inf'); reads back to a float). Absence/null means \"not provided\", NOT unbounded."
                             },
                             "llm_scoring": {
                                 "type": "object",

--- a/post_codegen.py
+++ b/post_codegen.py
@@ -48,10 +48,10 @@ PATCHES = [
     },
     {
         'file': 'every_eval_ever/eval_types.py',
-        'import_add': 'model_validator',
+        'import_add': ['model_validator', 'field_serializer'],
         'class_name': 'MetricConfig',
         'validator': """
-    # --- validators (added by post_codegen.py) ---
+    # --- validators / serializers (added by post_codegen.py) ---
 
     @model_validator(mode="after")
     def validate_score_type_requirements(self):
@@ -65,7 +65,27 @@ PATCHES = [
                 raise ValueError("score_type 'continuous' requires min_score")
             if self.max_score is None:
                 raise ValueError("score_type 'continuous' requires max_score")
+        # A NaN bound is never meaningful (and NaN != NaN breaks comparisons).
+        # inf/-inf are allowed (unbounded); null is handled above per score_type.
+        for _name in ('min_score', 'max_score'):
+            _v = getattr(self, _name)
+            if _v is not None and _v != _v:
+                raise ValueError(f'{_name} must not be NaN')
         return self
+
+    @field_serializer('min_score', 'max_score', when_used='json')
+    def _serialize_bound(self, value):
+        # An unbounded bound is +/-inf; emit it as the JSON string
+        # "Infinity"/"-Infinity" (valid JSON that reads back to a float) rather
+        # than pydantic's default null or the non-standard bare Infinity token.
+        # when_used='json' covers BOTH model_dump_json() and
+        # model_dump(mode='json'); mode='python' keeps the native float. null
+        # stays null (reserved for "not provided", never unbounded).
+        if value == float('inf'):
+            return 'Infinity'
+        if value == float('-inf'):
+            return '-Infinity'
+        return value
 """,
     },
 ]
@@ -131,7 +151,9 @@ def patch_file(patch: dict) -> None:
         print(f'  {patch["file"]}: already patched, skipping')
         return
 
-    content = add_import(content, patch['import_add'])
+    imports = patch['import_add']
+    for symbol in [imports] if isinstance(imports, str) else imports:
+        content = add_import(content, symbol)
     content = append_to_last_class_field(
         content, patch['class_name'], patch['validator']
     )

--- a/tests/test_cli_inspect_uuid.py
+++ b/tests/test_cli_inspect_uuid.py
@@ -225,3 +225,44 @@ def test_convert_helm_directory_mode_reuses_generated_uuids_for_aggregate_file(
         '5cd3f6ca-2fd0-4f88-8f19-9d53089641df',
         '2e4f2dc0-9882-4a6f-8dd9-fcb3f8b007fb',
     ]
+
+
+def _make_lm_eval_args(log_path: Path, output_dir: Path) -> Namespace:
+    return Namespace(
+        log_path=str(log_path),
+        output_dir=str(output_dir),
+        source_organization_name='TestOrg',
+        evaluator_relationship='third_party',
+        source_organization_url=None,
+        source_organization_logo_url=None,
+        eval_library_name='lm_eval',
+        eval_library_version='unknown',
+        include_samples=False,
+        inference_engine=None,
+        inference_engine_version=None,
+    )
+
+
+def test_convert_lm_eval_reports_skipped_metrics_in_summary(tmp_path, capsys):
+    import json
+
+    # One task with a known metric (acc -> emitted) and an unknown-bounds metric
+    # (mystery_metric -> skipped for lack of KNOWN_METRIC_BOUNDS).
+    raw = {
+        'results': {'t': {'acc,none': 0.5, 'mystery_metric,none': 3.0}},
+        'configs': {'t': {}},
+        'higher_is_better': {'t': {'acc': True, 'mystery_metric': True}},
+        'n-samples': {'t': {}},
+        'config': {'model': 'hf', 'model_args': 'pretrained=org/model'},
+    }
+    log_path = tmp_path / 'results.json'
+    log_path.write_text(json.dumps(raw), encoding='utf-8')
+
+    rc = cli._cmd_convert_lm_eval(_make_lm_eval_args(log_path, tmp_path / 'out'))
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    # Success count stays on stdout; the loss is reported (not silent) on stderr.
+    assert 'Converted 1 evaluation log(s).' in captured.out
+    assert 'Skipped 1 metric result(s)' in captured.err
+    assert 'mystery_metric' in captured.err

--- a/tests/test_inf_serialization.py
+++ b/tests/test_inf_serialization.py
@@ -1,0 +1,138 @@
+"""Unbounded metric bounds: serialized as the JSON string "Infinity", scoped to
+MetricConfig, with null reserved for "not provided" and NaN rejected.
+
+Policy:
+- unbounded bound = float('inf')/-inf, written as the JSON *string* "Infinity"/
+  "-Infinity" (valid RFC-8259 JSON; pydantic reads it back to a float).
+- the field stays typed `float | None`, so "convertible to a number" is enforced
+  by the type itself; the schema pins the string form to exactly those two tokens.
+- null stays INVALID for a continuous metric (missing != unbounded).
+- NaN bounds are rejected.
+- scoped to MetricConfig: score/latency/etc. floats keep default serialization.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+import every_eval_ever.eval_types as ET
+from every_eval_ever.helpers import SCHEMA_VERSION, save_evaluation_log
+from every_eval_ever.validate import validate_file
+
+
+def _mc(min_score, max_score):
+    return ET.MetricConfig(
+        metric_name='PSNR',
+        lower_is_better=False,
+        score_type=ET.ScoreType.continuous,
+        min_score=min_score,
+        max_score=max_score,
+    )
+
+
+def _log(min_score, max_score):
+    return ET.EvaluationLog(
+        schema_version=SCHEMA_VERSION,
+        evaluation_id='src/dev_model/2026',
+        retrieved_timestamp='1700000000.0',
+        source_metadata=ET.SourceMetadata(
+            source_name='x',
+            source_type='documentation',
+            source_organization_name='x',
+            evaluator_relationship='third_party',
+        ),
+        eval_library=ET.EvalLibrary(name='unknown', version='unknown'),
+        model_info=ET.ModelInfo(name='m', id='dev/model'),
+        evaluation_results=[
+            ET.EvaluationResult(
+                evaluation_name='e',
+                source_data=ET.SourceDataUrl(
+                    dataset_name='d', source_type='url', url=['http://x']
+                ),
+                metric_config=_mc(min_score, max_score),
+                score_details=ET.ScoreDetails(score=30.0),
+            )
+        ],
+    )
+
+
+def test_unbounded_serializes_as_infinity_string():
+    dumped = _mc(float('-inf'), float('inf')).model_dump_json()
+    assert '"max_score":"Infinity"' in dumped
+    assert '"min_score":"-Infinity"' in dumped
+    # ...and that output is STRICT-valid JSON (parses in JS/Go/jq/orjson)
+    json.loads(dumped, parse_constant=_reject_constant)
+
+
+def _reject_constant(c):  # would fire only on a bare Infinity/NaN token
+    raise AssertionError(f'non-standard JSON token emitted: {c}')
+
+
+def test_field_stays_float_and_reads_back():
+    # the wire form is a string, but the Python value is a real float
+    mc = _mc(0.0, float('inf'))
+    assert mc.max_score == float('inf')
+    reparsed = ET.MetricConfig.model_validate(
+        json.loads(mc.model_dump_json())
+    )
+    assert reparsed.max_score == float('inf')
+    # convertibility is enforced by the float type: a non-numeric string is rejected
+    with pytest.raises(ValidationError):
+        ET.MetricConfig.model_validate(
+            {'metric_name': 'x', 'lower_is_better': False,
+             'score_type': 'continuous', 'min_score': 0.0, 'max_score': 'banana'}
+        )
+
+
+def test_finite_bounds_stay_numbers():
+    dumped = _mc(0.0, 100.0).model_dump_json()
+    assert '"max_score":100.0' in dumped and 'Infinity' not in dumped
+
+
+def test_null_bound_is_still_invalid_for_continuous():
+    # missing != unbounded: null must stay rejected so it can't masquerade as inf
+    with pytest.raises(ValidationError):
+        _mc(0.0, None)
+
+
+def test_nan_bound_is_rejected():
+    with pytest.raises(ValidationError):
+        _mc(0.0, float('nan'))
+
+
+def test_mode_json_path_also_emits_string():
+    # Regression: cli.py / instance writers serialize via
+    # json.dump(model_dump(mode='json')) -- NOT model_dump_json(). The field
+    # serializer must fire there too, or an inf bound leaks the bare (invalid)
+    # Infinity token. Assert it's the STRING and the result is strict-valid JSON.
+    d = _mc(0.0, float('inf')).model_dump(mode='json')
+    assert d['max_score'] == 'Infinity'
+    dumped = json.dumps(d)
+    json.loads(dumped, parse_constant=_reject_constant)
+
+
+def test_mode_python_keeps_native_float():
+    # Python consumers get a real float, not the wire string.
+    d = _mc(0.0, float('inf')).model_dump(mode='python')
+    assert d['max_score'] == float('inf')
+
+
+def test_no_model_wide_inf_config():
+    # The fix is a field serializer on min/max_score, NOT a model-wide
+    # ser_json_inf_nan -- so other MetricConfig floats / other models aren't
+    # swept up (no inf/NaN-everywhere blast radius).
+    assert ET.MetricConfig.model_config.get('ser_json_inf_nan') is None
+    assert _mc(0.0, 1.0).model_dump(mode='json')['max_score'] == 1.0  # finite stays a number
+
+
+def test_aggregate_round_trip_validates(tmp_path):
+    path = save_evaluation_log(_log(0.0, float('inf')), tmp_path, 'dev', 'model')
+    report = validate_file(path)
+    assert report.valid, report.errors
+    mc = json.loads(path.read_text())['evaluation_results'][0]['metric_config']
+    assert mc['max_score'] == 'Infinity'  # string on the wire
+    # and the whole file is strict-valid JSON
+    json.loads(path.read_text(), parse_constant=_reject_constant)

--- a/tests/test_lm_eval_adapter.py
+++ b/tests/test_lm_eval_adapter.py
@@ -292,3 +292,33 @@ def test_na_stderr_treated_as_absent():
     assert uncertainty is not None
     assert uncertainty.standard_error is None
     assert uncertainty.num_samples == 100
+
+
+# ── Unbounded / unknown metric bounds ──────────────────────────────────
+
+
+def test_ter_is_unbounded_infinity_and_unknown_metric_skipped():
+    import json
+    import warnings
+
+    adapter = LMEvalAdapter()
+    raw = {
+        'results': {
+            't': {'ter,none': 42.0, 'mystery_metric,none': 3.0}
+        },
+        'configs': {'t': {}},
+        'higher_is_better': {'t': {'ter': False, 'mystery_metric': True}},
+        'n-samples': {'t': {}},
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        results = adapter._build_evaluation_results(raw, 't')
+
+    descs = [r.metric_config.evaluation_description for r in results]
+    # 'ter' is unbounded above -> inf, serialized as the "Infinity" string
+    ter = next(r for r in results if r.metric_config.evaluation_description == 'ter')
+    assert ter.metric_config.max_score == float('inf')
+    assert json.loads(ter.metric_config.model_dump_json())['max_score'] == 'Infinity'
+    # a metric with no known bounds is skipped (not emitted with null bounds)
+    assert 'mystery_metric' not in descs
+    assert any('mystery_metric' in str(c.message) for c in caught)

--- a/tests/test_lm_eval_adapter.py
+++ b/tests/test_lm_eval_adapter.py
@@ -322,3 +322,5 @@ def test_ter_is_unbounded_infinity_and_unknown_metric_skipped():
     # a metric with no known bounds is skipped (not emitted with null bounds)
     assert 'mystery_metric' not in descs
     assert any('mystery_metric' in str(c.message) for c in caught)
+    # the skip is recorded so a caller can report the loss (not just warn)
+    assert adapter.get_skipped_metrics() == [('t', 'mystery_metric')]


### PR DESCRIPTION
## Problem
An unbounded continuous bound (PSNR, perplexity, TER, …) is `float('inf')`/`-inf`, but pydantic's default serialization wrote it to JSON `null` — which then failed the existing `continuous requires min/max_score` validator. So `inf` could be **read but not written**: unbounded metrics could only be dropped, faked, or made invalid.

## Fix
**Core** — a field serializer on `MetricConfig.min_score`/`max_score` emits `inf`/`-inf` as the JSON **string** `"Infinity"`/`"-Infinity"`:
- valid RFC-8259 JSON (parses in JS / Go / jq / orjson, not just Python) that pydantic reads back to `float('inf')`;
- chosen over model-level `ser_json_inf_nan` because that only affects `model_dump_json()` — the codebase also writes via `json.dump(model_dump(mode='json'))` (`cli.py`, instance writers), which would emit the bare, **invalid** `Infinity` token. `field_serializer(when_used='json')` covers **both** paths; `mode='python'` keeps the native float;
- the field stays typed `float | None`, so "convertible to a number" is enforced by the type; the schema pins the string form to exactly `{"Infinity","-Infinity"}`.

**Semantics (kept strict on purpose)**
- `null` stays **invalid** for a continuous metric: *missing ≠ unbounded*, so `null` cannot masquerade as `inf`; unbounded uses `inf`, genuinely-missing bounds stay invalid.
- `NaN` bounds are rejected (never meaningful; `NaN != NaN` breaks comparisons).

**Convention applied in-repo** (`converters/lm_eval`) so nothing is left emitting null-for-unbounded: `ter` bound `(0.0, None)` → `(0.0, inf)`, and a metric with no entry in `KNOWN_METRIC_BOUNDS` is now **skipped with a warning** instead of building an invalid null-bounded continuous config. **Supersedes #206.**

**Regen-safe:** `post_codegen.py` re-applies the validator + serializer to `MetricConfig`.

## Tests
`tests/test_inf_serialization.py` (both dump paths incl. the `mode='json'` regression, `mode='python'` float, strict-JSON validity, float typing/round-trip, null-still-invalid, NaN-rejected) + a new `lm_eval` case. Full suite green (207 passed / 20 skipped), ruff clean.

## Portability
`"Infinity"`/`"-Infinity"` is valid JSON everywhere. A statically-typed consumer (Go `float64`) needs a small custom unmarshaller for the `number | "Infinity"` union — the schema `enum` documents exactly what to expect.

## Follow-ups (separate — not required for correctness here)
- **`eval-card-registry` (separate repo):** reclassify the ~9 canonical metrics whose `max_score: null` means *unbounded* (`elo`, `cost-per-task`, `latency-*`, `rank`, …) to `inf`; leave the genuinely-vague ones (`score`, `*.mean` placeholders) `null`.
- **`EEE_datastore`:** re-run / patch affected records in parallel.
