### PR TITLE
Show validator warnings on files that pass

### DIFF
--- a/every_eval_ever/validator/validate.py
+++ b/every_eval_ever/validator/validate.py
@@ -146,7 +146,12 @@ def _truncate(value: object, max_len: int = 80) -> str:
 
 
 def render_report_rich(report: ValidationReport, console: Console) -> None:
-    """Render one validation report as a terminal panel."""
+    """Render one validation report as a terminal panel.
+
+    Warnings are shown whether or not the file passed. A warning on a passing
+    file is exactly what the datastore review bot reports on a submission, so
+    dropping it locally sends contributors into review with surprises.
+    """
     if report.valid:
         label = Text(' PASS ', style='bold white on green')
         kind = (
@@ -154,23 +159,19 @@ def render_report_rich(report: ValidationReport, console: Console) -> None:
             if report.file_type == 'aggregate'
             else f'Instance (InstanceLevelEvaluationLog, {report.line_count} lines)'
         )
-        console.print(
-            Panel(
-                Text.assemble(label, '  ', (kind, 'dim')),
-                title=f'[blue underline]{report.file_path}[/]',
-                title_align='left',
-                border_style='green',
-            )
+        border_style = 'yellow' if report.warnings else 'green'
+    else:
+        label = Text(' FAIL ', style='bold white on red')
+        kind = (
+            'Aggregate (EvaluationLog)'
+            if report.file_type == 'aggregate'
+            else 'Instance (InstanceLevelEvaluationLog)'
         )
-        return
+        border_style = 'red'
 
-    label = Text(' FAIL ', style='bold white on red')
-    kind = (
-        'Aggregate (EvaluationLog)'
-        if report.file_type == 'aggregate'
-        else 'Instance (InstanceLevelEvaluationLog)'
-    )
-    lines = [Text.assemble(label, '  ', (kind, 'dim')), Text('')]
+    lines = [Text.assemble(label, '  ', (kind, 'dim'))]
+    if report.errors or report.warnings:
+        lines.append(Text(''))
     for index, error in enumerate(report.errors, 1):
         lines.append(Text(f'  {index}. {error["loc"]}', style='cyan'))
         lines.append(Text(f'     {error["msg"]}'))
@@ -188,7 +189,7 @@ def render_report_rich(report: ValidationReport, console: Console) -> None:
             Text('\n').join(lines),
             title=f'[blue underline]{report.file_path}[/]',
             title_align='left',
-            border_style='red',
+            border_style=border_style,
         )
     )
 
