### PR TITLE
AGENTS.md: tie-breaker principles, and keep change-rationale out of docstrings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ convert external eval sources into it.
 - **Tests/lint**: add an offline, fixture-based `tests/test_<name>_adapter.py`, guard
   optional deps so the `core` CI matrix skips cleanly, and keep `ruff check` green —
   see the skill's `reference/verification.md` and `reference/gotchas.md` for the exact mechanics.
+- **Docstrings say what, not why-I-changed-it.** A docstring documents what the function
+  does and what a caller must know. Rationale for a change, what it replaced, and notes
+  aimed at a reviewer belong in the **PR description** — a maintainer reads that once,
+  instead of reading it every time they open the file. Where a future editor really would
+  break something, leave a one-line `#` comment at that line, not a paragraph in the
+  docstring. If it needs a paragraph, it needs the PR.
 - **Publish through the repo, not by hand**: `converters.common.publication.publish_evaluation_logs`
   writes records atomically; `SourceConversionResult` + `save_failure_report` + a non-zero
   exit account for every source row you could not convert.

--- a/tests/test_skill_conversion.py
+++ b/tests/test_skill_conversion.py
@@ -1,21 +1,16 @@
-"""Keep the eee-dataset-conversion skill honest against the live validator.
+"""Validate the eee-dataset-conversion skill's own output against the live validator.
 
-No agent runs here. The skill's *prescribed output* is frozen twice over:
+Two frozen artifacts, both re-checked through the CLI (semantic checks only run at a
+canonical ``data/<collection>/<developer>/<model>/`` path):
 
 * ``.claude/skills/eee-dataset-conversion/templates/`` — the code the skill tells a
-  contributor (or an agent) to copy. The tests below execute it.
+  contributor to copy. The tests below execute it.
 * ``tests/data/skill_reference_conversion/`` — one committed conversion produced by
-  those templates: the artifact a contributor following the skill would submit.
+  those templates.
 
-Both are re-checked by the real CLI validator, with the semantic checks that only run
-at a canonical ``data/<collection>/<developer>/<model>/`` path. Change the schema, the
-validator, or the publisher and this file goes red, naming the skill as the thing to
-fix — instead of the change surfacing in a contributor's first PR.
-
-What this does NOT catch: a *new* rule that the reference conversion happens to satisfy
-already. Then CI stays green while `reference/datastore-gate.md` quietly goes incomplete.
-So when you add a check to the validator, re-derive that file from `REGISTERED_CHECKS`
-rather than trusting a green run here.
+Scope: this catches drift in what the templates emit. A new validator rule that the
+reference conversion already satisfies leaves it green, so re-derive
+``reference/datastore-gate.md`` from ``REGISTERED_CHECKS`` when adding a check.
 
 Regenerate the frozen conversion after a deliberate change:
 
@@ -73,11 +68,9 @@ def _remedy(what_broke: str, *, where: str, regenerate: bool = True) -> str:
 
 
 def _load_template(name: str) -> types.ModuleType:
-    """Import a skill template by path (they live outside the package tree).
+    """Import a skill template by path, substituting a real slug for its placeholder.
 
-    The templates ship `<src>` placeholders on purpose — the datastore path helpers
-    reject them, so a half-filled-in copy fails loudly. Substituting a real slug is
-    the first edit a contributor makes, so the test makes it too.
+    The datastore path helpers reject `<src>`, so the substitution is required to run.
     """
     path = TEMPLATE_DIR / name
     if not path.is_file():
@@ -142,15 +135,10 @@ def _sample_item() -> types.SimpleNamespace:
 
 
 def _assert_gate_clean(paths: list[Path], capsys) -> None:
-    """Run the real validator CLI over `paths`; require errors AND warnings empty.
-
-    Warnings are asserted deliberately: these files are the exemplar contributors copy,
-    so a warning here is inherited by everyone who follows the skill. If a new warning
-    class turns this red, fix the skill and regenerate the frozen records rather than
-    dropping the assertion. Nothing here blocks a merge, so your change can land first.
-    """
+    """Run the real validator CLI over `paths`; require errors AND warnings empty."""
     exit_code = validate_main([str(path) for path in paths] + ['--format', 'json'])
     reports = json.loads(capsys.readouterr().out)
+    # Warnings count as failures here: fix the skill, don't drop the assertion.
     complaints = [
         {'file': report['file'], 'errors': report['errors'], 'warnings': report['warnings']}
         for report in reports
@@ -286,11 +274,7 @@ def test_frozen_reference_conversion_still_passes_the_gate(capsys):
 
 
 def test_frozen_reference_conversion_matches_the_templates(tmp_path):
-    """The frozen conversion must still be what the templates produce today.
-
-    Without this, editing a template and forgetting to regenerate would leave a stale
-    fixture that keeps passing — and the two frozen artifacts would drift apart.
-    """
+    """The frozen conversion must still be byte-identical to the templates' output."""
     if not _frozen_record_files():
         pytest.skip(f'no frozen reference conversion under {FROZEN_DIR}')
     regenerate_frozen_reference(tmp_path / 'regenerated')


