### PR TITLE
Split contributor docs into CONTRIBUTING.md, and write down the review policy

### DIFF
--- a/.claude/skills/eee-dataset-conversion/SKILL.md
+++ b/.claude/skills/eee-dataset-conversion/SKILL.md
@@ -87,8 +87,12 @@ dataset, a harness dump) and you must emit EEE records. Two artifacts:
 7. **Ask, then log your decisions.** Two channels, don't confuse them:
    - **Ask the operator (live)** when a choice *sets policy*: creating a new
      canonical id · dropping a non-trivial share of the data · an ambiguous metric
-     choice · bounding an unbounded metric · re-hosting large data. Don't decide
-     these silently — the person running you is there to answer.
+     choice · bounding an unbounded metric · re-hosting large data · **the source
+     won't fit without a structural change** (a schema field, an edit to a base
+     adapter or a shared converter, relaxing a validator rule). Don't decide these
+     silently — the person running you is there to answer. The structural one is not
+     yours to fold into this PR: its design gets agreed before a PR exists, and
+     carrying it here would hold the adapter behind that discussion.
    - **Log (in the PR)** every *non-obvious* choice — not just where it was hard. A
      confident wrong choice produces no "friction," so log decisions, not pain.
    Finish with a ready-to-merge PR carrying the decision log below. General gaps

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!-- Thanks for contributing! Delete sections that don't apply. -->
+
+## What / source
+<!-- What does this change do? For an adapter: what source does it convert, and to what grain? -->
+
+## Checklist
+- [ ] `python -m every_eval_ever validate <files>` is clean — **no warnings either** —
+      run at the final `data/<collection>/<dev>/<model>/` path, where the semantic
+      checks run
+- [ ] every unconvertible source row is in `adapter_reports/`, and the command exits
+      non-zero (not a silent skip)
+- [ ] offline unit test added + full `pytest tests` green
+- [ ] `ruff check` clean
+- [ ] model/benchmark ids resolve in the registry (or an alias PR is prepared)
+- [ ] content spot-checked (no answer leak, not double-counted, stable `evaluation_id`)
+
+## Decisions & coverage
+<!-- Skip this section if this isn't a data/conversion or skill change.
+     Otherwise: this PR should be ready to merge, and this section makes the non-obvious
+     calls visible so a maintainer can comment and the skill/schema can improve. Log every
+     non-obvious CHOICE (not just where it was hard — a confident wrong choice has no
+     "friction"). "None" is a valid answer. Mark anything that would recur on other
+     datasets as General, so it can become a follow-up rather than being re-solved by
+     the next contributor. -->
+
+- Decision / where: 
+  Chose / instead of: 
+  Confidence (high/med/low): 
+  General? (yes/no): 
+
+**Coverage:** N source rows → N records, M dropped (reason) — <!-- no silent caps -->
+
+**Operator asked about policy calls?** <!-- new canonical id / big data drop /
+ambiguous or unbounded metric / re-hosting large data — which, and what was decided -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,15 @@
 ## What / source
 <!-- What does this change do? For an adapter: what source does it convert, and to what grain? -->
 
+## Review lane
+<!-- See CONTRIBUTING.md § "How your PR gets reviewed". Pick one; a maintainer may disagree. -->
+- [ ] **Fast** — no conflicts, scoped (tests / one adapter / one file), verified by me, under ~1000 hand-written lines
+- [ ] **Needs a human** — design change, cross-package, large, refactor, material change in outcome, or large agent-authored change
+
+<!-- If this is a large or structural change: link the issue or discussion where the design was
+     agreed. Structural PRs opened without prior agreement will sit — we can't review them cold. -->
+Design agreed in:
+
 ## Checklist
 - [ ] `python -m every_eval_ever validate <files>` is clean — **no warnings either** —
       run at the final `data/<collection>/<dev>/<model>/` path, where the semantic
@@ -32,4 +41,3 @@
 
 **Operator asked about policy calls?** <!-- new canonical id / big data drop /
 ambiguous or unbounded metric / re-hosting large data — which, and what was decided -->
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,6 @@ convert external eval sources into it.
   exit account for every source row you could not convert.
 - A dataset contribution is usually three PRs (adapter here · ids in `eval-card-registry`
   · data in `EEE_datastore`) — cross-link them. See the skill's "three PRs" section.
