### PR TITLE
docs: note nltk import-guard interaction with the helm extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ pip install 'every-eval-ever[helm]'
 pip install 'every-eval-ever[all]'
 ```
 
+> [!NOTE]
+> **`helm` extra + nltk's import guard.** The `helm` extra pulls in `nltk`, and
+> nltk ≥ 3.10.1 ships an import guard (`nltk/inisec.py`, a CWE-427 mitigation)
+> that blocks nltk-initiated imports of any module whose file resolves *under the
+> current working directory*. With the common in-project virtualenv layout
+> (`uv`'s `.venv/`, or any venv inside the repo), site-packages sits under the
+> CWD, so the guard trips on nltk's own dependencies and importing the HELM
+> converter fails. The extra currently caps `nltk<3.10.1`, so this does not bite
+> by default. If you move to a newer nltk, keep the environment **outside** the
+> checkout — the same thing CI does via `UV_PROJECT_ENVIRONMENT` — e.g.
+> `UV_PROJECT_ENVIRONMENT=/tmp/eee-venv uv sync --extra helm`, or create your
+> venv outside the repository. Upstream tracker:
+> [nltk#3730](https://github.com/nltk/nltk/issues/3730).
+
 ### Terminology
 
 | Term | Our Definition | Example |


### PR DESCRIPTION
## What

A short README note under the optional-extras install block documenting the `helm` extra's interaction with nltk's import guard, and how to work around it for local/downstream use.

## Why — the local/downstream side of #212

#212 fixed the CI failure by relocating the venv outside the checkout (`UV_PROJECT_ENVIRONMENT=$RUNNER_TEMP/eee-venv`), which keeps nltk unpinned in CI. #213 additionally capped `nltk<3.10.1` in the `helm` extra, which is what currently protects **local dev and downstream `pip install .[helm]`** on the default in-project venv layout.

The gap this note closes is forward-looking: the cap is meant to be lifted once nltk fixes the guard ([nltk#3730](https://github.com/nltk/nltk/issues/3730)). When that happens, anyone on an in-project `.venv` who moves to nltk ≥ 3.10.1 hits the same `import helm` failure again — because the relocation lives only in CI. Documenting the `UV_PROJECT_ENVIRONMENT` recipe generalizes the CI fix to humans, so the cap can be removed later without silently breaking local/downstream installs.

## Note

No code or dependency change — docs only. This is a suggestion; happy to reword, move it (e.g. nearer the HELM converter section), or drop it if you'd rather keep the README lean. Follow-up to #212 and #213.