### PR DESCRIPTION
## What

Two additions to `AGENTS.md`, both about what agents should carry in mind when editing.

### 1. Three tie-breaker principles

For the cases the existing conventions don't decide. Each names a losing side, so each is arguable in review:

- **Report, don't interpret** — the class of defect no validator can catch: one published number attributed to four configs, a metric described as the full benchmark when a subset was run, `pass@k` recorded for upstream's `pass^k`, a field filled in to look complete. A principle is the right instrument here precisely because no enumeration of rules covers it.
- **Prefer a check to an instruction** — and delete the prose the check replaces, so this section shrinks over time.
- **Don't spend a contributor's attention on what a machine can verify.**

Deliberately left out: "write clean, maintainable code" and its relatives. Every agent already believes it is doing that, so the line changes no decision — and vague value words get cited as justification for whatever the agent wanted to do anyway. The falsifiable versions are already in the conventions section ("the test is the enforcement; prose that duplicates it is what went stale last time").

### 2. Docstrings say what, not why-I-changed-it

Maintainer feedback on a validator PR:

> can you add to your AGENTS.md or Claude.md etc., not to add these comments to the docstring? It adds clutter in the code and should be in the PR comments on github (like it's a self note/explanation and not something needed in the docstring)

This adds that as a convention in `AGENTS.md`, and applies it to the one file in the repo that had the same pattern — `tests/test_skill_conversion.py`, which landed in #208 shortly before the feedback arrived.

```
- Docstrings say what, not why-I-changed-it. A docstring documents what the function
  does and what a caller must know. Rationale for a change, what it replaced, and notes
  aimed at a reviewer belong in the PR description — a maintainer reads that once,
  instead of reading it every time they open the file. Where a future editor really would
  break something, leave a one-line `#` comment at that line, not a paragraph in the
  docstring. If it needs a paragraph, it needs the PR.
```

## What was trimmed

Three docstrings in `tests/test_skill_conversion.py`, −29/+19 lines:

- `_assert_gate_clean` — a four-line justification for asserting on warnings as well as errors.
- `test_frozen_reference_conversion_matches_the_templates` — a "without this test, X would happen" note.
- `_load_template` — editorial about why the placeholder substitution mirrors a contributor's first edit.

The one thing that genuinely needed to stay in the code is the warnings rule, since a future editor would otherwise relax the assertion. It survives as a single line at the assertion:

```python
# Warnings count as failures here: fix the skill, don't drop the assertion.
```

The reasoning behind it now lives in [#208's description](https://github.com/evaleval/every_eval_ever/pull/208): those files are the exemplar the skill tells contributors to copy, so a warning there is inherited by everyone who follows the guidance. Real submissions keep the usual latitude to ship with an explained warning.

The module docstring is kept — it states what the file is, what the two frozen artifacts are, the scope limitation, and the regeneration command, rather than why it was written. Happy to trim further if you read that line differently.

## Notes

- Verified against current `main`: 311 passed / 20 skipped, `ruff check` clean.
- The same pattern exists in the in-flight validator branches (`render_report_rich`'s docstring in the warnings-visible work, among others); it's queued for whoever lands those rather than changed here.
