### PR TITLE
Ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,12 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
+# Claude Code
+#  `.claude/skills/` is shared and tracked. `settings.local.json` is per-machine
+#  tool-permission state that Claude Code writes as you approve things, so it
+#  differs for every contributor and must never be committed.
+.claude/settings.local.json
+
 # Marimo
 marimo/_static/
 marimo/_lsp/


### PR DESCRIPTION
#208 added `.claude/skills/eee-dataset-conversion/` — shared content that
belongs in the repository. Claude Code also writes
`.claude/settings.local.json` next to it: per-machine tool-permission state
that accumulates as a contributor approves individual commands.

It differs for every contributor, means nothing to anyone else, and is now the
file most likely to be committed by accident, because a tracked `.claude/`
directory exists and `git add .claude` looks reasonable.

One line plus a comment saying which part of `.claude/` is shared and which is
not, so the next person does not have to guess.

Verified: `main` tracks exactly the 11 skill files under `.claude/` and nothing
else, so this un-tracks nothing and changes no existing file's status — it only
keeps the per-machine file out. `git check-ignore -v` confirms the rule matches
once the file exists.
