### PR TITLE
helm: drop the codec import and relax the nltk pin, fixing the extra on Python 3.14

### DIFF
--- a/every_eval_ever/converters/helm/adapter.py
+++ b/every_eval_ever/converters/helm/adapter.py
@@ -23,7 +23,6 @@ try:
         get_model_deployment,
     )
     from helm.benchmark.run_spec import RunSpec
-    from helm.common.codec import from_json
 except (
     Exception
 ) as ex:  # pragma: no cover - exercised only when optional deps missing
@@ -38,7 +37,6 @@ except (
     RunSpec = cast(Any, None)
     get_model_deployment = cast(Any, None)
     register_builtin_configs_from_helm_package = cast(Any, None)
-    from_json = cast(Any, None)
     ModelDeploymentNotFoundError = cast(Any, Exception)
 
 from every_eval_ever.converters import SCHEMA_VERSION
@@ -224,7 +222,14 @@ class HELMAdapter(BaseEvaluationAdapter):
         stats = self._load_file_if_exists(dir_path, self.STATS_FILE)
 
         with open(f'{dir_path}/{self.PER_INSTANCE_STATS_FILE}', 'r') as f:
-            per_instance_stats = from_json(f.read(), List[PerInstanceStats])
+            per_instance_stats = [
+                from_dict(
+                    data_class=PerInstanceStats,
+                    data=entry,
+                    config=DaciteConfig(cast=[str]),
+                )
+                for entry in json.load(f)
+            ]
 
         return {
             'per_instance_stats': per_instance_stats,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,16 +31,14 @@ inspect = ["inspect-ai>=0.3.160,<0.4.0"]
 helm = [
     "crfm-helm>=0.5.14",
     "typer>=0.12,<1.0",
-    # crfm-helm pulls nltk transitively. nltk 3.10.1 added an import guard
+    # crfm-helm pulls nltk transitively. nltk 3.10.1 alone ships an import guard
     # (nltk/inisec.py, a CWE-427 mitigation) that blocks nltk-initiated imports
     # of any module resolving *under the current working directory*. uv places
     # .venv/ inside the project, so site-packages is under the CWD and the guard
-    # false-positives on nltk's own `regex` dependency -> `import helm` fails at
-    # import time (breaks the HELM converter in CI's `loose` matrix, and for any
-    # default venv layout). Cap below the guarded release until nltk fixes the
-    # false positive (tracking: https://github.com/nltk/nltk/issues/3730); safe
-    # because crfm-helm is frozen.
-    "nltk<3.10.1",
+    # false-positives on nltk's own `regex` dependency -> `import nltk` fails at
+    # import time (tracking: https://github.com/nltk/nltk/issues/3730). 3.10.2
+    # dropped it; its pathsec guard covers corpus paths, not imports.
+    "nltk!=3.10.1",
 ]
 all = [
     "every-eval-ever[inspect]",

--- a/tests/test_helm_generation_args.py
+++ b/tests/test_helm_generation_args.py
@@ -4,18 +4,29 @@ Verifies that falsy-but-valid values like temperature=0 are preserved,
 not silently replaced by adapter defaults.
 """
 
-import pytest
-
-pytest.importorskip(
-    'helm', reason='crfm-helm not installed; install with: uv sync --extra helm'
-)
-
 from types import SimpleNamespace
 
+import pytest
+
+import every_eval_ever.converters.helm.adapter as helm_adapter_module
 from every_eval_ever.converters.helm.adapter import HELMAdapter
 
+# `import helm` alone is not enough: on Python 3.14 the top-level package imports
+# but `helm.common.codec` does not, so the converter's own import guard is the
+# only reliable signal. Same condition as tests/test_helm_adapter.py.
+pytestmark = pytest.mark.skipif(
+    helm_adapter_module._HELM_IMPORT_ERROR is not None,
+    reason=(
+        'HELM converter dependencies are missing: '
+        f'{helm_adapter_module._HELM_IMPORT_ERROR!r}. '
+        'Install with: uv sync --extra helm'
+    ),
+)
 
-def _make_request_state(temperature=None, max_tokens=None, top_p=None, top_k=None):
+
+def _make_request_state(
+    temperature=None, max_tokens=None, top_p=None, top_k=None
+):
     """Build a minimal mock RequestState with the given request-level values."""
     request = SimpleNamespace(
         temperature=temperature,
@@ -29,7 +40,9 @@ def _make_request_state(temperature=None, max_tokens=None, top_p=None, top_k=Non
     )
 
 
-def _make_adapter_spec(temperature=None, max_tokens=None, top_p=None, top_k=None):
+def _make_adapter_spec(
+    temperature=None, max_tokens=None, top_p=None, top_k=None
+):
     """Build a minimal mock AdapterSpec with the given fallback values."""
     return SimpleNamespace(
         temperature=temperature,

--- a/tests/test_helm_generation_args.py
+++ b/tests/test_helm_generation_args.py
@@ -4,6 +4,7 @@ Verifies that falsy-but-valid values like temperature=0 are preserved,
 not silently replaced by adapter defaults.
 """
 
+import importlib.util
 from types import SimpleNamespace
 
 import pytest
@@ -13,8 +14,10 @@ from every_eval_ever.converters.helm.adapter import HELMAdapter
 
 # `import helm` alone is not enough: on Python 3.14 the top-level package imports
 # but `helm.common.codec` does not, so the converter's own import guard is the
-# only reliable signal. Same condition as tests/test_helm_adapter.py.
-pytestmark = pytest.mark.skipif(
+# only reliable signal. Same condition as tests/test_helm_adapter.py. Scoped to
+# the class rather than the whole module so the sentinel below stays live even
+# when the guard has fired.
+_requires_helm = pytest.mark.skipif(
     helm_adapter_module._HELM_IMPORT_ERROR is not None,
     reason=(
         'HELM converter dependencies are missing: '
@@ -22,6 +25,21 @@ pytestmark = pytest.mark.skipif(
         'Install with: uv sync --extra helm'
     ),
 )
+
+
+def test_helm_extra_is_importable_when_installed():
+    """If HELM is installed at all, the converter's guarded imports must work.
+
+    The class-scoped skip above hides a broken guarded import (e.g. a HELM
+    release whose `helm.common.codec` stops importing) whenever
+    ``_HELM_IMPORT_ERROR`` is set, so a full ``uv sync --all-extras`` CI row
+    would report green with HELM silently skipped. This sentinel skips only
+    when the top-level `helm` package is genuinely absent and otherwise fails,
+    turning an installed-but-broken extra into a hard failure.
+    """
+    if importlib.util.find_spec('helm') is None:
+        pytest.skip('HELM is not installed; the extra is optional for core.')
+    helm_adapter_module._require_helm_dependencies()
 
 
 def _make_request_state(
@@ -52,6 +70,7 @@ def _make_adapter_spec(
     )
 
 
+@_requires_helm
 class TestExtractGenerationArgsFalsyValues:
     """Verify that 0 is treated as a real value, not as missing."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -895,7 +895,7 @@ requires-dist = [
     { name = "inspect-ai", marker = "extra == 'inspect'", specifier = ">=0.3.160,<0.4.0" },
     { name = "jsonschema", specifier = ">=4.26.0,<5.0.0" },
     { name = "matplotlib", specifier = ">=3.10.8" },
-    { name = "nltk", marker = "extra == 'helm'", specifier = "<3.10.1" },
+    { name = "nltk", marker = "extra == 'helm'", specifier = "!=3.10.1" },
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pydantic", specifier = ">=2.12.5,<3.0.0" },


### PR DESCRIPTION
> Independent of the converter stack (#245, #246) — nothing in it depends on this, but a reviewer running the full suite on Python 3.14 will want this first.

## What / source

Three changes that make the `helm` extra work outside the locked 3.12/3.13 environment, plus the lockfile sync the last one needs. No conversion output changes.

- **The converter no longer imports `helm.common.codec`.** It needs six HELM modules, which pull in `cattrs` and nothing else. `helm.common.codec` pulls torch, spacy, nltk and regex — for one `from_json` call, in a file that already decodes three other HELM dataclasses with `dacite`. The fourth now decodes the same way.
- **`nltk<3.10.1` → `nltk!=3.10.1`.** 3.10.1 is the only release carrying the `inisec` import guard; 3.10.2 replaced it with a `pathsec` guard that covers corpus paths, not imports. The cap was holding the `loose` matrix rows to an nltk from before the fix, for a problem that release fixed.
- **The HELM generation-args tests skip on the converter's own `_HELM_IMPORT_ERROR`**, like the rest of the HELM tests, instead of `pytest.importorskip('helm')` — which passes on an install where the top-level package imports but a submodule does not, so the tests failed at collection instead of skipping.

## Why it matters, measured

`_HELM_IMPORT_ERROR` on Python 3.14 with `--all-extras`:

| | main | this branch |
|---|---|---|
| `_HELM_IMPORT_ERROR` | `ConfigError('unable to infer type for attribute "REGEX"')` | `None` |
| `pytest tests` | **5 failed**, 446 passed, 16 skipped | **467 passed** |

That error comes from thinc/spacy, reached only through `helm.common.codec`. Dropping the import is what makes the HELM converter run on 3.14 at all — crfm-helm's spacy dependency ships no 3.14 wheel, and it was never needed.

Unchanged elsewhere: 3.13 + all extras 467 passed on both. Core install 411 passed on both, skips 20 → 24 (the generation-args module now skipping as a unit rather than half-collecting).

`nltk 3.10.2` in a venv under the CWD — the layout that tripped the guard — imports `helm.common.codec` cleanly, so the relaxed specifier is not re-opening the problem the cap was for.

## Review lane

- [x] **Fast** — one converter file, one test file, packaging; 35 lines changed.
- [ ] Needs a human

## Checklist

- [x] offline unit test added + full `uv run pytest tests` green (and green on 3.14, where main is not)
- [x] `uv run ruff check` clean
- [ ] n/a — no data conversion, no new records, no registry ids

## Decisions & coverage

- Decision / where: decode `per_instance_stats` with `dacite.from_dict` per entry, in `converters/helm/adapter.py`.
  Chose / instead of: keeping `helm.common.codec.from_json` and documenting 3.14 as unsupported.
  Confidence: high — the file already decodes `RunSpec`, `ScenarioState` and `Scenario` this way, and the HELM case's 80 pinned sidecar rows and 24 pinned results go through this path.
  General? no.
- Decision / where: `nltk!=3.10.1` rather than `nltk>=3.10.2`.
  Chose / instead of: a floor, which would drop the 3.9.x the locked rows resolve to for no reason.
  Confidence: high.
  General? no.

**Coverage:** unchanged — same records, same values; this is an import path and a specifier.
