### PR TITLE
Cap nltk<3.10.1 in helm extra (fixes 'flaky' full/loose CI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,16 @@ inspect = ["inspect-ai>=0.3.160,<0.4.0"]
 helm = [
     "crfm-helm>=0.5.14",
     "typer>=0.12,<1.0",
+    # crfm-helm pulls nltk transitively. nltk 3.10.1 added an import guard
+    # (nltk/inisec.py, a CWE-427 mitigation) that blocks nltk-initiated imports
+    # of any module resolving *under the current working directory*. uv places
+    # .venv/ inside the project, so site-packages is under the CWD and the guard
+    # false-positives on nltk's own `regex` dependency -> `import helm` fails at
+    # import time (breaks the HELM converter in CI's `loose` matrix, and for any
+    # default venv layout). Cap below the guarded release until nltk fixes the
+    # false positive (tracking: https://github.com/nltk/nltk/issues/3730); safe
+    # because crfm-helm is frozen.
+    "nltk<3.10.1",
 ]
 all = [
     "every-eval-ever[inspect]",

--- a/uv.lock
+++ b/uv.lock
@@ -865,10 +865,12 @@ dependencies = [
 all = [
     { name = "crfm-helm" },
     { name = "inspect-ai" },
+    { name = "nltk" },
     { name = "typer" },
 ]
 helm = [
     { name = "crfm-helm" },
+    { name = "nltk" },
     { name = "typer" },
 ]
 inspect = [
@@ -893,6 +895,7 @@ requires-dist = [
     { name = "inspect-ai", marker = "extra == 'inspect'", specifier = ">=0.3.160,<0.4.0" },
     { name = "jsonschema", specifier = ">=4.26.0,<5.0.0" },
     { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "nltk", marker = "extra == 'helm'", specifier = "<3.10.1" },
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pydantic", specifier = ">=2.12.5,<3.0.0" },


### PR DESCRIPTION
## What

Cap the `helm` extra's transitive `nltk` at `<3.10.1`, the last release before nltk's new import guard. Two-line change (`pyproject.toml` + regenerated `uv.lock`).

## Why — the "flaky" `full / loose` CI failure is nltk 3.10.1

The `full / loose` matrix leg has been going red/green seemingly at random (e.g. it failed on a recent PR while `full / locked`, `core / locked`, `core / loose` all passed on the same commit). It is **not flaky and not caused by any PR content** — it tracks the state of PyPI at resolve time:

- `locked` legs replay `uv.lock`, which pins **nltk 3.9.2**.
- `loose` legs run `uv sync --upgrade`, which re-resolves to the **newest** nltk.

nltk **3.10.1** ships [`nltk/inisec.py`](https://github.com/nltk/nltk), a CWE-427 mitigation that installs a meta-path finder blocking **nltk-initiated** imports of any module whose file resolves **under the current working directory**. `uv` places `.venv/` *inside* the project, so site-packages sits under the CWD — and the guard false-positives on nltk's own `regex` dependency:

```
ImportError: Blocked import of regex from current working directory for security reasons.
  .venv/.../nltk/inisec.py
```

That aborts the `from helm... import` chain in `every_eval_ever/converters/helm/adapter.py`, whose broad `except Exception` re-raises it as the misleading:

```
ImportError: HELM converter dependencies are missing. Install with: uv sync --extra helm ...
```

So every test that instantiates `HELMAdapter()` fails — but only when the resolver happens to pick nltk ≥ 3.10.1.

## This is a latent breakage, not just a CI badge

Because the trigger is "venv under the CWD" (the default `uv`/`.venv` layout), the same `import helm` failure hits **local development and any downstream user** the moment `uv.lock` is regenerated past nltk 3.10.0 (a routine `uv lock --upgrade`, Dependabot, or any dep nudging nltk up). `locked` is green today only by the accident of an older pin.

## Why this fix

The real bug is upstream: nltk's guard should exempt the running interpreter's own `site-packages` / `sys.prefix` rather than block anything under CWD. Until that lands, the correct repo-side fix is a **dependency constraint, not a security-disable**:

| Option | Fixes loose | Fixes locked/local | Keeps nltk's CWE-427 guard | Notes |
|---|---|---|---|---|
| `PYTHONSAFEPATH=1` / `-P` in CI | ❌ | ❌ | — | Verified: the guard ignores `safe_path`; does **not** help |
| `NLTK_DISABLE_IMPORT_SECURITY=1` in CI | ✅ | ❌ | ❌ disables it | CI-only; turns off a security feature |
| `os.environ.setdefault(...)` in the adapter | ✅ | ✅ | ❌ disables it | Disables the guard for all downstream helm users |
| **Cap `nltk<3.10.1` (this PR)** | ✅ | ✅ | ✅ intact | Deterministic; one-line revert when nltk fixes it |

Since the crfm-helm stack is effectively frozen, pinning its transitive nltk to last-known-good is coherent and harmless. `crfm-helm` requires `nltk!=3.9.0,~=3.7`, so the cap intersects cleanly — the lock stays at 3.9.2 and `loose` may go up to the clean 3.10.0.

## Verification

- Reproduced the guard in an isolated venv: nltk **3.9.4** and **3.10.0** have no `inisec.py`; **3.10.1** does and blocks `regex` when the venv is under CWD. `NLTK_DISABLE_IMPORT_SECURITY=1` clears it; `PYTHONSAFEPATH=1` does not; a venv outside the repo also clears it (and still blocks a real `regex.py` shadow — the guard is doing its job, just over-broadly).
- `uv lock` re-resolves with the cap (187 packages, no conflict); `uv lock --locked` passes.
- CI on this PR is the end-to-end proof — the previously-red `full / loose` leg should now be green.

## Follow-up

The durable fix belongs in nltk (exempt the active interpreter's site-packages). I'm happy to file that issue and link it here; this cap is a clean one-line revert once it ships.

Independent of #208 (skill docs) and #212 (validator) — safe to land on its own.