@@ -200,6 +201,7 @@ def render_summary_rich(
     passed = sum(1 for report in reports if report.valid)
     failed = len(reports) - passed
     total_errors = sum(len(report.errors) for report in reports)
+    total_warnings = sum(len(report.warnings) for report in reports)
     if failed:
         style = 'bold red'
         message = (
@@ -209,6 +211,16 @@ def render_summary_rich(
     else:
         style = 'bold green'
         message = f'All {passed} file(s) passed validation'
+    if total_warnings:
+        # Warnings never change the exit code; say so, so a green run that the
+        # review bot will comment on does not read as "nothing to do". A failed
+        # run stays red — the warnings are the smaller problem there.
+        if not failed:
+            style = 'bold yellow'
+        message += (
+            f'\n{total_warnings} warning(s) — not fatal, but the datastore '
+            'review bot reports them'
+        )
     console.print()
     console.print(
         Panel(Text(message, style=style), title='Summary', border_style='dim')

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
+import io
 import json
 from pathlib import Path
 
 import pytest
+from rich.console import Console
 
 from every_eval_ever.schema import get_schema_version
 from every_eval_ever.validate import (
+    ValidationReport,
     expand_paths,
     main,
     render_report_github,
     render_report_json,
+    render_report_rich,
+    render_summary_rich,
 )
 from every_eval_ever.validate import (
     validate_aggregate as _validate_aggregate,
@@ -439,6 +444,93 @@ class TestOutputFormats:
         report = validate_file(fp)
         output = render_report_github([report])
         assert output == ''
+
+
+class TestWarningVisibility:
+    """A warning on a passing file must reach the terminal.
+
+    The JSON and GitHub renderers already emit warnings regardless of validity,
+    so only the default `rich` output could hide one — which is the output a
+    contributor actually looks at before submitting.
+    """
+
+    @staticmethod
+    def _render(report: ValidationReport) -> str:
+        stream = io.StringIO()
+        console = Console(
+            file=stream, width=100, no_color=True, legacy_windows=False
+        )
+        render_report_rich(report, console)
+        render_summary_rich([report], console)
+        return stream.getvalue()
+
+    @staticmethod
+    def _passing_report(warnings: list[dict[str, str]]) -> ValidationReport:
+        return ValidationReport(
+            file_path=Path('data/bench/dev/model/x.json'),
+            valid=True,
+            file_type='aggregate',
+            warnings=warnings,
+        )
+
+    def test_passing_file_still_shows_its_warnings(self):
+        output = self._render(
+            self._passing_report(
+                [
+                    {
+                        'loc': 'evaluation_results[0].metric_config',
+                        'msg': 'something worth a second look',
+                        'type': 'semantic_warning',
+                    }
+                ]
+            )
+        )
+        assert 'PASS' in output
+        assert 'something worth a second look' in output
+        assert 'evaluation_results[0].metric_config' in output
+
+    def test_summary_counts_warnings_and_says_they_are_not_fatal(self):
+        output = self._render(
+            self._passing_report(
+                [{'loc': '', 'msg': 'first', 'type': 'semantic_warning'}]
+            )
+        )
+        assert '1 warning(s)' in output
+        assert 'not fatal' in output
+
+    def test_clean_pass_stays_quiet(self):
+        output = self._render(self._passing_report([]))
+        assert 'PASS' in output
+        # Either capitalization would be a leaked warning line.
+        assert 'arning' not in output
+
+    def test_a_failing_file_still_reads_as_a_failure(self):
+        """Warnings must not soften the summary of a run that failed.
+
+        Colour is the only signal the summary panel carries, so a failed run
+        recolored to warning-yellow would announce the smaller problem.
+        """
+        report = ValidationReport(
+            file_path=Path('data/bench/dev/model/x.json'),
+            valid=False,
+            file_type='aggregate',
+            errors=[
+                {'loc': 'model_info', 'msg': 'boom', 'type': 'value_error'}
+            ],
+            warnings=[{'loc': '', 'msg': 'first', 'type': 'semantic_warning'}],
+        )
+        stream = io.StringIO()
+        console = Console(
+            file=stream, width=100, force_terminal=True, legacy_windows=False
+        )
+        render_summary_rich([report], console)
+        output = stream.getvalue()
+
+        assert '1 file(s) failed' in output
+        assert '1 warning(s)' in output
+        # rich renders 'bold red' as 1;31 and 'bold yellow' as 1;33.
+        assert '\x1b[1;31m' in output
+        assert '\x1b[1;33m' not in output
 
 
 class TestExitCode:


### PR DESCRIPTION
## Problem

`report.warnings` is invisible in the CLI's default output whenever the file
passes. `render_report_rich` returns early on a valid report, and
`render_summary_rich` counts only errors, so a file with warnings prints a
plain green `PASS` and the run ends with `All N file(s) passed validation`.

The datastore review bot does not work that way. It consumes
`--format github`, which emits `::warning` annotations regardless of
validity, and `--format json` carries `warnings` too. So the contributor
path is: validate locally, see all green, submit, and get a review comment
about something their own tooling already knew.

## Change

- `render_report_rich` renders warnings on passing files as well as failing
  ones, with a yellow border to distinguish "passed, with notes" from a
  clean pass.
- `render_summary_rich` reports the warning total and says explicitly that
  warnings are not fatal but the review bot reports them — so a green run
  that will still draw a comment does not read as "nothing to do".

Exit code semantics are untouched: `main` still returns 1 only when a
report is invalid.

## Why now

Every entry in `REGISTERED_CHECKS` on `main` has severity `error`, so
`report.warnings` is always empty today and this PR changes nothing
observable on its own. That is also the reason it is worth landing first:
until warnings are visible locally, adding a `warning`-severity check gives
contributors a review comment with no local way to reproduce it. Two such
checks follow in #222 and #223; each stands alone, and neither depends on
this one for the bot's output.

## Tests

`TestWarningVisibility` in `tests/test_validate.py` renders a report through
a `Console` writing to a `StringIO` and asserts the warning text and its
location appear on a `PASS`, that the summary says `1 warning(s)` and `not
fatal`, and that a clean pass mentions no warnings at all.
