### PR TITLE
[Feature] Add standalone local folder validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,38 @@ uv run python -m every_eval_ever validate --format github 'data/*/*/*/*.json*'
 
 Exit code is `0` if all files pass and `1` if any fail.
 
+### Validate local folders with the standalone script
+
+Use the standalone script when generated files are not yet arranged as a
+datastore checkout. It accepts files, glob patterns, and directories at any
+depth without accessing a pull request or changing the package CLI:
+
+```sh
+# Human-readable terminal report
+uv run python scripts/local_validate.py /path/to/output
+
+# Structured diagnostics for an agent or another program
+uv run python scripts/local_validate.py --format json /path/to/output
+```
+
+Directories are searched recursively for every `.json` and `.jsonl` file.
+Hidden descendants and directory symlinks are not traversed. Every matching
+file is validated; unrelated JSON is reported as invalid rather than silently
+skipped.
+
+The script uses the current bundled schemas and registered semantic checks.
+Datastore placement and naming problems are warnings locally, so a record may
+be valid but **not merge-ready**. Aggregate/sample content and relationship
+problems remain errors. A warning-only run exits `0`; a run containing an error
+exits `1`. Fix every warning before submitting the files for merge. Checks that
+require PR history or repository-wide remote state remain the responsibility
+of the validator bot.
+
+JSON output includes the schema version and fingerprint, a summary, and one
+report per file with its status, field or line location, message, offending
+input when available, errors, and warnings. Operational directory notices are
+written to stderr so stdout remains parseable JSON.
+
 ## 🗂️ Data Structure
 
 Evaluation data is hosted on the [Hugging Face datastore](https://huggingface.co/datasets/evaleval/EEE_datastore). The folder structure is:

--- a/README.md
+++ b/README.md
@@ -167,11 +167,15 @@ datastore checkout. It accepts files, glob patterns, and directories at any
 depth without accessing a pull request or changing the package CLI:
 
 ```sh
-# Human-readable terminal report
+# Grouped human-readable terminal report
 uv run python scripts/local_validate.py /path/to/output
 
-# Structured diagnostics for an agent or another program
+# Stream structured diagnostics to stdout
 uv run python scripts/local_validate.py --format json /path/to/output
+
+# Show grouped terminal output and save every individual finding
+uv run python scripts/local_validate.py \
+  --json-log local-validation.json /path/to/output
 ```
 
 Directories are searched recursively for every `.json` and `.jsonl` file.
@@ -187,10 +191,16 @@ exits `1`. Fix every warning before submitting the files for merge. Checks that
 require PR history or repository-wide remote state remain the responsibility
 of the validator bot.
 
+Terminal output starts with pass, warning-only, and failure counts, then groups
+identical errors and warnings by type, location, and message. It shows each
+group's occurrence and affected-file counts instead of printing one panel per
+file. Use `--json-log PATH` to retain every individual finding while keeping
+the grouped terminal view.
+
 JSON output includes the schema version and fingerprint, a summary, and one
 report per file with its status, field or line location, message, offending
-input when available, errors, and warnings. Operational directory notices are
-written to stderr so stdout remains parseable JSON.
+input when available, errors, and warnings. Operational directory and log
+notices are written to stderr so stdout remains parseable JSON.
 
 ## 🗂️ Data Structure
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,10 @@ uv run python -m every_eval_ever validate --format github 'data/*/*/*/*.json*'
 | `--format {rich,json,github}` | `rich` | Output format |
 | `--max-errors N` | `50` | Maximum errors reported per JSONL file |
 
-Exit code is `0` if all files pass and `1` if any fail.
+Rich output distinguishes clean `PASS`, non-fatal `WARN`, and blocking `FAIL`
+results. Its summary reports clean-pass, warning-only, and failure counts.
+Warnings keep exit code `0`, but must still be fixed before merge. Exit code is
+`1` if any file fails.
 
 ### Validate local folders with the standalone script
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,9 @@ uv run python -m every_eval_ever validate --format github 'data/*/*/*/*.json*'
 
 Rich output distinguishes clean `PASS`, non-fatal `WARN`, and blocking `FAIL`
 results. Its summary reports clean-pass, warning-only, and failure counts.
-Warnings keep exit code `0`, but must still be fixed before merge. Exit code is
-`1` if any file fails.
+Clean runs exit `0`, runs containing an error exit `1`, and warning-only runs
+exit `2`. Warnings do not make a record schema-invalid, but they block merge
+until fixed.
 
 ### Validate local folders with the standalone script
 
@@ -189,10 +190,10 @@ skipped.
 The script uses the current bundled schemas and registered semantic checks.
 Datastore placement and naming problems are warnings locally, so a record may
 be valid but **not merge-ready**. Aggregate/sample content and relationship
-problems remain errors. A warning-only run exits `0`; a run containing an error
-exits `1`. Fix every warning before submitting the files for merge. Checks that
-require PR history or repository-wide remote state remain the responsibility
-of the validator bot.
+problems remain errors. A clean run exits `0`, a run containing an error exits
+`1`, and a warning-only run exits `2`. Fix every warning before submitting the
+files for merge. Checks that require PR history or repository-wide remote state
+remain the responsibility of the validator bot.
 
 Terminal output starts with pass, warning-only, and failure counts, then groups
 identical errors and warnings by type, location, and message. It shows each

--- a/every_eval_ever/validator/validate.py
+++ b/every_eval_ever/validator/validate.py
@@ -146,31 +146,31 @@ def _truncate(value: object, max_len: int = 80) -> str:
 
 
 def render_report_rich(report: ValidationReport, console: Console) -> None:
-    """Render one validation report as a terminal panel."""
+    """Render one validation report with visible errors and warnings."""
     if report.valid:
-        label = Text(' PASS ', style='bold white on green')
+        if report.warnings:
+            label = Text(' WARN ', style='bold black on yellow')
+            border_style = 'yellow'
+        else:
+            label = Text(' PASS ', style='bold white on green')
+            border_style = 'green'
         kind = (
             'Aggregate (EvaluationLog)'
             if report.file_type == 'aggregate'
             else f'Instance (InstanceLevelEvaluationLog, {report.line_count} lines)'
         )
-        console.print(
-            Panel(
-                Text.assemble(label, '  ', (kind, 'dim')),
-                title=f'[blue underline]{report.file_path}[/]',
-                title_align='left',
-                border_style='green',
-            )
+    else:
+        label = Text(' FAIL ', style='bold white on red')
+        border_style = 'red'
+        kind = (
+            'Aggregate (EvaluationLog)'
+            if report.file_type == 'aggregate'
+            else f'Instance (InstanceLevelEvaluationLog, {report.line_count} lines)'
         )
-        return
 
-    label = Text(' FAIL ', style='bold white on red')
-    kind = (
-        'Aggregate (EvaluationLog)'
-        if report.file_type == 'aggregate'
-        else 'Instance (InstanceLevelEvaluationLog)'
-    )
-    lines = [Text.assemble(label, '  ', (kind, 'dim')), Text('')]
+    lines = [Text.assemble(label, '  ', (kind, 'dim'))]
+    if report.errors or report.warnings:
+        lines.append(Text(''))
     for index, error in enumerate(report.errors, 1):
         lines.append(Text(f'  {index}. {error["loc"]}', style='cyan'))
         lines.append(Text(f'     {error["msg"]}'))
@@ -188,7 +188,7 @@ def render_report_rich(report: ValidationReport, console: Console) -> None:
             Text('\n').join(lines),
             title=f'[blue underline]{report.file_path}[/]',
             title_align='left',
-            border_style='red',
+            border_style=border_style,
         )
     )
 