-
 ## Changing the schema, the validator, or the publisher
 These change what a *contribution* must look like, so the contributor-facing guidance is
 part of the change — not a follow-up.
@@ -62,5 +61,6 @@ part of the change — not a follow-up.
   duplicates it is what went stale last time.
 
 ## Human docs
-`README.md` and `every_eval_ever/adapters/README.md` are for people. Keep agent
+`README.md` (understand & use), `CONTRIBUTING.md` (author & submit) and
+`every_eval_ever/adapters/README.md` (adapter authors) are for people. Keep agent
 instructions here and in `.claude/skills/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,13 @@ convert external eval sources into it.
   exit account for every source row you could not convert.
 - A dataset contribution is usually three PRs (adapter here · ids in `eval-card-registry`
   · data in `EEE_datastore`) — cross-link them. See the skill's "three PRs" section.
+- **Get agreement before building something structural.** A scoped change — one adapter,
+  one file, tests — can go straight to a PR. A design change, a cross-package change, a
+  large refactor, or anything that changes what existing data comes out as needs its
+  approach agreed *first*, in an issue or with a maintainer — opening the PR is not how you
+  start that conversation, and a structural PR that arrives cold will sit.
+  Full policy: `CONTRIBUTING.md` § "How your PR gets reviewed".
+
 ## Changing the schema, the validator, or the publisher
 These change what a *contribution* must look like, so the contributor-facing guidance is
 part of the change — not a follow-up.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,144 @@
+# Contributing to Every Eval Ever
+
+Thanks for contributing! This repo defines the **Every Eval Ever (EEE)** schema and hosts the tooling around it — validation, converters, and adapters. The evaluation data itself lives in the [Hugging Face datastore](https://huggingface.co/datasets/evaleval/EEE_datastore), split into files by individual model and stored using [`eval.schema.json`](every_eval_ever/schemas/eval.schema.json) under `data/{benchmark_name}/{developer_name}/{model_name}/`.
+
+For what the schema *is* and how to read a record, start with the [README](README.md) — [The Schema in Practice](README.md#-the-schema-in-practice), [Instance-Level Data](README.md#-instance-level-data), and [`eval.schema.json`](every_eval_ever/schemas/eval.schema.json) itself. This guide covers authoring and submitting: how to submit data, and what to do when you change the schema or the tooling.
+
+> **Using an AI coding agent?** This repo ships an `eee-dataset-conversion` skill ([`.claude/skills/eee-dataset-conversion/`](.claude/skills/eee-dataset-conversion/), indexed from [AGENTS.md](AGENTS.md)) that walks an agent through a conversion — schema field traps, aggregate + instance records, verification, and a decision log to paste into the PR. The rules below apply to agent-authored PRs too, and the agent is expected to follow them.
+
+## 📥 Submitting evaluation data
+
+New data is contributed to the [Hugging Face datastore](https://huggingface.co/datasets/evaleval/EEE_datastore).
+
+### TL;DR
+
+1. Data must conform to [`eval.schema.json`](every_eval_ever/schemas/eval.schema.json) (current version: `0.3.0`, exported as `every_eval_ever.helpers.SCHEMA_VERSION` — read it from there rather than hardcoding).
+2. The validation pipeline verifies data submitted in a pull request automatically, and can also be triggered manually by commenting ```/eee validate changed``` on the HF PR. Run [validation](README.md#-data-validation) locally first.
+3. An EvalEval member will review and merge your submission.
+
+### PR naming convention
+
+Use these prefixes in your pull request titles:
+
+- `[Submission]` — New evaluation data
+- `[Issue #N]` — Fix for a specific GitHub issue
+- `[Feature]` — New functionality not tied to an issue
+- `[Docs]` — Documentation changes
+- `[ACL Shared Task]` — Shared task submissions (priority review)
+
+### UUID naming convention
+
+Each JSON file is named with a **UUID (Universally Unique Identifier)** in the format `{uuid}.json`. The UUID is generated (using standard UUID v4) when creating a new evaluation result file. This ensures that:
+
+- **Multiple evaluations** of the same model can exist without conflicts (each gets a unique UUID)
+- **Different timestamps** are stored as separate files with different UUIDs (not as separate folders)
+- A model may have multiple result files, with each file representing different iterations or runs of the leaderboard/evaluation
+- UUIDs can be generated using Python's `uuid.uuid4()` function.
+
+**Example**: The model `openai/gpt-4o-2024-11-20` might have multiple files like:
+
+- `e70acf51-30ef-4c20-b7cc-51704d114d70.json` (evaluation run #1)
+- `a1b2c3d4-5678-90ab-cdef-1234567890ab.json` (evaluation run #2)
+
+Note: each file can contain multiple individual results related to one model. See [examples in the datastore](https://huggingface.co/datasets/evaleval/EEE_datastore/tree/main/data).
+
+### How to add a new eval
+
+1. Add a new folder under [`data/`](https://huggingface.co/datasets/evaleval/EEE_datastore/tree/main/data) on the Hugging Face datastore with a codename for your eval.
+2. For each model, use the Hugging Face (`developer_name/model_name`) naming convention to create a 2-tier folder structure.
+3. Add a JSON file with results for each model and name it `{uuid}.json`.
+4. [Optional] Add scripts used to generate the data under [`every_eval_ever/adapters/`](every_eval_ever/adapters/) in this repository (see e.g. [`every_eval_ever/adapters/global_mmlu_lite/adapter.py`](every_eval_ever/adapters/global_mmlu_lite/adapter.py)).
+5. [Submit] Two ways to submit your evaluation data:
+   - **Option A: Drag & drop via Hugging Face** — Go to [evaleval/EEE_datastore](https://huggingface.co/datasets/evaleval/EEE_datastore) → click "Files and versions" → "Contribute" → "Upload files" → drag and drop your data → select "Open as a pull request to the main branch". See [step-by-step screenshots](https://docs.google.com/document/d/1dxTQF8ncGCzaAOIj0RX7E9Hg4THmUBzezDOYUp_XdCY/edit?usp=sharing).
+   - **Option B: Upload via `huggingface_hub`** — Useful for larger submissions or many files.
+
+     ```python
+     from huggingface_hub import HfApi
+
+     api = HfApi()
+
+     pr_url = api.upload_folder(
+         folder_path="data/my-eval",
+         path_in_repo="data/my-eval",
+         repo_id="evaleval/EEE_datastore",
+         repo_type="dataset",
+         commit_message="[Submission] Add my eval",
+         commit_description="Adds evaluation data for my eval.",
+         create_pr=True,  # opens a PR instead of committing directly
+     )
+
+     print(pr_url)
+     ```
+
+     To add more files to the same PR, use the PR ref returned by Hugging Face (for example, `refs/pr/XX`):
+
+     ```python
+     from huggingface_hub import HfApi
+
+     api = HfApi()
+
+     api.upload_file(
+         path_or_fileobj="data/my-eval/developer/model/uuid_samples.jsonl",
+         path_in_repo="data/my-eval/developer/model/uuid_samples.jsonl",
+         repo_id="evaleval/EEE_datastore",
+         repo_type="dataset",
+         revision="refs/pr/XX",  # upload to an existing PR
+         commit_message="[Submission] Add instance-level samples",
+     )
+     ```
+
+Before opening the PR, validate locally — see [Data Validation](README.md#-data-validation).
+
+## 🧾 Filling in the schema
+
+Conventions for authoring records. For what each field *means*, see [The Schema in Practice](README.md#-the-schema-in-practice) and [`eval.schema.json`](every_eval_ever/schemas/eval.schema.json); the schema is always the source of truth.
+
+1. **`model_info`**: Use Hugging Face formatting (`developer_name/model_name`). If a model does not come from Hugging Face, use the exact API reference. Check [examples in data/livecodebenchpro](https://huggingface.co/datasets/evaleval/EEE_datastore/tree/main/data/livecodebenchpro). Notably, some do have a **date included in the model name**, but others **do not**. For example:
+
+- OpenAI: `gpt-4o-2024-11-20`, `gpt-5-2025-08-07`, `o3-2025-04-16`
+- Anthropic: `claude-3-7-sonnet-20250219`, `claude-3-sonnet-20240229`
+- Google: `gemini-2.5-pro`, `gemini-2.5-flash`
+- xAI (Grok): `grok-2-2024-08-13`, `grok-3-2025-01-15`
+
+2. **`evaluation_id`**: Use `{benchmark_name/model_id/retrieved_timestamp}` format (e.g. `livecodebenchpro/qwen3-235b-a22b-thinking-2507/1760492095.8105888`).
+
+3. **`inference_platform`** vs **`inference_engine`**: Where possible specify where the evaluation was run using one of these two fields.
+
+- `inference_platform`: Use this field when the evaluation was run through a remote API (e.g. `openai`, `huggingface`, `openrouter`, `anthropic`, `xai`).
+- `inference_engine`: Use this field when the evaluation was run locally. This is an object with `name` and `version` (e.g. `{"name": "vllm", "version": "0.6.0"}`).
+
+4. The `source_type` on `source_metadata` has two options: `documentation` and `evaluation_run`. Use `documentation` when results are scraped from a leaderboard or paper. Use `evaluation_run` when the evaluation was run locally (e.g. via an eval converter).
+
+5. **`source_data`** is specified per evaluation result (inside `evaluation_results`), with three variants:
+
+- `source_type: "url"` — link to a web source (e.g. leaderboard API)
+- `source_type: "hf_dataset"` — reference to a Hugging Face dataset (e.g. `{"hf_repo": "google/IFEval"}`)
+- `source_type: "other"` — for private or proprietary datasets
+
+6. The schema accommodates both numeric and level-based (e.g. Low, Medium, High) metrics. For level-based metrics, the actual `value` should be converted to an integer (e.g. Low = 1, Medium = 2, High = 3), and the `level_names` property should be used to specify the mapping of levels to integers.
+
+7. **Timestamps**: The schema has three timestamp fields — use them as follows:
+
+- `retrieved_timestamp` (required) — when this record was created, in Unix epoch format (e.g. `1760492095.8105888`)
+- `evaluation_timestamp` (top-level, optional) — when the evaluation was run
+- `evaluation_results[].evaluation_timestamp` (per-result, optional) — when a specific evaluation result was produced, if different results were run at different times
+
+8. Additional details can be provided in several places in the schema. They are not required, but can be useful for detailed analysis.
+
+- `model_info.additional_details`: any additional information about the model itself (e.g. number of parameters)
+- `evaluation_results.generation_config.generation_args`: additional arguments used to generate outputs from the model
+- `evaluation_results.generation_config.additional_details`: any additional information about the evaluation process that is not captured elsewhere
+
+## 🔧 Changing the schema, the validator, or the publisher
+
+These change what a *contribution* has to look like, so the contributor-facing guidance is part of the change rather than a follow-up.
+
+1. **Regenerate the Pydantic types** and commit the result — the commands are in [Auto-generation of Pydantic Classes](README.md#-auto-generation-of-pydantic-classes-for-schema).
+
+2. **Run `tests/test_skill_conversion.py`.** It re-validates the [`eee-dataset-conversion` skill](.claude/skills/eee-dataset-conversion/SKILL.md) — its templates and one frozen reference conversion — through the real CLI with semantic checks on. When it goes red, fix the **skill**, not the test: the failure message names the file and gives the regeneration command. This test is the reason there is no checklist of skill files to update here; it catches the drift that a checklist used to be relied on for.
+
+3. **Consider a `schema_version` bump.** A field-optionality change moved it `0.2.2 → 0.2.3` (see #212), and it has since moved to `0.3.0`. Whether a given change warrants a bump is a judgement call, not a rule — decide, and flag it in the PR so a reviewer can weigh in.
+
+## 🧩 A contribution is usually three PRs
+
+A dataset contribution normally spans three repos: the adapter here, the canonical ids in [`eval-card-registry`](https://github.com/evaleval/eval-card-registry), and the data in the [`EEE_datastore`](https://huggingface.co/datasets/evaleval/EEE_datastore). Cross-link them so a reviewer can see the whole change — each one on its own looks incomplete. The skill's "three PRs" section has the details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,21 @@
 
 Thanks for contributing! This repo defines the **Every Eval Ever (EEE)** schema and hosts the tooling around it — validation, converters, and adapters. The evaluation data itself lives in the [Hugging Face datastore](https://huggingface.co/datasets/evaleval/EEE_datastore), split into files by individual model and stored using [`eval.schema.json`](every_eval_ever/schemas/eval.schema.json) under `data/{benchmark_name}/{developer_name}/{model_name}/`.
 
-For what the schema *is* and how to read a record, start with the [README](README.md) — [The Schema in Practice](README.md#-the-schema-in-practice), [Instance-Level Data](README.md#-instance-level-data), and [`eval.schema.json`](every_eval_ever/schemas/eval.schema.json) itself. This guide covers authoring and submitting: how to submit data, and what to do when you change the schema or the tooling.
+For what the schema *is* and how to read a record, start with the [README](README.md) — [The Schema in Practice](README.md#-the-schema-in-practice), [Instance-Level Data](README.md#-instance-level-data), and [`eval.schema.json`](every_eval_ever/schemas/eval.schema.json) itself. This guide covers authoring and submitting: how your PR gets reviewed, how to submit data, and what to do when you change the schema or the tooling.
 
 > **Using an AI coding agent?** This repo ships an `eee-dataset-conversion` skill ([`.claude/skills/eee-dataset-conversion/`](.claude/skills/eee-dataset-conversion/), indexed from [AGENTS.md](AGENTS.md)) that walks an agent through a conversion — schema field traps, aggregate + instance records, verification, and a decision log to paste into the PR. The rules below apply to agent-authored PRs too, and the agent is expected to follow them.
+
+## 🔍 How your PR gets reviewed
+
+Which lane you land in depends on the change, not on who wrote it.
+
+**Fast — reviewed and merged quickly, sometimes by an agent.** No conflicts with `main`; scoped to one adapter, one file, or the tests; understood and verified by you; under ~1000 hand-written lines. A new adapter, a small validator behaviour change, a workflow fix. A maintainer can also put any PR in this lane with the **`auto-review`** label — ask in your description if you think yours belongs here.
+
+**Needs a human** — either of the PR or of an agent's review of it — if any of the above doesn't hold, or for: a design change · a change spanning packages · a large refactor · more than ~1000 hand-written lines · a material change in outcome, where the same input now produces different data · a large agent-authored change. In practice: schema changes, edits to base adapters, changing or dropping a validator rule, restructuring.
+
+**Planning something structural? Agree the approach before opening a PR.** Open an issue or raise it with a maintainer. We don't have the capacity to review a large structural PR that arrives cold, so one opened ahead of that agreement will sit — which wastes your work, not ours.
+
+*Hand-written lines* excludes the generated types (`every_eval_ever/eval_types.py`, `instance_level_types.py`) and fixtures under `tests/data/`. Generated files anywhere else count in full: bulk output landing in the package is itself a thing to review, not a line-count technicality. And the threshold triages — don't split one coherent change into three to duck under it.
 
 ## 📥 Submitting evaluation data
 
@@ -70,22 +82,9 @@ Note: each file can contain multiple individual results related to one model. Se
      print(pr_url)
      ```
 
-     To add more files to the same PR, use the PR ref returned by Hugging Face (for example, `refs/pr/XX`):
-
-     ```python
-     from huggingface_hub import HfApi
-
-     api = HfApi()
-
-     api.upload_file(
-         path_or_fileobj="data/my-eval/developer/model/uuid_samples.jsonl",
-         path_in_repo="data/my-eval/developer/model/uuid_samples.jsonl",
-         repo_id="evaleval/EEE_datastore",
-         repo_type="dataset",
-         revision="refs/pr/XX",  # upload to an existing PR
-         commit_message="[Submission] Add instance-level samples",
-     )
-     ```
+     To add files to that PR rather than opening another, pass the PR ref Hugging Face
+     returned as `revision` (e.g. `revision="refs/pr/XX"`) to `upload_file` or a further
+     `upload_folder`.
 
 Before opening the PR, validate locally — see [Data Validation](README.md#-data-validation).
 
@@ -131,7 +130,7 @@ Conventions for authoring records. For what each field *means*, see [The Schema 
 
 ## 🔧 Changing the schema, the validator, or the publisher
 
-These change what a *contribution* has to look like, so the contributor-facing guidance is part of the change rather than a follow-up.
+These change what a *contribution* has to look like, so they are slow-lane by default, and the contributor-facing guidance is part of the change rather than a follow-up.
 
 1. **Regenerate the Pydantic types** and commit the result — the commands are in [Auto-generation of Pydantic Classes](README.md#-auto-generation-of-pydantic-classes-for-schema).
 

--- a/README.md
+++ b/README.md
@@ -46,120 +46,13 @@ pip install 'every-eval-ever[all]'
 | **Composite Benchmark** | A collection of simple benchmarks aggregated into one overall score, testing multiple capabilities at once | BIG-Bench bundles >200 tasks with a single aggregate score |
 | **Metric** | Any numerical or categorical value used to score performance on a benchmark (accuracy, F1, precision, recall, …) | A model scores 92% accuracy on MMLU |
 
-## 🚀 Contributor Guide
-New data can be contributed to the [Hugging Face Dataset](https://huggingface.co/datasets/evaleval/EEE_datastore) using the following process:
+## 🚀 Contributing
 
-Leaderboard/evaluation data is split-up into files by individual model, and data for each model is stored using [`eval.schema.json`](every_eval_ever/schemas/eval.schema.json). The repository is structured into folders as `data/{benchmark_name}/{developer_name}/{model_name}/`.
+Contributing data, writing an adapter, or changing the schema? **[CONTRIBUTING.md](CONTRIBUTING.md)** is the guide: how your PR gets reviewed, how to submit data to the datastore, the naming conventions, and the conventions for filling in each field.
 
-### TL;DR How to successfully submit
+The rest of this README is for *reading* EEE — what the schema says, how to validate a record, and what the converters do.
 
-1. Data must conform to [`eval.schema.json`](every_eval_ever/schemas/eval.schema.json) (current version: `0.3.0`)
-2. The validation pipeline will automatically verify the data submitted in the pull request, but can also be manually triggered by typing ```/eee validate changed``` in a comment on the HF PR.
-3. An EvalEval member will review and merge your submission
-
-### PR Naming Convention
-
-Use these prefixes in your pull request titles:
-
-- `[Submission]` - New evaluation data
-- `[Issue #N]` - Fix for a specific GitHub issue
-- `[Feature]` - New functionality not tied to an issue
-- `[Docs]` - Documentation changes
-- `[ACL Shared Task]` - Shared task submissions (priority review)
-
-### UUID Naming Convention
-
-Each JSON file is named with a **UUID (Universally Unique Identifier)** in the format `{uuid}.json`. The UUID is automatically generated (using standard UUID v4) when creating a new evaluation result file. This ensures that:
-- **Multiple evaluations** of the same model can exist without conflicts (each gets a unique UUID)
-- **Different timestamps** are stored as separate files with different UUIDs (not as separate folders)
-- A model may have multiple result files, with each file representing different iterations or runs of the leaderboard/evaluation
-- UUID's can be generated using Python's `uuid.uuid4()` function.
-
-**Example**: The model `openai/gpt-4o-2024-11-20` might have multiple files like:
-- `e70acf51-30ef-4c20-b7cc-51704d114d70.json` (evaluation run #1)
-- `a1b2c3d4-5678-90ab-cdef-1234567890ab.json` (evaluation run #2)
-
-Note: Each file can contain multiple individual results related to one model. See [examples in the datastore](https://huggingface.co/datasets/evaleval/EEE_datastore/tree/main/data).
-
-### How to add new eval:
-
-1. Add a new folder under [`data/`](https://huggingface.co/datasets/evaleval/EEE_datastore/tree/main/data) on the Hugging Face datastore with a codename for your eval.
-2. For each model, use the Hugging Face (`developer_name/model_name`) naming convention to create a 2-tier folder structure.
-3. Add a JSON file with results for each model and name it `{uuid}.json`.
-4. [Optional] Add scripts used to generate the data under [`every_eval_ever/adapters/`](every_eval_ever/adapters/) in this repository (see e.g. [`every_eval_ever/adapters/global_mmlu_lite/adapter.py`](every_eval_ever/adapters/global_mmlu_lite/adapter.py)).
-5. [Submit] Two ways to submit your evaluation data:
-   - **Option A: Drag & drop via Hugging Face** — Go to [evaleval/EEE_datastore](https://huggingface.co/datasets/evaleval/EEE_datastore) → click "Files and versions" → "Contribute" → "Upload files" → drag and drop your data → select "Open as a pull request to the main branch". See [step-by-step screenshots](https://docs.google.com/document/d/1dxTQF8ncGCzaAOIj0RX7E9Hg4THmUBzezDOYUp_XdCY/edit?usp=sharing).
-   - **Option B: Upload via `huggingface_hub`** — Useful for larger submissions or many files.
-
-     ```python
-     from huggingface_hub import HfApi
-
-     api = HfApi()
-
-     pr_url = api.upload_folder(
-         folder_path="data/my-eval",
-         path_in_repo="data/my-eval",
-         repo_id="evaleval/EEE_datastore",
-         repo_type="dataset",
-         commit_message="[Submission] Add my eval",
-         commit_description="Adds evaluation data for my eval.",
-         create_pr=True,  # opens a PR instead of committing directly
-     )
-
-     print(pr_url)
-     ```
-
-     To add more files to the same PR, use the PR ref returned by Hugging Face (for example, `refs/pr/XX`):
-
-     ```python
-     from huggingface_hub import HfApi
-
-     api = HfApi()
-
-     api.upload_file(
-         path_or_fileobj="data/my-eval/developer/model/uuid_samples.jsonl",
-         path_in_repo="data/my-eval/developer/model/uuid_samples.jsonl",
-         repo_id="evaleval/EEE_datastore",
-         repo_type="dataset",
-         revision="refs/pr/XX",  # upload to an existing PR
-         commit_message="[Submission] Add instance-level samples",
-     )
-     ```
-### Schema Instructions
-
-1. **`model_info`**: Use Hugging Face formatting (`developer_name/model_name`). If a model does not come from Hugging Face, use the exact API reference. Check [examples in data/livecodebenchpro](https://huggingface.co/datasets/evaleval/EEE_datastore/tree/main/data/livecodebenchpro). Notably, some do have a **date included in the model name**, but others **do not**. For example:
-- OpenAI: `gpt-4o-2024-11-20`, `gpt-5-2025-08-07`, `o3-2025-04-16`
-- Anthropic: `claude-3-7-sonnet-20250219`, `claude-3-sonnet-20240229`
-- Google: `gemini-2.5-pro`, `gemini-2.5-flash`
-- xAI (Grok): `grok-2-2024-08-13`, `grok-3-2025-01-15`
-
-2. **`evaluation_id`**: Use `{benchmark_name/model_id/retrieved_timestamp}` format (e.g. `livecodebenchpro/qwen3-235b-a22b-thinking-2507/1760492095.8105888`).
-
-3. **`inference_platform`** vs **`inference_engine`**: Where possible specify where the evaluation was run using one of these two fields.
-- `inference_platform`: Use this field when the evaluation was run through a remote API (e.g., `openai`, `huggingface`, `openrouter`, `anthropic`, `xai`).
-- `inference_engine`: Use this field when the evaluation was run locally. This is now an object with `name` and `version` (e.g. `{"name": "vllm", "version": "0.6.0"}`).
-
-4. The `source_type` on `source_metadata` has two options: `documentation` and `evaluation_run`. Use `documentation` when results are scraped from a leaderboard or paper. Use `evaluation_run` when the evaluation was run locally (e.g. via an eval converter).
-
-5. **`source_data`** is specified per evaluation result (inside `evaluation_results`), with three variants:
-- `source_type: "url"` — link to a web source (e.g. leaderboard API)
-- `source_type: "hf_dataset"` — reference to a Hugging Face dataset (e.g. `{"hf_repo": "google/IFEval"}`)
-- `source_type: "other"` — for private or proprietary datasets
-
-6. The schema is designed to accommodate both numeric and level-based (e.g. Low, Medium, High) metrics. For level-based metrics, the actual 'value' should be converted to an integer (e.g. Low = 1, Medium = 2, High = 3), and the `level_names` property should be used to specify the mapping of levels to integers.
-
-7. **Timestamps**: The schema has three timestamp fields — use them as follows:
-- `retrieved_timestamp` (required) — when this record was created, in Unix epoch format (e.g. `1760492095.8105888`)
-- `evaluation_timestamp` (top-level, optional) — when the evaluation was run
-- `evaluation_results[].evaluation_timestamp` (per-result, optional) — when a specific evaluation result was produced, if different results were run at different times
-
-8. Additional details can be provided in several places in the schema. They are not required, but can be useful for detailed analysis.
-- `model_info.additional_details`: Use this field to provide any additional information about the model itself (e.g. number of parameters)
-- `evaluation_results.generation_config.generation_args`: Specify additional arguments used to generate outputs from the model
-- `evaluation_results.generation_config.additional_details`: Use this field to provide any additional information about the evaluation process that is not captured elsewhere
-
-
-### Instance-Level Data
+## 🧩 Instance-Level Data
 
 For evaluations that include per-sample results, the individual results should be stored in a companion `{uuid}_samples.jsonl` file in the same folder (one JSONL per JSON, sharing the same UUID). The aggregate JSON file refers to its JSONL via the `detailed_evaluation_results` field. The instance-level schema ([`instance_level_eval.schema.json`](every_eval_ever/schemas/instance_level_eval.schema.json)) supports three interaction types:
 
@@ -188,7 +81,7 @@ Example `single_turn` instance:
 }
 ```
 
-### Agentic Evaluations
+## 🤖 Agentic Evaluations
 
 For agentic evaluations (e.g., SWE-Bench, GAIA), the aggregate schema captures configuration under `generation_config.generation_args`:
 


### PR DESCRIPTION
## What

Three things, one per commit:

1. **Split the contributor docs out of the README into a root `CONTRIBUTING.md`**, per audience — *understand & use* stays in the README, *author & submit* moves out.
2. **Restore the repo-wide PR template**, recovered from where it was parked.
3. **Write down the review policy** — the two lanes, and the rule about agreeing structural work before opening a PR.

Docs only; no `.py` files touched.

## Why now

An earlier attempt at (1) and (2) was carved out of #208 by 941aa85c1, to keep that PR scoped to the skill — *"a repo-wide PULL_REQUEST_TEMPLATE.md and a new issue template are a separate maintainer decision and shouldn't gate them."* That was right. The issue template was later pulled back in and landed; the PR template went to a branch that was never opened. The `CONTRIBUTING.md` half never reached GitHub at all. This reunites them and adds the policy that prompted the question.

## The split

The README was serving two audiences at once. `Contributor Guide`, PR/UUID naming, how-to-add and `Schema Instructions` move to `CONTRIBUTING.md` (409 → 302 lines).

`Instance-Level Data` and `Agentic Evaluations` **stay** — they document the record format, which a consumer needs as much as an author — and are promoted `###` → `##` now that the Contributor Guide no longer encloses them.

The earlier version's commit message said "slim README to a pointer" but only *added* `CONTRIBUTING.md`, leaving the README untouched and the two duplicating each other. This does the removal. Stale references fixed on the way: the root `eval.schema.json` symlink is gone (→ `every_eval_ever/schemas/`), `utils/` → `every_eval_ever/adapters/`, `schema_version` `0.2.3` → `0.3.0`, and `post_codegen` runs as a module.

The skill-sync section deliberately carries **no** checklist of skill files to update. `tests/test_skill_conversion.py` is the enforcement; the table that used to sit there is exactly what went stale.

## The policy, and two things it needed pinned down

**The size limit counts hand-written lines.** As a raw diff count it contradicts its own flagship case — "a new adapter" is the fast lane, yet adapters routinely pass 1000 lines on fixtures alone, and any schema touch drags in a regenerated `eval_types.py`. So the two generated type modules and `tests/data/**` don't count. Only there: generated files dumped anywhere else count in full, because bulk output landing in the package is the kind of thing review is *for*.

**`auto-review` is maintainer-applied.** Self-serve would make the fast-lane gate self-declared with nothing checking it, which is the one property the gate can't have. The label has been created on this repo.

**Placement follows this repo's own rule about not restating things.** `CONTRIBUTING.md` carries the policy. `AGENTS.md` and the skill get only the half that changes what an agent *does* — get the design agreed before building something structural, and don't fold a schema tweak into an adapter PR, since that drags the adapter into the slow lane behind a design discussion. The PR template gets a lane checkbox and a `Design agreed in:` slot, which is where the rule actually bites.

## Verification

- `pytest tests/test_skill_conversion.py` — 7 passed (the skill tripwire)
- `ruff check` — clean
- every internal markdown link and anchor resolves, checked programmatically across all `.md` files

**Pre-existing failure, unrelated to this branch:** `tests/test_helm_generation_args.py::TestExtractGenerationArgsFalsyValues` has 5 failures on current `main` — zero-valued `temperature`/`top_p`/`top_k` and a low `max_tokens` aren't preserved, which reads like a falsy-value `or` fallback. Worth its own issue.

## Review lane

**Needs a human** by its own policy — cross-file docs restructure, material change to contributor-facing guidance. The wording is the substance here, so please read it as wording.