### PR TITLE
AGENTS.md: three tie-breaker principles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,15 @@ convert external eval sources into it.
 - Validate: `python -m every_eval_ever validate <files-or-glob>` (`.json`→aggregate,
   `.jsonl`→instance; directories are rejected).
 
+## Principles (tie-breakers, for when the conventions below don't decide)
+- **Report, don't interpret.** The job is the most correct data in a unified form. Record
+  what the source states; never infer or tidy a value to make a record look complete. An
+  unknown is data; a guess is corruption. If the source is ambiguous, ask in the PR.
+- **Prefer a check to an instruction.** If a test or a CI job can enforce a rule, add that
+  instead of writing the rule down — and delete the prose it replaces.
+- **Don't spend a contributor's attention on what a machine can verify.** No checklist
+  item for something CI could check.
+
 ## Conventions (non-negotiable)
 - **The schemas are the source of truth.** When a doc and a schema disagree, the schema wins.
 - **Validating ≠ correct.** Everything must pass `validate`, but spot-check *content*


### PR DESCRIPTION
## What

Three tie-breaker principles at the top of `AGENTS.md`, for the cases the conventions below it don't decide. 9 lines, one file.

```
## Principles (tie-breakers, for when the conventions below don't decide)
- Report, don't interpret. The job is the most correct data in a unified form. Record
  what the source states; never infer or tidy a value to make a record look complete. An
  unknown is data; a guess is corruption. If the source is ambiguous, ask in the PR.
- Prefer a check to an instruction. If a test or a CI job can enforce a rule, add that
  instead of writing the rule down — and delete the prose it replaces.
- Don't spend a contributor's attention on what a machine can verify. No checklist
  item for something CI could check.
```

## Why these three, and not a longer list

Each names a losing side, so each is arguable in review rather than decorative.

**Report, don't interpret** covers the one class of defect no validator can catch, and every instance below is real, from this repo's own review history: a published leaderboard number attributed to four configs it didn't cover; a metric described as the full 214-task benchmark when 33 tasks were run; `pass@k` recorded for what upstream computes as `pass^k`; a field filled in so a record looks complete. Rules can't enumerate that class — which is exactly when a principle is the right instrument.

**Prefer a check to an instruction** is self-applying: it says this section should shrink as rules become tests. `tests/test_skill_conversion.py` is the worked example, and the next candidate is a ruff job (currently configured in `pyproject.toml` but run by no workflow, so lint is enforced only by reviewers noticing).

**Don't spend a contributor's attention on what a machine can verify** has a standing precedent: #225 proposed a PR-template checklist and was closed for exactly this reason — checkboxes GitHub never checks, for things CI already runs or should.

Deliberately left out: "write clean, maintainable code" and its relatives. Every agent already believes it is doing that, so the line changes no decision — and vague value words get cited as justification for whatever the agent wanted to do anyway. The falsifiable version is already in the conventions section: "the test is the enforcement; prose that duplicates it is what went stale last time."

## Notes

- Verified against current `main`: 311 passed / 20 skipped.
- This missed #232's merge window by minutes; it's the same commit, rebuilt on current `main`.
