### PR TITLE
[Docs] Fix README instance example to conform to the instance schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,13 @@ Example `single_turn` instance:
   "evaluation_id": "math_eval/meta-llama/Llama-2-7b-chat/1706000000",
   "model_id": "meta-llama/Llama-2-7b-chat",
   "evaluation_name": "math_eval",
-  "sample_id": 4,
+  "sample_id": "4",
   "interaction_type": "single_turn",
-  "input": { "raw": "If 2^10 = 4^x, what is the value of x?", "reference": "5" },
-  "output": { "raw": "Rewrite 4 as 2^2, so 4^x = 2^(2x). Since 2^10 = 2^(2x), x = 5." },
-  "answer_attribution": [{ "source": "output.raw", "extracted_value": "5" }],
+  "input": { "raw": "If 2^10 = 4^x, what is the value of x?", "reference": ["5"] },
+  "output": { "raw": ["Rewrite 4 as 2^2, so 4^x = 2^(2x). Since 2^10 = 2^(2x), x = 5."] },
+  "answer_attribution": [
+    { "turn_idx": 0, "source": "output.raw", "extracted_value": "5", "extraction_method": "match", "is_terminal": true }
+  ],
   "evaluation": { "score": 1.0, "is_correct": true }
 }
 ```


### PR DESCRIPTION
## Problem

The `single_turn` example in the README does not validate against
`InstanceLevelEvaluationLog`. Six errors:

```
sample_id: Input should be a valid string
input.reference: Input should be a valid list
output.raw: Input should be a valid list
answer_attribution.0.turn_idx: Field required
answer_attribution.0.extraction_method: Field required
answer_attribution.0.is_terminal: Field required
```

It is the first complete instance-level record a contributor sees, so the
shapes it gets wrong — scalar instead of array for `reference` and
`output.raw`, an int `sample_id`, an `answer_attribution` entry missing its
three required fields — are the shapes they then reproduce and get corrected
on in review.

## Change

The example now validates: `"4"`, `["5"]`, `["Rewrite 4 as 2^2, …"]`, and an
`answer_attribution` entry carrying `turn_idx`, `extraction_method`, and
`is_terminal`. Verified by loading the block out of `README.md` and running
it through `InstanceLevelEvaluationLog.model_validate` — clean after, the six
errors above before.

## Why there is no test guarding this

A test that validates every ` ```json ` block would need a marker
convention: of the five blocks in `README.md`, one is a complete record, one
is a `generation_args` fragment, and three are JSONL snippets that are not
single JSON documents. Adding that convention is a larger change than this
fix and is worth doing separately if README examples drift again.