@@ -196,19 +196,28 @@ def render_report_rich(report: ValidationReport, console: Console) -> None:
 def render_summary_rich(
     reports: list[ValidationReport], console: Console
 ) -> None:
-    """Render the aggregate pass/fail summary."""
-    passed = sum(1 for report in reports if report.valid)
-    failed = len(reports) - passed
+    """Render clean-pass, warning-only, and failure counts."""
+    passed = sum(
+        1 for report in reports if report.valid and not report.warnings
+    )
+    warned = sum(
+        1 for report in reports if report.valid and report.warnings
+    )
+    failed = sum(1 for report in reports if not report.valid)
     total_errors = sum(len(report.errors) for report in reports)
+    total_warnings = sum(len(report.warnings) for report in reports)
+    message = (
+        f'{passed} passed, {warned} warning-only, {failed} failed '
+        f'({total_errors} errors, {total_warnings} warnings)'
+    )
     if failed:
         style = 'bold red'
-        message = (
-            f'{failed} file(s) failed, {passed} passed '
-            f'({total_errors} total errors)'
-        )
+    elif warned:
+        style = 'bold yellow'
+        message += '\nValid locally, but not merge-ready. Fix all warnings.'
     else:
         style = 'bold green'
-        message = f'All {passed} file(s) passed validation'
+        message += '\nAll files passed validation.'
     console.print()
     console.print(
         Panel(Text(message, style=style), title='Summary', border_style='dim')

--- a/every_eval_ever/validator/validate.py
+++ b/every_eval_ever/validator/validate.py
@@ -200,9 +200,7 @@ def render_summary_rich(
     passed = sum(
         1 for report in reports if report.valid and not report.warnings
     )
-    warned = sum(
-        1 for report in reports if report.valid and report.warnings
-    )
+    warned = sum(1 for report in reports if report.valid and report.warnings)
     failed = sum(1 for report in reports if not report.valid)
     total_errors = sum(len(report.errors) for report in reports)
     total_warnings = sum(len(report.warnings) for report in reports)
@@ -243,6 +241,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog='eee-validate',
         description='Validate EEE files using strict JSON and bundled schemas',
+        epilog='Exit codes: 0 clean, 1 errors, 2 warnings only.',
     )
     parser.add_argument(
         'paths',
@@ -276,9 +275,7 @@ def main(argv: list[str] | None = None) -> int:
         print('No files found to validate.', file=sys.stderr)
         return 1
 
-    local_contexts = [
-        (path, *_local_path_context(path)) for path in file_paths
-    ]
+    local_contexts = [(path, *_local_path_context(path)) for path in file_paths]
     reports = [
         validate_file(
             path,
@@ -303,7 +300,11 @@ def main(argv: list[str] | None = None) -> int:
             render_report_rich(report, console)
         render_summary_rich(reports, console)
 
-    return 1 if any(not report.valid for report in reports) else 0
+    if any(not report.valid for report in reports):
+        return 1
+    if any(report.warnings for report in reports):
+        return 2
+    return 0
 
 
 if __name__ == '__main__':

--- a/scripts/local_validate.py
+++ b/scripts/local_validate.py
@@ -75,8 +75,7 @@ def expand_directory(directory: Path) -> list[Path]:
     if not files:
         suffixes = ' or '.join(DATA_SUFFIXES)
         raise ValueError(
-            f'directory contains no {suffixes} files: '
-            f'{directory.as_posix()!r}'
+            f'directory contains no {suffixes} files: {directory.as_posix()!r}'
         )
     return files
 
@@ -151,9 +150,7 @@ def _aggregate_sibling(sample_path: Path) -> Path | None:
     suffix = '_samples.jsonl'
     if not sample_path.name.endswith(suffix):
         return None
-    return sample_path.with_name(
-        f'{sample_path.name[: -len(suffix)]}.json'
-    )
+    return sample_path.with_name(f'{sample_path.name[: -len(suffix)]}.json')
 
 
 def _logical_parent(path: Path, actual_repo_path: str | None) -> PurePosixPath:
@@ -193,7 +190,9 @@ def _repository_context(
         ]
     except OSError:
         siblings = [path]
-    files = {(parent / sibling.name).as_posix(): sibling for sibling in siblings}
+    files = {
+        (parent / sibling.name).as_posix(): sibling for sibling in siblings
+    }
     display_path = actual_repo_path or path.as_posix()
     return repo_path, LocalRepositoryFiles(files), display_path
 
@@ -269,9 +268,7 @@ def validate_local_file(
     actual_findings = check_path_structure(display_path)
     path_warnings.extend(_path_warning(message) for message in actual_findings)
     report.errors = retained_errors
-    report.warnings = _deduplicate_findings(
-        [*report.warnings, *path_warnings]
-    )
+    report.warnings = _deduplicate_findings([*report.warnings, *path_warnings])
     report.valid = not report.errors
     return report
 
@@ -302,13 +299,17 @@ def _summary(
     error_count = sum(len(report.errors) for report in reports) + len(
         input_errors
     )
+    failed = statuses.count('fail')
+    warned = statuses.count('warn')
+    exit_code = 1 if input_errors or failed else 2 if warned else 0
     return {
         'files': len(reports),
         'passed': statuses.count('pass'),
-        'warned': statuses.count('warn'),
-        'failed': statuses.count('fail'),
+        'warned': warned,
+        'failed': failed,
         'errors': error_count,
         'warnings': sum(len(report.warnings) for report in reports),
+        'exit_code': exit_code,
         'merge_ready': (
             not input_errors
             and bool(reports)
@@ -331,9 +332,7 @@ def json_payload(
             'scope': 'local',
         },
         'summary': _summary(reports, input_errors),
-        'input_errors': [
-            _normalise_finding(error) for error in input_errors
-        ],
+        'input_errors': [_normalise_finding(error) for error in input_errors],
         'reports': [
             {
                 'file': str(report.file_path),
@@ -346,8 +345,7 @@ def json_payload(
                     _normalise_finding(error) for error in report.errors
                 ],
                 'warnings': [
-                    _normalise_finding(warning)
-                    for warning in report.warnings
+                    _normalise_finding(warning) for warning in report.warnings
                 ],
             }
             for report in reports
@@ -376,9 +374,7 @@ def group_findings(
     reports: list[ValidationReport], attribute: str
 ) -> list[tuple[tuple[str, str, str], list[tuple[Path, dict[str, Any]]]]]:
     """Group report findings by type, normalized location, and message."""
-    groups: dict[
-        tuple[str, str, str], list[tuple[Path, dict[str, Any]]]
-    ] = {}
+    groups: dict[tuple[str, str, str], list[tuple[Path, dict[str, Any]]]] = {}
     for report in reports:
         findings = getattr(report, attribute)
         for finding in findings:
@@ -506,6 +502,7 @@ def main(argv: list[str] | None = None) -> int:
         description=(
             'Validate local EEE files or folders without accessing a PR.'
         ),
+        epilog='Exit codes: 0 clean, 1 errors, 2 warnings only.',
     )
     parser.add_argument(
         'paths',
@@ -569,7 +566,11 @@ def main(argv: list[str] | None = None) -> int:
         render_grouped_rich(reports, console)
         if log_error is not None:
             console.print(log_error['msg'], style='bold red')
-    return 1 if log_error or any(not report.valid for report in reports) else 0
+    if log_error or any(not report.valid for report in reports):
+        return 1
+    if any(report.warnings for report in reports):
+        return 2
+    return 0
 
 
 if __name__ == '__main__':

--- a/scripts/local_validate.py
+++ b/scripts/local_validate.py
@@ -7,6 +7,7 @@ import argparse
 import glob
 import json
 import os
+import re
 import sys
 from collections.abc import Callable, Container
 from pathlib import Path, PurePosixPath
@@ -31,6 +32,8 @@ from every_eval_ever.validator.validation_core import (
 
 DATA_SUFFIXES = ('.json', '.jsonl')
 _LOCAL_PARENT = PurePosixPath('data/local/local/local')
+_LINE_LOCATION_RE = re.compile(r'^line \d+ -> ')
+_MAX_GROUP_FILES = 5
 
 
 class LocalRepositoryFiles(Container[str]):
@@ -364,83 +367,79 @@ def render_json(
     )
 
 
-def _kind(report: ValidationReport) -> str:
-    if report.file_type == 'aggregate':
-        return 'Aggregate (EvaluationLog)'
-    if report.file_type == 'instance':
-        return (
-            'Instance (InstanceLevelEvaluationLog, '
-            f'{report.line_count} lines)'
-        )
-    return report.file_type.title() or 'Unknown file type'
+def _group_location(finding: dict[str, Any]) -> str:
+    location = str(finding.get('loc') or '(root)')
+    return _LINE_LOCATION_RE.sub('', location)
 
 
-def _truncate(value: object, max_length: int = 160) -> str:
-    text = repr(value)
-    if len(text) <= max_length:
-        return text
-    return f'{text[: max_length - 3]}...'
-
-
-def _finding_lines(
-    findings: list[dict[str, Any]], *, severity: str
-) -> list[Text]:
-    lines: list[Text] = []
-    style = 'red' if severity == 'ERROR' else 'yellow'
-    for index, finding in enumerate(findings, start=1):
-        location = finding.get('loc') or '(root)'
-        finding_type = finding.get('type') or 'validation_finding'
-        lines.append(
-            Text(
-                f'  {severity} {index} · {location} [{finding_type}]',
-                style=style,
+def group_findings(
+    reports: list[ValidationReport], attribute: str
+) -> list[tuple[tuple[str, str, str], list[tuple[Path, dict[str, Any]]]]]:
+    """Group report findings by type, normalized location, and message."""
+    groups: dict[
+        tuple[str, str, str], list[tuple[Path, dict[str, Any]]]
+    ] = {}
+    for report in reports:
+        findings = getattr(report, attribute)
+        for finding in findings:
+            key = (
+                str(finding.get('type') or 'validation_finding'),
+                _group_location(finding),
+                str(finding.get('msg') or ''),
             )
+            groups.setdefault(key, []).append((report.file_path, finding))
+    return list(groups.items())
+
+
+def _render_finding_groups(
+    reports: list[ValidationReport],
+    console: Console,
+    *,
+    attribute: str,
+    severity: str,
+) -> None:
+    groups = group_findings(reports, attribute)
+    if not groups:
+        return
+    style = 'red' if severity == 'ERROR' else 'yellow'
+    console.print()
+    console.print(
+        Text(
+            f'{severity.title()}s: {len(groups)} group(s), '
+            f'{sum(len(items) for _, items in groups)} occurrence(s)',
+            style=f'bold {style}',
         )
-        lines.append(Text(f'    {finding.get("msg", "")}'))
-        if finding.get('input') is not None:
+    )
+    for index, ((finding_type, location, message), items) in enumerate(
+        groups, start=1
+    ):
+        files = list(dict.fromkeys(path for path, _ in items))
+        shown_files = files[:_MAX_GROUP_FILES]
+        lines = [
+            Text(f'{location} [{finding_type}]', style=style),
+            Text(message),
+            Text(''),
+            Text(
+                f'{len(items)} occurrence(s) in {len(files)} file(s)',
+                style='bold',
+            ),
+        ]
+        lines.extend(Text(f'  {path}', style='dim') for path in shown_files)
+        if len(files) > len(shown_files):
             lines.append(
                 Text(
-                    f'    Got: {_truncate(finding["input"])}',
+                    f'  ... and {len(files) - len(shown_files)} more',
                     style='dim',
                 )
             )
-        lines.append(Text(''))
-    return lines
-
-
-def render_report_rich(report: ValidationReport, console: Console) -> None:
-    status = report_status(report)
-    if status == 'pass':
-        label = Text(' PASS ', style='bold white on green')
-        border = 'green'
-    elif status == 'warn':
-        label = Text(' WARN ', style='bold black on yellow')
-        border = 'yellow'
-    else:
-        label = Text(' FAIL ', style='bold white on red')
-        border = 'red'
-
-    lines = [Text.assemble(label, '  ', (_kind(report), 'dim'))]
-    if report.errors or report.warnings:
-        lines.append(Text(''))
-    lines.extend(_finding_lines(report.errors, severity='ERROR'))
-    lines.extend(_finding_lines(report.warnings, severity='WARNING'))
-    if status == 'warn':
-        lines.append(
-            Text(
-                '  Valid locally, but not merge-ready. Fix all warnings.',
-                style='bold yellow',
+        console.print(
+            Panel(
+                Text('\n').join(lines),
+                title=f'{severity} GROUP {index}',
+                title_align='left',
+                border_style=style,
             )
         )
-
-    console.print(
-        Panel(
-            Text('\n').join(lines),
-            title=Text(str(report.file_path), style='blue underline'),
-            title_align='left',
-            border_style=border,
-        )
-    )
 
 
 def render_summary_rich(
@@ -463,6 +462,33 @@ def render_summary_rich(
     console.print()
     console.print(
         Panel(Text(message, style=style), title='Summary', border_style='dim')
+    )
+
+
+def render_grouped_rich(
+    reports: list[ValidationReport], console: Console
+) -> None:
+    """Render counts first, then grouped errors and warnings."""
+    render_summary_rich(reports, console)
+    _render_finding_groups(
+        reports,
+        console,
+        attribute='errors',
+        severity='ERROR',
+    )
+    _render_finding_groups(
+        reports,
+        console,
+        attribute='warnings',
+        severity='WARNING',
+    )
+    console.print()
+    console.print(
+        Text(
+            'Use --format json for every individual finding, or '
+            '--json-log PATH to save the detailed report.',
+            style='dim',
+        )
     )
 
 
@@ -493,6 +519,12 @@ def main(argv: list[str] | None = None) -> int:
         dest='output_format',
         help='Output format (default: rich).',
     )
+    parser.add_argument(
+        '--json-log',
+        type=Path,
+        default=None,
+        help='Write the detailed per-file JSON report to this path.',
+    )
     args = parser.parse_args(argv)
 
     def report_directory(directory: Path, count: int) -> None:
@@ -513,14 +545,31 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     reports = [validate_local_file(path) for path in paths]
+    log_error: dict[str, Any] | None = None
+    if args.json_log is not None:
+        try:
+            args.json_log.parent.mkdir(parents=True, exist_ok=True)
+            args.json_log.write_text(render_json(reports), encoding='utf-8')
+        except OSError as exc:
+            log_error = _input_error(
+                f'could not write JSON log {args.json_log}: {exc}'
+            )
+        else:
+            print(f'Detailed JSON log: {args.json_log}', file=sys.stderr)
+
     if args.output_format == 'json':
-        print(render_json(reports))
+        print(
+            render_json(
+                reports,
+                input_errors=[log_error] if log_error is not None else None,
+            )
+        )
     else:
         console = Console()
-        for report in reports:
-            render_report_rich(report, console)
-        render_summary_rich(reports, console)
-    return 1 if any(not report.valid for report in reports) else 0
+        render_grouped_rich(reports, console)
+        if log_error is not None:
+            console.print(log_error['msg'], style='bold red')
+    return 1 if log_error or any(not report.valid for report in reports) else 0
 
 
 if __name__ == '__main__':

--- a/scripts/local_validate.py
+++ b/scripts/local_validate.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""Validate local EEE files and folders without repository or PR access."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+from collections.abc import Callable, Container
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+
+from every_eval_ever.validator.json_utils import (
+    StrictJSONError,
+    strict_json_loads,
+)
+from every_eval_ever.validator.validation_core import (
+    DEFAULT_MAX_ERRORS,
+    ValidationReport,
+    check_path_structure,
+    get_schema_fingerprint,
+    get_schema_version,
+    validate_file,
+)
+
+DATA_SUFFIXES = ('.json', '.jsonl')
+_LOCAL_PARENT = PurePosixPath('data/local/local/local')
+
+
+class LocalRepositoryFiles(Container[str]):
+    """Map logical repository paths used by checks to physical local files."""
+
+    def __init__(self, files: dict[str, Path]) -> None:
+        self.files = files
+
+    def __contains__(self, repo_path: object) -> bool:
+        return isinstance(repo_path, str) and repo_path in self.files
+
+    def read_text(self, repo_path: str) -> str:
+        try:
+            path = self.files[repo_path]
+        except KeyError as exc:
+            raise OSError(f'local file is not available: {repo_path}') from exc
+        return path.read_text(encoding='utf-8')
+
+
+def expand_directory(directory: Path) -> list[Path]:
+    """Return data files below a directory without hidden or linked trees."""
+
+    def raise_walk_error(error: OSError) -> None:
+        raise error
+
+    files: list[Path] = []
+    for parent, directories, names in os.walk(
+        directory, onerror=raise_walk_error
+    ):
+        directories[:] = [
+            name for name in directories if not name.startswith('.')
+        ]
+        files.extend(
+            Path(parent) / name
+            for name in names
+            if name.endswith(DATA_SUFFIXES) and not name.startswith('.')
+        )
+    files.sort()
+    if not files:
+        suffixes = ' or '.join(DATA_SUFFIXES)
+        raise ValueError(
+            f'directory contains no {suffixes} files: '
+            f'{directory.as_posix()!r}'
+        )
+    return files
+
+
+def expand_inputs(
+    values: list[str],
+    *,
+    on_directory: Callable[[Path, int], None] | None = None,
+) -> list[Path]:
+    """Expand files, folders, and glob patterns into unique local files."""
+    result: list[Path] = []
+    seen: set[Path] = set()
+    for value in values:
+        matches = (
+            sorted(glob.glob(value, recursive='**' in value))
+            if glob.has_magic(value)
+            else [value]
+        )
+        if not matches:
+            raise ValueError(f'file pattern matched no files: {value!r}')
+        for match in matches:
+            path = Path(match)
+            if not path.exists():
+                raise ValueError(f'file or directory does not exist: {match!r}')
+            if path.is_dir():
+                expanded = expand_directory(path)
+                if on_directory is not None:
+                    on_directory(path, len(expanded))
+            else:
+                expanded = [path]
+            for file_path in expanded:
+                identity = file_path.absolute()
+                if identity in seen:
+                    continue
+                result.append(file_path)
+                seen.add(identity)
+    return result
+
+
+def _repo_path_under_data(path: Path) -> str | None:
+    absolute = path.absolute()
+    data_dir = next(
+        (ancestor for ancestor in absolute.parents if ancestor.name == 'data'),
+        None,
+    )
+    if data_dir is None:
+        return None
+    return absolute.relative_to(data_dir.parent).as_posix()
+
+
+def _load_object(path: Path) -> dict[str, Any] | None:
+    try:
+        loaded = strict_json_loads(path.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError, StrictJSONError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _declared_companion(data: dict[str, Any] | None) -> str | None:
+    if data is None:
+        return None
+    detail = data.get('detailed_evaluation_results')
+    if not isinstance(detail, dict):
+        return None
+    reference = detail.get('file_path')
+    if not isinstance(reference, str) or not reference.strip():
+        return None
+    return reference.strip()
+
+
+def _aggregate_sibling(sample_path: Path) -> Path | None:
+    suffix = '_samples.jsonl'
+    if not sample_path.name.endswith(suffix):
+        return None
+    return sample_path.with_name(
+        f'{sample_path.name[: -len(suffix)]}.json'
+    )
+
+
+def _logical_parent(path: Path, actual_repo_path: str | None) -> PurePosixPath:
+    if actual_repo_path is not None:
+        return PurePosixPath(actual_repo_path).parent
+
+    aggregate_data: dict[str, Any] | None = None
+    if path.suffix == '.json':
+        aggregate_data = _load_object(path)
+    elif path.suffix == '.jsonl':
+        aggregate_path = _aggregate_sibling(path)
+        if aggregate_path is not None and aggregate_path.is_file():
+            aggregate_data = _load_object(aggregate_path)
+
+    reference = _declared_companion(aggregate_data)
+    if reference is not None:
+        return PurePosixPath(reference).parent
+    return _LOCAL_PARENT
+
+
+def _repository_context(
+    path: Path,
+) -> tuple[str, LocalRepositoryFiles, str]:
+    actual_repo_path = _repo_path_under_data(path)
+    parent = _logical_parent(path, actual_repo_path)
+    repo_path = (
+        actual_repo_path
+        if actual_repo_path is not None
+        else (parent / path.name).as_posix()
+    )
+
+    try:
+        siblings = [
+            sibling
+            for sibling in path.parent.iterdir()
+            if sibling.is_file() and sibling.suffix in DATA_SUFFIXES
+        ]
+    except OSError:
+        siblings = [path]
+    files = {(parent / sibling.name).as_posix(): sibling for sibling in siblings}
+    display_path = actual_repo_path or path.as_posix()
+    return repo_path, LocalRepositoryFiles(files), display_path
+
+
+def _declared_path_findings(path: Path) -> list[str]:
+    if path.suffix != '.json':
+        return []
+    reference = _declared_companion(_load_object(path))
+    return check_path_structure(reference) if reference is not None else []
+
+
+def _path_warning(message: str, *, location: str = '(path)') -> dict[str, Any]:
+    return {
+        'loc': location,
+        'msg': message,
+        'type': 'path_warning',
+    }
+
+
+def _deduplicate_findings(
+    findings: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for finding in findings:
+        key = (
+            str(finding.get('loc', '')),
+            str(finding.get('msg', '')),
+            str(finding.get('type', '')),
+        )
+        if key not in seen:
+            result.append(finding)
+            seen.add(key)
+    return result
+
+
+def validate_local_file(
+    path: Path, *, max_errors: int = DEFAULT_MAX_ERRORS
+) -> ValidationReport:
+    """Validate one physical file while treating datastore paths as advisory."""
+    repo_path, repository, display_path = _repository_context(path)
+    report = validate_file(
+        path,
+        max_errors=max_errors,
+        repo_path=repo_path,
+        available_files=repository,
+        read_repo_file=repository.read_text,
+        run_semantic_checks=True,
+    )
+
+    logical_findings = check_path_structure(repo_path)
+    declared_findings = _declared_path_findings(path)
+    path_messages = [*logical_findings, *declared_findings]
+    retained_errors: list[dict[str, Any]] = []
+    path_warnings: list[dict[str, Any]] = []
+    for error in report.errors:
+        location = str(error.get('loc', ''))
+        message = str(error.get('msg', ''))
+        rendered = f'{location}: {message}' if location else message
+        matched_path_message = next(
+            (
+                path_message
+                for path_message in path_messages
+                if path_message in rendered
+            ),
+            None,
+        )
+        if matched_path_message is not None:
+            path_warnings.append(_path_warning(matched_path_message))
+        else:
+            retained_errors.append(error)
+
+    actual_findings = check_path_structure(display_path)
+    path_warnings.extend(_path_warning(message) for message in actual_findings)
+    report.errors = retained_errors
+    report.warnings = _deduplicate_findings(
+        [*report.warnings, *path_warnings]
+    )
+    report.valid = not report.errors
+    return report
+
+
+def report_status(report: ValidationReport) -> str:
+    if not report.valid:
+        return 'fail'
+    return 'warn' if report.warnings else 'pass'
+
+
+def report_merge_ready(report: ValidationReport) -> bool:
+    return report.valid and not report.warnings
+
+
+def _normalise_finding(finding: dict[str, Any]) -> dict[str, Any]:
+    return {
+        'type': finding.get('type', ''),
+        'location': finding.get('loc', ''),
+        'message': finding.get('msg', ''),
+        'input': finding.get('input'),
+    }
+
+
+def _summary(
+    reports: list[ValidationReport], input_errors: list[dict[str, Any]]
+) -> dict[str, Any]:
+    statuses = [report_status(report) for report in reports]
+    error_count = sum(len(report.errors) for report in reports) + len(
+        input_errors
+    )
+    return {
+        'files': len(reports),
+        'passed': statuses.count('pass'),
+        'warned': statuses.count('warn'),
+        'failed': statuses.count('fail'),
+        'errors': error_count,
+        'warnings': sum(len(report.warnings) for report in reports),
+        'merge_ready': (
+            not input_errors
+            and bool(reports)
+            and all(report_merge_ready(report) for report in reports)
+        ),
+    }
+
+
+def json_payload(
+    reports: list[ValidationReport],
+    *,
+    input_errors: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return the stable machine-readable local validation result."""
+    input_errors = input_errors or []
+    return {
+        'validator': {
+            'schema_version': get_schema_version(),
+            'schema_fingerprint': get_schema_fingerprint(),
+            'scope': 'local',
+        },
+        'summary': _summary(reports, input_errors),
+        'input_errors': [
+            _normalise_finding(error) for error in input_errors
+        ],
+        'reports': [
+            {
+                'file': str(report.file_path),
+                'status': report_status(report),
+                'valid': report.valid,
+                'merge_ready': report_merge_ready(report),
+                'file_type': report.file_type,
+                'line_count': report.line_count,
+                'errors': [
+                    _normalise_finding(error) for error in report.errors
+                ],
+                'warnings': [
+                    _normalise_finding(warning)
+                    for warning in report.warnings
+                ],
+            }
+            for report in reports
+        ],
+    }
+
+
+def render_json(
+    reports: list[ValidationReport],
+    *,
+    input_errors: list[dict[str, Any]] | None = None,
+) -> str:
+    return json.dumps(
+        json_payload(reports, input_errors=input_errors),
+        indent=2,
+        default=str,
+    )
+
+
+def _kind(report: ValidationReport) -> str:
+    if report.file_type == 'aggregate':
+        return 'Aggregate (EvaluationLog)'
+    if report.file_type == 'instance':
+        return (
+            'Instance (InstanceLevelEvaluationLog, '
+            f'{report.line_count} lines)'
+        )
+    return report.file_type.title() or 'Unknown file type'
+
+
+def _truncate(value: object, max_length: int = 160) -> str:
+    text = repr(value)
+    if len(text) <= max_length:
+        return text
+    return f'{text[: max_length - 3]}...'
+
+
+def _finding_lines(
+    findings: list[dict[str, Any]], *, severity: str
+) -> list[Text]:
+    lines: list[Text] = []
+    style = 'red' if severity == 'ERROR' else 'yellow'
+    for index, finding in enumerate(findings, start=1):
+        location = finding.get('loc') or '(root)'
+        finding_type = finding.get('type') or 'validation_finding'
+        lines.append(
+            Text(
+                f'  {severity} {index} · {location} [{finding_type}]',
+                style=style,
+            )
+        )
+        lines.append(Text(f'    {finding.get("msg", "")}'))
+        if finding.get('input') is not None:
+            lines.append(
+                Text(
+                    f'    Got: {_truncate(finding["input"])}',
+                    style='dim',
+                )
+            )
+        lines.append(Text(''))
+    return lines
+
+
+def render_report_rich(report: ValidationReport, console: Console) -> None:
+    status = report_status(report)
+    if status == 'pass':
+        label = Text(' PASS ', style='bold white on green')
+        border = 'green'
+    elif status == 'warn':
+        label = Text(' WARN ', style='bold black on yellow')
+        border = 'yellow'
+    else:
+        label = Text(' FAIL ', style='bold white on red')
+        border = 'red'
+
+    lines = [Text.assemble(label, '  ', (_kind(report), 'dim'))]
+    if report.errors or report.warnings:
+        lines.append(Text(''))
+    lines.extend(_finding_lines(report.errors, severity='ERROR'))
+    lines.extend(_finding_lines(report.warnings, severity='WARNING'))
+    if status == 'warn':
+        lines.append(
+            Text(
+                '  Valid locally, but not merge-ready. Fix all warnings.',
+                style='bold yellow',
+            )
+        )
+
+    console.print(
+        Panel(
+            Text('\n').join(lines),
+            title=Text(str(report.file_path), style='blue underline'),
+            title_align='left',
+            border_style=border,
+        )
+    )
+
+
+def render_summary_rich(
+    reports: list[ValidationReport], console: Console
+) -> None:
+    summary = _summary(reports, [])
+    message = (
+        f'{summary["passed"]} passed, {summary["warned"]} warning-only, '
+        f'{summary["failed"]} failed '
+        f'({summary["errors"]} errors, {summary["warnings"]} warnings)'
+    )
+    if summary['failed']:
+        style = 'bold red'
+    elif summary['warned']:
+        style = 'bold yellow'
+        message += '\nValid locally, but not merge-ready. Fix all warnings.'
+    else:
+        style = 'bold green'
+        message += '\nMerge-ready for the checks available locally.'
+    console.print()
+    console.print(
+        Panel(Text(message, style=style), title='Summary', border_style='dim')
+    )
+
+
+def _input_error(message: str) -> dict[str, Any]:
+    return {
+        'loc': '(input)',
+        'msg': message,
+        'type': 'input_error',
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog='python scripts/local_validate.py',
+        description=(
+            'Validate local EEE files or folders without accessing a PR.'
+        ),
+    )
+    parser.add_argument(
+        'paths',
+        nargs='+',
+        help='Files, folders, or glob patterns to validate.',
+    )
+    parser.add_argument(
+        '--format',
+        choices=['rich', 'json'],
+        default='rich',
+        dest='output_format',
+        help='Output format (default: rich).',
+    )
+    args = parser.parse_args(argv)
+
+    def report_directory(directory: Path, count: int) -> None:
+        print(
+            f'{directory.as_posix()}: validating {count} file(s) found '
+            'recursively',
+            file=sys.stderr,
+        )
+
+    try:
+        paths = expand_inputs(args.paths, on_directory=report_directory)
+    except (OSError, ValueError) as exc:
+        error = _input_error(str(exc))
+        if args.output_format == 'json':
+            print(render_json([], input_errors=[error]))
+        else:
+            print(str(exc), file=sys.stderr)
+        return 1
+
+    reports = [validate_local_file(path) for path in paths]
+    if args.output_format == 'json':
+        print(render_json(reports))
+    else:
+        console = Console()
+        for report in reports:
+            render_report_rich(report, console)
+        render_summary_rich(reports, console)
+    return 1 if any(not report.valid for report in reports) else 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_local_validate.py
+++ b/tests/test_local_validate.py
@@ -49,9 +49,7 @@ def test_noncanonical_record_is_valid_but_not_merge_ready(tmp_path: Path):
     assert report.valid is True
     assert report.errors == []
     assert report.warnings
-    assert all(
-        warning['type'] == 'path_warning' for warning in report.warnings
-    )
+    assert all(warning['type'] == 'path_warning' for warning in report.warnings)
     assert local_validate.report_status(report) == 'warn'
     assert local_validate.report_merge_ready(report) is False
 
@@ -163,17 +161,16 @@ def test_json_output_is_detailed_and_stdout_stays_parseable(
     folder = tmp_path / 'flat'
     write_json(folder / 'results.json', valid_aggregate())
 
-    exit_code = local_validate.main(
-        ['--format', 'json', folder.as_posix()]
-    )
+    exit_code = local_validate.main(['--format', 'json', folder.as_posix()])
 
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
-    assert exit_code == 0
+    assert exit_code == 2
     assert payload['validator']['scope'] == 'local'
     assert payload['validator']['schema_version']
     assert payload['validator']['schema_fingerprint']
     assert payload['summary']['warned'] == 1
+    assert payload['summary']['exit_code'] == 2
     assert payload['summary']['merge_ready'] is False
     assert payload['reports'][0]['status'] == 'warn'
     warning = payload['reports'][0]['warnings'][0]
@@ -184,18 +181,17 @@ def test_json_output_is_detailed_and_stdout_stays_parseable(
 
 
 def test_json_output_describes_input_errors(tmp_path: Path, capsys):
-    exit_code = local_validate.main(
-        ['--format', 'json', tmp_path.as_posix()]
-    )
+    exit_code = local_validate.main(['--format', 'json', tmp_path.as_posix()])
 
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert exit_code == 1
     assert payload['summary']['errors'] == 1
+    assert payload['summary']['exit_code'] == 1
     assert payload['summary']['merge_ready'] is False
     assert payload['input_errors'][0]['type'] == 'input_error'
-    assert 'contains no .json or .jsonl' in (
-        payload['input_errors'][0]['message']
+    assert (
+        'contains no .json or .jsonl' in (payload['input_errors'][0]['message'])
     )
 
 
@@ -204,9 +200,7 @@ def test_json_output_gives_agents_field_level_errors(tmp_path: Path, capsys):
     del aggregate['evaluation_id']
     path = write_json(tmp_path / 'results.json', aggregate)
 
-    exit_code = local_validate.main(
-        ['--format', 'json', path.as_posix()]
-    )
+    exit_code = local_validate.main(['--format', 'json', path.as_posix()])
 
     payload = json.loads(capsys.readouterr().out)
     error = payload['reports'][0]['errors'][0]
@@ -246,7 +240,7 @@ def test_json_log_keeps_individual_warning_details(tmp_path: Path, capsys):
 
     captured = capsys.readouterr()
     payload = json.loads(log_path.read_text(encoding='utf-8'))
-    assert exit_code == 0
+    assert exit_code == 2
     assert payload['summary']['warned'] == 1
     assert payload['reports'][0]['file'] == str(path)
     assert payload['reports'][0]['warnings']
@@ -260,6 +254,15 @@ def test_rich_output_marks_warning_only_run(tmp_path: Path, capsys):
     exit_code = local_validate.main([path.as_posix()])
 
     captured = capsys.readouterr()
-    assert exit_code == 0
+    assert exit_code == 2
     assert 'WARN' in captured.out
     assert 'not merge-ready' in captured.out
+
+
+def test_clean_run_exits_zero(tmp_path: Path, capsys):
+    path = canonical_aggregate(tmp_path)
+
+    exit_code = local_validate.main([path.as_posix()])
+
+    assert exit_code == 0
+    assert '1 passed, 0 warning-only, 0 failed' in capsys.readouterr().out

--- a/tests/test_local_validate.py
+++ b/tests/test_local_validate.py
@@ -219,6 +219,41 @@ def test_json_output_gives_agents_field_level_errors(tmp_path: Path, capsys):
     assert 'input' in error
 
 
+def test_rich_output_groups_repeated_errors(tmp_path: Path, capsys):
+    folder = tmp_path / 'flat'
+    aggregate = valid_aggregate()
+    del aggregate['evaluation_id']
+    write_json(folder / 'first.json', aggregate)
+    write_json(folder / 'second.json', aggregate)
+
+    exit_code = local_validate.main([folder.as_posix()])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert '0 passed, 0 warning-only, 2 failed' in captured.out
+    assert 'Errors: 1 group(s), 2 occurrence(s)' in captured.out
+    assert '2 occurrence(s) in 2 file(s)' in captured.out
+
+
+def test_json_log_keeps_individual_warning_details(tmp_path: Path, capsys):
+    folder = tmp_path / 'flat'
+    path = write_json(folder / 'results.json', valid_aggregate())
+    log_path = tmp_path / 'reports' / 'local-validation.json'
+
+    exit_code = local_validate.main(
+        ['--json-log', log_path.as_posix(), path.as_posix()]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(log_path.read_text(encoding='utf-8'))
+    assert exit_code == 0
+    assert payload['summary']['warned'] == 1
+    assert payload['reports'][0]['file'] == str(path)
+    assert payload['reports'][0]['warnings']
+    assert payload['reports'][0]['warnings'][0]['message']
+    assert f'Detailed JSON log: {log_path}' in captured.err
+
+
 def test_rich_output_marks_warning_only_run(tmp_path: Path, capsys):
     path = write_json(tmp_path / 'results.json', valid_aggregate())
 

--- a/tests/test_local_validate.py
+++ b/tests/test_local_validate.py
@@ -1,0 +1,230 @@
+"""Tests for the standalone local folder validator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import local_validate
+from tests.test_validation_scope import UUID, valid_aggregate, valid_sample
+
+
+def write_json(path: Path, data: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding='utf-8')
+    return path
+
+
+def write_jsonl(path: Path, rows: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ''.join(f'{json.dumps(row)}\n' for row in rows),
+        encoding='utf-8',
+    )
+    return path
+
+
+def canonical_aggregate(tmp_path: Path) -> Path:
+    return write_json(
+        tmp_path / 'data' / 'bench' / 'dev' / 'model' / f'{UUID}.json',
+        valid_aggregate(),
+    )
+
+
+def test_canonical_record_is_merge_ready(tmp_path: Path):
+    report = local_validate.validate_local_file(canonical_aggregate(tmp_path))
+
+    assert report.valid is True
+    assert report.errors == []
+    assert report.warnings == []
+    assert local_validate.report_status(report) == 'pass'
+    assert local_validate.report_merge_ready(report) is True
+
+
+def test_noncanonical_record_is_valid_but_not_merge_ready(tmp_path: Path):
+    path = write_json(tmp_path / 'results.json', valid_aggregate())
+
+    report = local_validate.validate_local_file(path)
+
+    assert report.valid is True
+    assert report.errors == []
+    assert report.warnings
+    assert all(
+        warning['type'] == 'path_warning' for warning in report.warnings
+    )
+    assert local_validate.report_status(report) == 'warn'
+    assert local_validate.report_merge_ready(report) is False
+
+
+def test_non_uuid_filename_is_advisory_in_canonical_tree(tmp_path: Path):
+    path = write_json(
+        tmp_path / 'data' / 'bench' / 'dev' / 'model' / 'results.json',
+        valid_aggregate(),
+    )
+
+    report = local_validate.validate_local_file(path)
+
+    assert report.valid is True
+    assert any('UUID4' in warning['msg'] for warning in report.warnings)
+
+
+def test_wrong_canonical_depth_is_advisory(tmp_path: Path):
+    path = write_json(
+        tmp_path / 'data' / 'bench' / 'model' / f'{UUID}.json',
+        valid_aggregate(),
+    )
+
+    report = local_validate.validate_local_file(path)
+
+    assert report.valid is True
+    assert report.errors == []
+    assert len(report.warnings) == 1
+    assert 'Unexpected path depth' in report.warnings[0]['msg']
+
+
+def test_arbitrary_folder_uses_physical_companion(tmp_path: Path):
+    folder = tmp_path / 'arbitrary' / 'output'
+    aggregate_path = folder / f'{UUID}.json'
+    sample_path = folder / f'{UUID}_samples.jsonl'
+    aggregate = valid_aggregate()
+    aggregate['detailed_evaluation_results'] = {
+        'format': 'jsonl',
+        'file_path': f'data/bench/dev/model/{UUID}_samples.jsonl',
+        'total_rows': 1,
+    }
+    write_json(aggregate_path, aggregate)
+    write_jsonl(sample_path, [valid_sample()])
+
+    aggregate_report = local_validate.validate_local_file(aggregate_path)
+    sample_report = local_validate.validate_local_file(sample_path)
+
+    assert aggregate_report.valid is True, aggregate_report.errors
+    assert sample_report.valid is True, sample_report.errors
+    assert aggregate_report.warnings
+    assert sample_report.warnings
+
+
+def test_companion_content_mismatch_remains_blocking(tmp_path: Path):
+    folder = tmp_path / 'flat'
+    aggregate_path = folder / f'{UUID}.json'
+    sample_path = folder / f'{UUID}_samples.jsonl'
+    aggregate = valid_aggregate()
+    aggregate['detailed_evaluation_results'] = {
+        'format': 'jsonl',
+        'file_path': f'data/bench/dev/model/{UUID}_samples.jsonl',
+        'total_rows': 2,
+    }
+    write_json(aggregate_path, aggregate)
+    write_jsonl(sample_path, [valid_sample()])
+
+    report = local_validate.validate_local_file(aggregate_path)
+
+    assert report.valid is False
+    assert any('total_rows' in error['loc'] for error in report.errors)
+    assert local_validate.report_status(report) == 'fail'
+
+
+def test_registered_semantic_rules_are_not_bypassed(tmp_path: Path):
+    aggregate = valid_aggregate()
+    del aggregate['model_info']['additional_details']['deployment_type']
+    path = write_json(tmp_path / f'{UUID}.json', aggregate)
+
+    report = local_validate.validate_local_file(path)
+
+    assert report.valid is False
+    assert any('deployment_type' in error['msg'] for error in report.errors)
+
+
+def test_recursive_discovery_skips_hidden_and_linked_directories(
+    tmp_path: Path,
+):
+    wanted = write_json(tmp_path / 'nested' / 'wanted.json', valid_aggregate())
+    write_json(tmp_path / '.venv' / 'ignored.json', valid_aggregate())
+    link = tmp_path / 'linked'
+    link.symlink_to(wanted.parent, target_is_directory=True)
+
+    paths = local_validate.expand_inputs([str(tmp_path), str(wanted)])
+
+    assert paths == [wanted]
+
+
+def test_unrelated_json_is_validated_not_skipped(tmp_path: Path):
+    path = write_json(tmp_path / 'package.json', {'name': 'not-an-eval'})
+
+    report = local_validate.validate_local_file(path)
+
+    assert report.valid is False
+    assert report.errors
+
+
+def test_json_output_is_detailed_and_stdout_stays_parseable(
+    tmp_path: Path, capsys
+):
+    folder = tmp_path / 'flat'
+    write_json(folder / 'results.json', valid_aggregate())
+
+    exit_code = local_validate.main(
+        ['--format', 'json', folder.as_posix()]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload['validator']['scope'] == 'local'
+    assert payload['validator']['schema_version']
+    assert payload['validator']['schema_fingerprint']
+    assert payload['summary']['warned'] == 1
+    assert payload['summary']['merge_ready'] is False
+    assert payload['reports'][0]['status'] == 'warn'
+    warning = payload['reports'][0]['warnings'][0]
+    assert set(warning) == {'type', 'location', 'message', 'input'}
+    assert warning['type'] == 'path_warning'
+    assert warning['message']
+    assert 'validating 1 file(s)' in captured.err
+
+
+def test_json_output_describes_input_errors(tmp_path: Path, capsys):
+    exit_code = local_validate.main(
+        ['--format', 'json', tmp_path.as_posix()]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 1
+    assert payload['summary']['errors'] == 1
+    assert payload['summary']['merge_ready'] is False
+    assert payload['input_errors'][0]['type'] == 'input_error'
+    assert 'contains no .json or .jsonl' in (
+        payload['input_errors'][0]['message']
+    )
+
+
+def test_json_output_gives_agents_field_level_errors(tmp_path: Path, capsys):
+    aggregate = valid_aggregate()
+    del aggregate['evaluation_id']
+    path = write_json(tmp_path / 'results.json', aggregate)
+
+    exit_code = local_validate.main(
+        ['--format', 'json', path.as_posix()]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    error = payload['reports'][0]['errors'][0]
+    assert exit_code == 1
+    assert payload['reports'][0]['status'] == 'fail'
+    assert payload['summary']['merge_ready'] is False
+    assert error['type']
+    assert 'evaluation_id' in error['location']
+    assert error['message']
+    assert 'input' in error
+
+
+def test_rich_output_marks_warning_only_run(tmp_path: Path, capsys):
+    path = write_json(tmp_path / 'results.json', valid_aggregate())
+
+    exit_code = local_validate.main([path.as_posix()])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert 'WARN' in captured.out
+    assert 'not merge-ready' in captured.out

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
+import io
 import json
 from pathlib import Path
 
 import pytest
+from rich.console import Console
 
 from every_eval_ever.schema import get_schema_version
 from every_eval_ever.validate import (
+    ValidationReport,
     expand_paths,
     main,
     render_report_github,
     render_report_json,
+    render_report_rich,
+    render_summary_rich,
 )
 from every_eval_ever.validate import (
     validate_aggregate as _validate_aggregate,
@@ -439,6 +444,88 @@ class TestOutputFormats:
         report = validate_file(fp)
         output = render_report_github([report])
         assert output == ''
+
+
+class TestWarningVisibility:
+    @staticmethod
+    def render(report: ValidationReport, *, color: bool = False) -> str:
+        stream = io.StringIO()
+        console = Console(
+            file=stream,
+            width=100,
+            no_color=not color,
+            force_terminal=color,
+            legacy_windows=False,
+        )
+        render_report_rich(report, console)
+        render_summary_rich([report], console)
+        return stream.getvalue()
+
+    @staticmethod
+    def passing_report(
+        warnings: list[dict[str, str]],
+    ) -> ValidationReport:
+        return ValidationReport(
+            file_path=Path('data/bench/dev/model/x.json'),
+            valid=True,
+            file_type='aggregate',
+            warnings=warnings,
+        )
+
+    def test_warning_only_file_is_visible_as_warn(self):
+        output = self.render(
+            self.passing_report(
+                [
+                    {
+                        'loc': 'evaluation_results[0].metric_config',
+                        'msg': 'something worth a second look',
+                        'type': 'semantic_warning',
+                    }
+                ]
+            )
+        )
+
+        assert 'WARN' in output
+        assert 'PASS' not in output
+        assert 'something worth a second look' in output
+        assert 'evaluation_results[0].metric_config' in output
+
+    def test_warning_summary_matches_local_validator_states(self):
+        output = self.render(
+            self.passing_report(
+                [{'loc': '', 'msg': 'first', 'type': 'semantic_warning'}]
+            )
+        )
+
+        assert '0 passed, 1 warning-only, 0 failed' in output
+        assert '1 warnings' in output
+        assert 'not merge-ready' in output
+
+    def test_clean_pass_stays_clean(self):
+        output = self.render(self.passing_report([]))
+
+        assert 'PASS' in output
+        assert 'WARN' not in output
+        assert '1 passed, 0 warning-only, 0 failed' in output
+
+    def test_failure_with_warning_stays_red(self):
+        report = ValidationReport(
+            file_path=Path('data/bench/dev/model/x.json'),
+            valid=False,
+            file_type='aggregate',
+            errors=[
+                {'loc': 'model_info', 'msg': 'boom', 'type': 'value_error'}
+            ],
+            warnings=[{'loc': '', 'msg': 'first', 'type': 'semantic_warning'}],
+        )
+
+        output = self.render(report, color=True)
+
+        assert 'FAIL' in output
+        assert '0 passed, 0 warning-only, 1 failed' in output
+        assert '1 warnings' in output
+        assert '\x1b[1;31m' in output
+        assert '\x1b[1;33m' not in output
 
 
 class TestExitCode:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -529,14 +529,54 @@ class TestWarningVisibility:
 
 
 class TestExitCode:
-    def test_exit_code_0_on_pass(self, tmp_path: Path):
-        fp = _write_json(tmp_path, 'pass.json', VALID_AGGREGATE)
-        report = validate_file(fp)
-        assert report.valid is True
+    def test_exit_code_0_on_clean_pass(self, tmp_path: Path):
+        path = (
+            tmp_path
+            / 'data'
+            / 'benchmark'
+            / 'developer'
+            / 'model'
+            / 'f82b2807-fb31-4e42-a4a4-497d7d7a7e61.json'
+        )
+        path.parent.mkdir(parents=True)
+        payload = {
+            **VALID_AGGREGATE,
+            'model_info': {
+                'name': 'test-model',
+                'id': 'org/test-model',
+                'developer': 'org',
+                'additional_details': {
+                    'deployment_type': 'unknown',
+                    'model_availability': 'unknown',
+                },
+            },
+        }
+        path.write_text(json.dumps(payload), encoding='utf-8')
+
+        assert main([str(path), '--format', 'json']) == 0
+
+    def test_exit_code_2_on_warning_only(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        fp = _write_json(tmp_path, 'warning.json', VALID_AGGREGATE)
+        report = ValidationReport(
+            file_path=fp,
+            valid=True,
+            file_type='aggregate',
+            warnings=[
+                {'loc': 'model_info', 'msg': 'fix me', 'type': 'warning'}
+            ],
+        )
+        monkeypatch.setattr(
+            'every_eval_ever.validator.validate.validate_file',
+            lambda *args, **kwargs: report,
+        )
+
+        assert main([str(fp), '--format', 'json']) == 2
 
     def test_exit_code_1_on_failure(self, tmp_path: Path):
         data = {**VALID_AGGREGATE}
         del data['evaluation_id']
         fp = _write_json(tmp_path, 'fail.json', data)
-        report = validate_file(fp)
-        assert report.valid is False
+
+        assert main([str(fp), '--format', 'json']) == 1


### PR DESCRIPTION
## What / source

Adds a standalone local validation frontend at `scripts/local_validate.py` and fixes warning visibility and merge blocking in the existing package Rich CLI.

The standalone frontend accepts files, globs, and arbitrarily nested folders, consumes the live validation core, and does not access PRs. Its terminal view starts with pass, warning-only, and failure counts, then groups identical findings with occurrence and affected-file counts. Detailed per-file diagnostics remain available through JSON stdout or `--json-log PATH`.

Both CLIs use the same three-state contract: clean PASS exits `0`, blocking FAIL exits `1`, and warning-only WARN exits `2`. Successful schema validation never hides warnings: warnings remain distinct from errors but block merge until fixed. Standalone JSON includes the exit code, merge readiness, grouped counts, and individual field-level diagnostics for agents.

The PR-based Hugging Face Space remains a separate frontend. Its matching warning visibility and blocking readiness changes are merged in [eee_validator Space PR #2](https://huggingface.co/spaces/evaleval/eee_validator/discussions/2) and [Space PR #3](https://huggingface.co/spaces/evaleval/eee_validator/discussions/3).

## Review lane

**Needs a human.** This adds a contributor-facing validation interface and changes warning-only CLI exit behavior from `0` to `2`, without changing schema validity or shared validator findings.

Design agreed in: scoped directly with the maintainer before implementation; no public issue link.

## Key boundaries

- `validation_core` and `REGISTERED_CHECKS` are unchanged
- schema validity and validation findings are unchanged
- warning-only is valid data but not merge-ready
- new schema and registered semantic rules propagate through `validate_file`
- no PR access, network access, uploads, or new dependencies in the local tool
- Space and local interfaces remain separate consumers of the shared package logic

## Verification

- package repository: 466 tests passed
- focused package-validator, local-validator, and skill-conversion tests: 59 passed
- Space: 61 tests and 10 subtests passed before PR #3 merged
- Ruff and format checks passed in both repositories
- `git diff --check` passed
- all four GitHub CI jobs pass

## Checklist

- [x] package and standalone warning behavior covered by offline tests
- [x] successful files cannot hide warnings
- [x] warning-only runs block automation with exit `2`
- [x] Space warning-only results expose `validation_status=warn` and `merge_ready=false`
- [x] full pytest suite green
- [x] Ruff green
- [x] documentation added
- [x] no schema, generated type, adapter, or datastore output changes