### PR TITLE
Report metric bounds, uncertainty and ids the way each harness computed them

### DIFF
--- a/every_eval_ever/converters/README.md
+++ b/every_eval_ever/converters/README.md
@@ -31,6 +31,38 @@ upstream passes it. Nor does it see a new upstream release — for that, a scrip
 mode (`--model dummy` for lm-eval, `--model mockllm/model` for Inspect) and converts
 that, on a schedule.
 
+### Naming a metric
+
+`metric_config.metric_id` is what a consumer joins on across sources, so the same
+quantity has to reach the same id from every converter. `converters/common/metrics.py`
+resolves that: a name the [eval-card-registry][registry] carries is published under the
+registry's canonical slug, and anything else under `<harness>.<name>`, marked
+`metric_id_status: unregistered` so it claims no global identity. Both forms record the
+registry revision they were resolved against.
+
+The map is resolved by hand rather than over the network, because a converter has to run
+offline and give the same answer every time. To re-check it against a registry checkout,
+and to list the metrics still waiting on an entry:
+
+```bash
+uv run python -m tools.verify_metric_ids --seed ../eval-card-registry/seed/metrics.yaml
+```
+
+It exits non-zero when a mapped id has left the registry, when a namespaced name has
+become resolvable, or when a name resolves to two entries. Adding entries is a pull
+request to the registry, not to this repository.
+
+Two rules worth stating, because both are easy to get wrong:
+
+- A parameter the harness spells into the name changes the metric's identity, not its
+  scale. HELM's `exact_match@5` is exact match over the best of five completions, and the
+  registry gives such metrics a slug of their own (`pass-at-1`, `recall-at-5`), so it
+  resolves its bounds from `exact_match` but never that metric's id.
+- Keeping two benchmarks' `accuracy` apart is `evaluation_name`'s job. Don't put the
+  benchmark in `metric_id`.
+
+[registry]: https://github.com/evaleval/eval-card-registry
+
 ### Inspect
 
 The conversion script from `Inspect AI` to the unified schema can be run using `every_eval_ever/converters/inspect/__main__.py`.

--- a/every_eval_ever/converters/common/metrics.py
+++ b/every_eval_ever/converters/common/metrics.py
@@ -173,6 +173,7 @@ _PERCENT_BOUNDS = (0.0, 100.0)
 
 _UNKNOWN_BOUNDS = {'bounds_status': 'unknown'}
 _NO_POLARITY = {'polarity': 'not_applicable'}
+_UNKNOWN_POLARITY = {'polarity': 'unknown'}
 _UNREGISTERED_ID = {'metric_id_status': 'unregistered'}
 # Both a resolved id and an unresolved one are claims about a registry state, so
 # each says which state it was: an `unregistered` marker with no revision beside
@@ -200,6 +201,13 @@ def metric_bounds_fields(
     details = dict(_NO_POLARITY) if name in DISPERSION_METRICS else {}
 
     if bounds is None:
+        # `lower_is_better` is required, so an unrecognized metric defaults to
+        # False; for one whose direction we cannot resolve that default is a
+        # guess a ranking consumer would misread as an asserted "higher is
+        # better", so it is marked like an unresolved range. A known direction
+        # (LOWER_IS_BETTER) or an inapplicable one (dispersion) keeps its answer.
+        if name not in LOWER_IS_BETTER and name not in DISPERSION_METRICS:
+            details = {**details, **_UNKNOWN_POLARITY}
         return {
             'lower_is_better': name in LOWER_IS_BETTER,
             'additional_details': {**details, **_UNKNOWN_BOUNDS},

--- a/every_eval_ever/converters/common/metrics.py
+++ b/every_eval_ever/converters/common/metrics.py
@@ -39,7 +39,9 @@ SHARED_METRIC_BOUNDS: dict[str, tuple[float, float]] = {
     'precision': (0.0, 1.0),
     'recall': (0.0, 1.0),
     'mcc': (-1.0, 1.0),
-    'brier_score': (0.0, 1.0),
+    # Not [0, 1]: the multi-class Brier score sums the squared error over every
+    # class, so all the mass on one wrong class costs 2.0.
+    'brier_score': (0.0, 2.0),
     # Dispersion of a score distribution, not a score: non-negative, and
     # unbounded above unless the underlying metric is bounded.
     'std': (0.0, float('inf')),

--- a/every_eval_ever/converters/common/metrics.py
+++ b/every_eval_ever/converters/common/metrics.py
@@ -35,6 +35,7 @@ SHARED_METRIC_BOUNDS: dict[str, tuple[float, float]] = {
     'std': (0.0, float('inf')),
     'stddev': (0.0, float('inf')),
     'stderr': (0.0, float('inf')),
+    'bootstrap_stderr': (0.0, float('inf')),
     'var': (0.0, float('inf')),
 }
 
@@ -59,7 +60,7 @@ LOWER_IS_BETTER: frozenset[str] = frozenset(
 # (`uncertainty.standard_error`, `uncertainty.standard_deviation`), so a
 # converter should prefer routing them there over emitting them as scores.
 DISPERSION_METRICS: frozenset[str] = frozenset(
-    {'std', 'stddev', 'stderr', 'var'}
+    {'std', 'stddev', 'stderr', 'bootstrap_stderr', 'var'}
 )
 
 _UNKNOWN_BOUNDS = {'bounds_status': 'unknown'}

--- a/every_eval_ever/converters/common/metrics.py
+++ b/every_eval_ever/converters/common/metrics.py
@@ -1,4 +1,4 @@
-"""What a metric's name tells us about its range and its polarity.
+"""What a metric's name tells us about its identity, its range and its polarity.
 
 Upstream harnesses report a metric's value and almost never its range, so the
 range has to come from the metric's definition. The names below mean the same
@@ -11,6 +11,16 @@ reports 0-100 while nltk's `sentence_bleu` (HELM's `bleu_1`/`bleu_4`) reports
 A metric that is in no table gets no bounds at all and a `bounds_status` marker,
 because `min_score`/`max_score` are nullable and "not provided" is true, while
 [0, 1] on an unbounded metric is not.
+
+`metric_id` is the field a consumer joins on across sources, so a metric that
+means the same thing in two harnesses has to arrive under the same id. That id
+is the eval-card-registry's canonical metric slug, resolved once by hand into
+`CANONICAL_METRIC_IDS` rather than over the network, because a converter has to
+run offline and give the same answer every time. Anything the registry does not
+carry gets `<harness>.<name>`, which is a stable join key within the harness and
+claims no global identity; `metric_id_status` marks those so the set needing a
+registry entry can be listed. Re-check the map against a registry checkout with
+`uv run python -m tools.verify_metric_ids --seed <registry>/seed/metrics.yaml`.
 """
 
 from __future__ import annotations
@@ -63,8 +73,109 @@ DISPERSION_METRICS: frozenset[str] = frozenset(
     {'std', 'stddev', 'stderr', 'bootstrap_stderr', 'var'}
 )
 
+# The eval-card-registry commit these ids were resolved against, on that repo's
+# main branch so anyone can check out the state that produced them. Bump it with
+# the map.
+METRIC_ID_REGISTRY_REVISION = '8b83e9c'
+
+# Harness metric name -> canonical registry metric id, matched case- and
+# separator-insensitively against each entry's id, display_name and aliases.
+# Only names the registry actually carries appear here; the rest are namespaced.
+CANONICAL_METRIC_IDS: dict[str, str] = {
+    'acc': 'accuracy',
+    'accuracy': 'accuracy',
+    'bleu': 'bleu',
+    'bleu_1': 'bleu-1',
+    'bleu_4': 'bleu-4',
+    'cer': 'cer',
+    'em': 'exact-match',
+    'exact_match': 'exact-match',
+    'f1': 'f1',
+    'f1_score': 'f1',
+    'perplexity': 'perplexity',
+    'precision': 'precision',
+    'recall': 'recall',
+    'rouge1': 'rouge-1',
+    'rouge2': 'rouge-2',
+    'rougeL': 'rouge-l',
+    'rouge_l': 'rouge-l',
+    'wer': 'wer',
+}
+
+# The family a metric aggregates safely within. Coarse on purpose: it says two
+# numbers are the same kind of quantity, not that they are comparable, which is
+# `evaluation_name`'s business. A metric whose family we would have to invent is
+# absent rather than guessed.
+METRIC_KINDS: dict[str, str] = {
+    'acc': 'accuracy',
+    'acc_norm': 'accuracy',
+    'accuracy': 'accuracy',
+    'chain_of_thought_correctness': 'accuracy',
+    'em': 'accuracy',
+    'exact_match': 'accuracy',
+    'ifeval_strict_accuracy': 'accuracy',
+    'math_equiv': 'accuracy',
+    'math_equiv_chain_of_thought': 'accuracy',
+    'mc1': 'accuracy',
+    'prefix_exact_match': 'accuracy',
+    'quasi_exact_match': 'accuracy',
+    'quasi_prefix_exact_match': 'accuracy',
+    'classification_macro_f1': 'f1',
+    'classification_micro_f1': 'f1',
+    'f1': 'f1',
+    'f1_score': 'f1',
+    'precision': 'precision',
+    'recall': 'recall',
+    'mcc': 'correlation',
+    'brier_score': 'brier_score',
+    'calibration_error': 'calibration_error',
+    'ece': 'calibration_error',
+    'bleu': 'text_overlap',
+    'bleu_1': 'text_overlap',
+    'bleu_4': 'text_overlap',
+    'chrf': 'text_overlap',
+    'rouge1': 'text_overlap',
+    'rouge2': 'text_overlap',
+    'rougeL': 'text_overlap',
+    'rougeLsum': 'text_overlap',
+    'rouge_l': 'text_overlap',
+    'cer': 'edit_distance',
+    'ter': 'edit_distance',
+    'wer': 'edit_distance',
+    'byte_perplexity': 'perplexity',
+    'perplexity': 'perplexity',
+    'word_perplexity': 'perplexity',
+    'bits_per_byte': 'compression_rate',
+    'std': 'dispersion',
+    'stddev': 'dispersion',
+    'stderr': 'dispersion',
+    'var': 'dispersion',
+    'bootstrap_stderr': 'dispersion',
+}
+
+# A unit that does not follow from the metric's resolved range. Everything on
+# exactly [0, 1] is a proportion and everything on exactly [0, 100] a percent,
+# which is derived rather than listed, so the same name reports the unit of
+# whichever harness table won: lm-eval's sacrebleu `bleu` is a percent and
+# HELM's nltk `bleu_1` a proportion, from their bounds alone. Listed here are
+# the metrics whose scale their bounds cannot show, such as a sacrebleu metric
+# that is percent-scaled but may exceed 100.
+METRIC_UNITS: dict[str, str] = {
+    'bits_per_byte': 'bits_per_byte',
+    'chrf': 'percent',
+    'ter': 'percent',
+}
+
+_PROPORTION_BOUNDS = (0.0, 1.0)
+_PERCENT_BOUNDS = (0.0, 100.0)
+
 _UNKNOWN_BOUNDS = {'bounds_status': 'unknown'}
 _NO_POLARITY = {'polarity': 'not_applicable'}
+_UNREGISTERED_ID = {'metric_id_status': 'unregistered'}
+# Both a resolved id and an unresolved one are claims about a registry state, so
+# each says which state it was: an `unregistered` marker with no revision beside
+# it does not tell a reader whether the entry has since been added.
+_ID_REVISION = {'metric_id_registry_revision': METRIC_ID_REGISTRY_REVISION}
 
 
 def metric_bounds_fields(
@@ -96,6 +207,70 @@ def metric_bounds_fields(
         'score_type': ScoreType.continuous,
         'min_score': bounds[0],
         'max_score': bounds[1],
+        'additional_details': details or None,
+    }
+
+
+def metric_unit(
+    metric_name: str | None, bounds: tuple[float, float] | None
+) -> str | None:
+    """The unit a metric's values are expressed in, where its scale states it."""
+    listed = METRIC_UNITS.get(metric_name or '')
+    if listed:
+        return listed
+    if bounds == _PROPORTION_BOUNDS:
+        return 'proportion'
+    if bounds == _PERCENT_BOUNDS:
+        return 'percent'
+    return None
+
+
+def metric_config_fields(
+    metric_name: str | None,
+    *,
+    harness: str,
+    bounds_table: dict[str, tuple[float, float]] | None = None,
+    lookup_name: str | None = None,
+    metric_parameters: dict[str, str | float | bool | None] | None = None,
+) -> dict[str, object]:
+    """The `MetricConfig` fields that follow from one metric's name.
+
+    Spread into a `MetricConfig(...)` call alongside the fields only the harness
+    knows. `lookup_name` is the name the tables are keyed on, for a harness that
+    decorates the reported name with something that does not change the metric
+    (HELM's `exact_match@5`); `metric_name` is still what gets published.
+    """
+    reported = metric_name or ''
+    name = lookup_name if lookup_name is not None else reported
+    table = (
+        {**SHARED_METRIC_BOUNDS, **bounds_table}
+        if bounds_table
+        else SHARED_METRIC_BOUNDS
+    )
+    bounds = table.get(name)
+    # A parameter the harness spelled into the name leaves the metric's scale
+    # alone but not its identity: HELM's `exact_match@5` is exact match over the
+    # best of five completions, which is a different and higher quantity than
+    # `exact_match`, and the registry gives such a metric a slug of its own
+    # (`pass-at-1`, `recall-at-5`). So the range comes from the undecorated name
+    # while the id may not, or a join on `exact-match` would average the two.
+    canonical = CANONICAL_METRIC_IDS.get(name) if name == reported else None
+
+    fields = metric_bounds_fields(name, bounds_table)
+    details = dict(fields.pop('additional_details') or {})
+    if reported:
+        details.update(_ID_REVISION)
+        if canonical is None:
+            details.update(_UNREGISTERED_ID)
+
+    return {
+        **fields,
+        'metric_id': (canonical or f'{harness}.{reported}')
+        if reported
+        else None,
+        'metric_kind': METRIC_KINDS.get(name),
+        'metric_unit': metric_unit(name, bounds),
+        'metric_parameters': metric_parameters or None,
         'additional_details': details or None,
     }
 

--- a/every_eval_ever/converters/common/metrics.py
+++ b/every_eval_ever/converters/common/metrics.py
@@ -1,0 +1,108 @@
+"""What a metric's name tells us about its range and its polarity.
+
+Upstream harnesses report a metric's value and almost never its range, so the
+range has to come from the metric's definition. The names below mean the same
+thing in every harness we convert, so their bounds are shared; anything whose
+scale is harness-specific belongs in that converter's own table, layered on top
+of `SHARED_METRIC_BOUNDS`. `bleu` is the cautionary example: sacrebleu (lm-eval)
+reports 0-100 while nltk's `sentence_bleu` (HELM's `bleu_1`/`bleu_4`) reports
+0-1, so the bare name cannot carry a range.
+
+A metric that is in no table gets no bounds at all and a `bounds_status` marker,
+because `min_score`/`max_score` are nullable and "not provided" is true, while
+[0, 1] on an unbounded metric is not.
+"""
+
+from __future__ import annotations
+
+from every_eval_ever.eval_types import ScoreType
+
+# Infinite bounds are serialized as the JSON strings "Infinity"/"-Infinity".
+SHARED_METRIC_BOUNDS: dict[str, tuple[float, float]] = {
+    'accuracy': (0.0, 1.0),
+    'acc': (0.0, 1.0),
+    'acc_norm': (0.0, 1.0),
+    'em': (0.0, 1.0),
+    'exact_match': (0.0, 1.0),
+    'f1': (0.0, 1.0),
+    'f1_score': (0.0, 1.0),
+    'precision': (0.0, 1.0),
+    'recall': (0.0, 1.0),
+    'mcc': (-1.0, 1.0),
+    'brier_score': (0.0, 1.0),
+    # Dispersion of a score distribution, not a score: non-negative, and
+    # unbounded above unless the underlying metric is bounded.
+    'std': (0.0, float('inf')),
+    'stddev': (0.0, float('inf')),
+    'stderr': (0.0, float('inf')),
+    'var': (0.0, float('inf')),
+}
+
+# Metrics whose definition fixes the direction, so no harness has to say so.
+LOWER_IS_BETTER: frozenset[str] = frozenset(
+    {
+        'bits_per_byte',
+        'brier_score',
+        'byte_perplexity',
+        'calibration_error',
+        'cer',
+        'ece',
+        'perplexity',
+        'ter',
+        'wer',
+        'word_perplexity',
+    }
+)
+
+# Metrics that summarize the spread of a score distribution. "Better" does not
+# apply to them, and the schema has fields for them on the score they describe
+# (`uncertainty.standard_error`, `uncertainty.standard_deviation`), so a
+# converter should prefer routing them there over emitting them as scores.
+DISPERSION_METRICS: frozenset[str] = frozenset(
+    {'std', 'stddev', 'stderr', 'var'}
+)
+
+_UNKNOWN_BOUNDS = {'bounds_status': 'unknown'}
+_NO_POLARITY = {'polarity': 'not_applicable'}
+
+
+def metric_bounds_fields(
+    metric_name: str | None,
+    bounds_table: dict[str, tuple[float, float]] | None = None,
+) -> dict[str, object]:
+    """The `MetricConfig` fields that describe one metric's range and direction.
+
+    Spread into a `MetricConfig(...)` call. `bounds_table` overrides and extends
+    the shared bounds for harnesses that spell a metric differently or report it
+    on a different scale.
+    """
+    table = (
+        {**SHARED_METRIC_BOUNDS, **bounds_table}
+        if bounds_table
+        else SHARED_METRIC_BOUNDS
+    )
+    name = metric_name or ''
+    bounds = table.get(name)
+    details = dict(_NO_POLARITY) if name in DISPERSION_METRICS else {}
+
+    if bounds is None:
+        return {
+            'lower_is_better': name in LOWER_IS_BETTER,
+            'additional_details': {**details, **_UNKNOWN_BOUNDS},
+        }
+    return {
+        'lower_is_better': name in LOWER_IS_BETTER,
+        'score_type': ScoreType.continuous,
+        'min_score': bounds[0],
+        'max_score': bounds[1],
+        'additional_details': details or None,
+    }
+
+
+def count_unknown_bounds(metric_configs) -> int:
+    """How many of these metric configs have no known range."""
+    return sum(
+        config.additional_details is not None
+        and config.additional_details.get('bounds_status') == 'unknown'
+        for config in metric_configs
+    )

--- a/every_eval_ever/converters/helm/adapter.py
+++ b/every_eval_ever/converters/helm/adapter.py
@@ -49,7 +49,7 @@ from every_eval_ever.converters.common.adapter import (
 )
 from every_eval_ever.converters.common.metrics import (
     count_unknown_bounds,
-    metric_bounds_fields,
+    metric_config_fields,
 )
 from every_eval_ever.converters.common.utils import sha256_file
 from every_eval_ever.converters.helm.instance_level_adapter import (
@@ -59,9 +59,11 @@ from every_eval_ever.converters.helm.instance_level_adapter import (
     _stat_name_part,
 )
 from every_eval_ever.converters.helm.metrics import (
+    HELM_HARNESS_ID,
     HELM_METRIC_BOUNDS,
     is_core_metric,
     metric_bounds_name,
+    metric_parameters,
 )
 from every_eval_ever.converters.helm.utils import extract_reasoning
 from every_eval_ever.eval_types import (
@@ -576,8 +578,12 @@ class HELMAdapter(BaseEvaluationAdapter):
             metric_config = MetricConfig(
                 evaluation_description=metric_name,
                 metric_name=metric_name,
-                **metric_bounds_fields(
-                    metric_bounds_name(metric_name), HELM_METRIC_BOUNDS
+                **metric_config_fields(
+                    metric_name,
+                    harness=HELM_HARNESS_ID,
+                    bounds_table=HELM_METRIC_BOUNDS,
+                    lookup_name=metric_bounds_name(metric_name),
+                    metric_parameters=metric_parameters(metric_name),
                 ),
             )
 

--- a/every_eval_ever/converters/helm/adapter.py
+++ b/every_eval_ever/converters/helm/adapter.py
@@ -121,6 +121,28 @@ def _instance_counts_by_result_id(per_instance_stats: List) -> Dict[str, int]:
     }
 
 
+def _instance_counts_by_split(stats_raw: List) -> Dict[str, int]:
+    """The instance count HELM itself reports for each split.
+
+    HELM emits a ``num_instances`` stat per split, whose mean is that split's
+    instance count. It is the only sample count available for a run converted
+    without its per-instance stats, where the alternative is the run-wide count
+    covering every split at once.
+    """
+    counts: Dict[str, int] = {}
+    for stat in stats_raw:
+        stat_name = getattr(stat, 'name', None)
+        if getattr(stat_name, 'name', None) != 'num_instances':
+            continue
+        if getattr(stat_name, 'perturbation', None) is not None:
+            continue
+        split = _stat_name_part(getattr(stat_name, 'split', None)) or ''
+        mean = getattr(stat, 'mean', None)
+        if isinstance(mean, (int, float)) and mean > 0:
+            counts[split] = int(mean)
+    return counts
+
+
 def _require_helm_dependencies() -> None:
     if _HELM_IMPORT_ERROR is not None:
         raise ImportError(
@@ -525,6 +547,7 @@ class HELMAdapter(BaseEvaluationAdapter):
         evaluation_results: List[EvaluationResult] = []
         seen_evaluation_result_ids: set[str] = set()
         instance_counts = _instance_counts_by_result_id(per_instance_stats_list)
+        split_instance_counts = _instance_counts_by_split(stats_raw)
 
         for stat in stats_raw:
             # The ID helper mirrors the instance-level converter. This is the
@@ -562,23 +585,23 @@ class HELMAdapter(BaseEvaluationAdapter):
             perturbation = getattr(stat.name, 'perturbation', None)
             perturbation_label = _stat_name_part(perturbation)
 
-            # HELM's spread is over train trials, so a single-trial run reports
-            # 0.0 by construction; publishing that would claim the score does not
-            # vary.
-            standard_deviation = (
-                getattr(stat, 'stddev', None) if (stat_count or 0) > 1 else None
-            )
+            # HELM's spread is across train trials, not across samples, so it is
+            # not the `standard_deviation` the schema asks for and it is 0.0 by
+            # construction for the single-trial runs that make up almost every
+            # published suite. It travels as itself instead.
+            trial_stddev = getattr(stat, 'stddev', None)
             # The per-instance stats state the sample count exactly for this
             # split and perturbation. A worst-case-over-perturbations stat has
             # none of its own and is computed over the instances of its split,
-            # which is what the unperturbed stat for the same split counts. The
-            # run's own instance count is the last resort, and covers every
-            # split at once.
+            # which is what the unperturbed stat for the same split counts, and
+            # what HELM's own `num_instances` reports for that split. The run's
+            # instance count is the last resort, and covers every split at once.
             num_samples = (
                 instance_counts.get(evaluation_result_id)
                 or instance_counts.get(
                     _evaluation_result_id(metric_name, split)
                 )
+                or split_instance_counts.get(_stat_name_part(split) or '')
                 or source_data.samples_number
                 or None
             )
@@ -593,16 +616,18 @@ class HELMAdapter(BaseEvaluationAdapter):
                     score_details=ScoreDetails(
                         score=score,
                         uncertainty=(
-                            Uncertainty(
-                                standard_deviation=standard_deviation,
-                                num_samples=num_samples,
-                            )
-                            if standard_deviation is not None or num_samples
+                            Uncertainty(num_samples=num_samples)
+                            if num_samples
                             else None
                         ),
                         details={
                             'num_train_trials': str(
                                 stat_count if stat_count is not None else ''
+                            ),
+                            'stddev_across_train_trials': (
+                                ''
+                                if trial_stddev is None
+                                else str(trial_stddev)
                             ),
                             'split': _stat_name_part(split) or '',
                             'perturbation': perturbation_label or '',

--- a/every_eval_ever/converters/helm/adapter.py
+++ b/every_eval_ever/converters/helm/adapter.py
@@ -47,6 +47,10 @@ from every_eval_ever.converters.common.adapter import (
     BaseEvaluationAdapter,
     SupportedLibrary,
 )
+from every_eval_ever.converters.common.metrics import (
+    count_unknown_bounds,
+    metric_bounds_fields,
+)
 from every_eval_ever.converters.common.utils import sha256_file
 from every_eval_ever.converters.helm.instance_level_adapter import (
     HELMInstanceLevelDataAdapter,
@@ -54,7 +58,11 @@ from every_eval_ever.converters.helm.instance_level_adapter import (
     _score_from_stat,
     _stat_name_part,
 )
-from every_eval_ever.converters.helm.metrics import is_core_metric
+from every_eval_ever.converters.helm.metrics import (
+    HELM_METRIC_BOUNDS,
+    is_core_metric,
+    metric_bounds_name,
+)
 from every_eval_ever.converters.helm.utils import extract_reasoning
 from every_eval_ever.eval_types import (
     DetailedEvaluationResults,
@@ -68,7 +76,6 @@ from every_eval_ever.eval_types import (
     MetricConfig,
     ModelInfo,
     ScoreDetails,
-    ScoreType,
     SourceDataHf,
     SourceMetadata,
     SourceType,
@@ -82,6 +89,36 @@ from every_eval_ever.helpers.io import (
     require_identity,
     require_uuid4,
 )
+
+
+def _instance_counts_by_result_id(per_instance_stats: List) -> Dict[str, int]:
+    """How many distinct instances each aggregate result was computed over.
+
+    HELM aggregates a run by averaging one value per train trial
+    (``Stat.take_mean()`` in ``helm.benchmark.metrics.metric``), so the ``count``
+    on a stat in ``stats.json`` is the number of trials, which is 1 for the
+    single-trial runs that make up almost every published suite. The number of
+    instances behind a score is therefore only recoverable from the per-instance
+    stats, keyed the same way the aggregate results are.
+    """
+    instance_ids: Dict[str, set] = {}
+    for entry in per_instance_stats:
+        instance_id = getattr(entry, 'instance_id', None)
+        if instance_id is None:
+            continue
+        for stat in getattr(entry, 'stats', None) or []:
+            stat_name = getattr(stat, 'name', None)
+            result_id = _evaluation_result_id(
+                getattr(stat_name, 'name', None),
+                getattr(stat_name, 'split', None),
+                getattr(stat_name, 'perturbation', None),
+            )
+            if result_id is None:
+                continue
+            instance_ids.setdefault(result_id, set()).add(str(instance_id))
+    return {
+        result_id: len(ids) for result_id, ids in instance_ids.items() if ids
+    }
 
 
 def _require_helm_dependencies() -> None:
@@ -487,6 +524,7 @@ class HELMAdapter(BaseEvaluationAdapter):
         # additional_details in a separate follow-up.
         evaluation_results: List[EvaluationResult] = []
         seen_evaluation_result_ids: set[str] = set()
+        instance_counts = _instance_counts_by_result_id(per_instance_stats_list)
 
         for stat in stats_raw:
             # The ID helper mirrors the instance-level converter. This is the
@@ -515,15 +553,35 @@ class HELMAdapter(BaseEvaluationAdapter):
             metric_config = MetricConfig(
                 evaluation_description=metric_name,
                 metric_name=metric_name,
-                lower_is_better=False,  # TODO schema.json check
-                score_type=ScoreType.continuous,
-                min_score=0,
-                max_score=1.0,
+                **metric_bounds_fields(
+                    metric_bounds_name(metric_name), HELM_METRIC_BOUNDS
+                ),
             )
 
             split = getattr(stat.name, 'split', None)
             perturbation = getattr(stat.name, 'perturbation', None)
             perturbation_label = _stat_name_part(perturbation)
+
+            # HELM's spread is over train trials, so a single-trial run reports
+            # 0.0 by construction; publishing that would claim the score does not
+            # vary.
+            standard_deviation = (
+                getattr(stat, 'stddev', None) if (stat_count or 0) > 1 else None
+            )
+            # The per-instance stats state the sample count exactly for this
+            # split and perturbation. A worst-case-over-perturbations stat has
+            # none of its own and is computed over the instances of its split,
+            # which is what the unperturbed stat for the same split counts. The
+            # run's own instance count is the last resort, and covers every
+            # split at once.
+            num_samples = (
+                instance_counts.get(evaluation_result_id)
+                or instance_counts.get(
+                    _evaluation_result_id(metric_name, split)
+                )
+                or source_data.samples_number
+                or None
+            )
 
             evaluation_results.append(
                 EvaluationResult(
@@ -534,20 +592,18 @@ class HELMAdapter(BaseEvaluationAdapter):
                     metric_config=metric_config,
                     score_details=ScoreDetails(
                         score=score,
-                        uncertainty=Uncertainty(
-                            standard_deviation=getattr(stat, 'stddev', None),
-                            # Split-specific HELM stats may cover fewer
-                            # examples than the full run, so use the stat's
-                            # own count when it is available.
-                            num_samples=(
-                                stat_count
-                                if stat_count is not None
-                                else adapter_spec.max_eval_instances
-                                or len(request_states)
-                            ),
+                        uncertainty=(
+                            Uncertainty(
+                                standard_deviation=standard_deviation,
+                                num_samples=num_samples,
+                            )
+                            if standard_deviation is not None or num_samples
+                            else None
                         ),
                         details={
-                            'count': str(getattr(stat, 'count', '')),
+                            'num_train_trials': str(
+                                stat_count if stat_count is not None else ''
+                            ),
                             'split': _stat_name_part(split) or '',
                             'perturbation': perturbation_label or '',
                         },
@@ -575,6 +631,25 @@ class HELMAdapter(BaseEvaluationAdapter):
                         },
                     ),
                 )
+            )
+
+        if not evaluation_results:
+            reported = sorted(
+                {
+                    name
+                    for name in (
+                        getattr(getattr(stat, 'name', None), 'name', None)
+                        for stat in stats_raw
+                    )
+                    if name
+                }
+            )
+            raise ValueError(
+                f'HELM run {run_spec.name!r} reports no metric this converter '
+                f'recognizes as a benchmark score, so there is nothing to '
+                f'publish. Its stats are: {", ".join(reported) or "(none)"}. '
+                f'Add the ones that are scores to CORE_METRIC_PREFIXES in '
+                f'every_eval_ever/converters/helm/metrics.py.'
             )
 
         if request_states:
@@ -624,6 +699,9 @@ class HELMAdapter(BaseEvaluationAdapter):
         else:
             detailed_evaluation_results = None
 
+        unknown_bounds_count = count_unknown_bounds(
+            result.metric_config for result in evaluation_results
+        )
         eval_log = EvaluationLog(
             schema_version=SCHEMA_VERSION,
             evaluation_id=evaluation_id,
@@ -646,6 +724,11 @@ class HELMAdapter(BaseEvaluationAdapter):
                     'evaluator_relationship'
                 )
                 or 'third_party',
+                additional_details=(
+                    {'metrics_with_unknown_bounds': str(unknown_bounds_count)}
+                    if unknown_bounds_count
+                    else None
+                ),
             ),
             eval_library=EvalLibrary(
                 name=metadata_args.get('eval_library_name', 'helm'),

--- a/every_eval_ever/converters/helm/metrics.py
+++ b/every_eval_ever/converters/helm/metrics.py
@@ -30,3 +30,33 @@ def is_core_metric(metric_name: Optional[str]) -> bool:
     return bool(metric_name) and any(
         metric_name.startswith(prefix) for prefix in CORE_METRIC_PREFIXES
     )
+
+
+# Bounds for the metrics HELM spells or scales its own way, layered over
+# converters/common/metrics.py::SHARED_METRIC_BOUNDS. HELM's `bleu_1`/`bleu_4`
+# are nltk's `sentence_bleu` and its `f1_score` is nltk's `f_measure`, so both
+# are 0-1 here, unlike lm-eval's `bleu`, which is sacrebleu's 0-100.
+HELM_METRIC_BOUNDS: dict[str, tuple[float, float]] = {
+    'quasi_exact_match': (0.0, 1.0),
+    'prefix_exact_match': (0.0, 1.0),
+    'quasi_prefix_exact_match': (0.0, 1.0),
+    'classification_micro_f1': (0.0, 1.0),
+    'classification_macro_f1': (0.0, 1.0),
+    'rouge_l': (0.0, 1.0),
+    'bleu_1': (0.0, 1.0),
+    'bleu_4': (0.0, 1.0),
+    'ifeval_strict_accuracy': (0.0, 1.0),
+    'chain_of_thought_correctness': (0.0, 1.0),
+    'math_equiv': (0.0, 1.0),
+    'math_equiv_chain_of_thought': (0.0, 1.0),
+}
+
+
+def metric_bounds_name(metric_name: str) -> str:
+    """The name to look bounds up under, without HELM's ``@k`` suffix.
+
+    ``exact_match@5`` is ``exact_match`` over the best of five completions: the
+    suffix says how many completions were considered, not on what scale the
+    result is reported.
+    """
+    return metric_name.split('@', 1)[0]

--- a/every_eval_ever/converters/helm/metrics.py
+++ b/every_eval_ever/converters/helm/metrics.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import Optional
 
+# The registry's canonical slug for this harness, which is what namespaces the
+# metric ids it reports that the registry does not carry.
+HELM_HARNESS_ID = 'helm'
+
 # HELM emits both benchmark metrics and bookkeeping telemetry in stats.json /
 # per_instance_stats.json. In this PR, only benchmark-quality metrics become
 # EEE aggregate/detail metric rows. Bookkeeping can be mapped to token_usage,
@@ -60,3 +64,14 @@ def metric_bounds_name(metric_name: str) -> str:
     result is reported.
     """
     return metric_name.split('@', 1)[0]
+
+
+def metric_parameters(metric_name: str) -> Optional[dict]:
+    """The parameters HELM's ``@k`` suffix states, as the schema's own field.
+
+    The suffix belongs in ``metric_parameters`` rather than only in the metric's
+    name, so a consumer can tell ``exact_match@5`` from ``exact_match@1``
+    without parsing it back out.
+    """
+    _, _, suffix = metric_name.partition('@')
+    return {'k': int(suffix)} if suffix.isdigit() else None

--- a/every_eval_ever/converters/inspect/adapter.py
+++ b/every_eval_ever/converters/inspect/adapter.py
@@ -112,6 +112,9 @@ _STDDEV_METRICS = frozenset({'std', 'stddev'})
 # Inspect's `stderr` is the analytic standard error of the mean; its
 # `bootstrap_stderr` resamples, which the schema records as the method.
 _STDERR_METHODS = {'stderr': 'analytic', 'bootstrap_stderr': 'bootstrap'}
+# When a scorer reports more than one, the analytic standard error of the mean
+# is the primary; a bootstrap resample is kept alongside it, not in its place.
+_STDERR_PREFERENCE = ('analytic', 'bootstrap')
 _UNCERTAINTY_METRICS = _STDDEV_METRICS | frozenset(_STDERR_METHODS)
 
 
@@ -135,6 +138,30 @@ class InspectAIAdapter(BaseEvaluationAdapter):
     @property
     def supported_library(self) -> SupportedLibrary:
         return SupportedLibrary.INSPECT_AI
+
+    @staticmethod
+    def _unselected_stderr_details(
+        stderr_by_method: dict[str, EvalMetric],
+        primary_method: str | None,
+    ) -> dict[str, str]:
+        """Preserve any standard error the primary is not.
+
+        Choosing the analytic value for ``standard_error`` should not discard
+        the bootstrap number Inspect also computed; the schema carries one
+        standard error, so the rest — its value and any parameters it names,
+        such as the resample count — is kept in the score's string details.
+        """
+        details: dict[str, str] = {}
+        for method, metric in stderr_by_method.items():
+            if method == primary_method:
+                continue
+            details[metric.name] = str(metric.value)
+            params = getattr(metric, 'params', None)
+            if isinstance(params, dict) and params:
+                details[f'{metric.name}_params'] = json.dumps(
+                    params, sort_keys=True, default=str
+                )
+        return details
 
     def _extract_uncertainty(
         self,
@@ -168,6 +195,7 @@ class InspectAIAdapter(BaseEvaluationAdapter):
         generation_config: GenerationConfig,
         stderr_value: float | None = None,
         stderr_method: str | None = None,
+        stderr_extra: dict[str, str] | None = None,
         stddev_value: float | None = None,
         num_samples: int | None = None,
     ) -> EvaluationResult:
@@ -188,6 +216,7 @@ class InspectAIAdapter(BaseEvaluationAdapter):
             ),
             score_details=ScoreDetails(
                 score=metric_info.value,
+                details=stderr_extra or None,
                 uncertainty=self._extract_uncertainty(
                     stderr_value, stderr_method, stddev_value, num_samples
                 ),
@@ -231,13 +260,32 @@ class InspectAIAdapter(BaseEvaluationAdapter):
                     ),
                 )
 
-            stderr_value, stderr_method = next(
+            # A scorer can report the analytic stderr and a bootstrap resample
+            # of the same score. Prefer the analytic standard error of the mean;
+            # keep whichever is not chosen (with any parameters it carries) in
+            # the score's details, rather than letting dict order decide which
+            # survives and silently dropping the other.
+            stderr_by_method = {
+                _STDERR_METHODS[m.name]: m
+                for m in scorer.metrics.values()
+                if m.name in _STDERR_METHODS
+            }
+            primary_method = next(
                 (
-                    (m.value, _STDERR_METHODS[m.name])
-                    for m in scorer.metrics.values()
-                    if m.name in _STDERR_METHODS
+                    method
+                    for method in _STDERR_PREFERENCE
+                    if method in stderr_by_method
                 ),
-                (None, None),
+                None,
+            )
+            stderr_value = (
+                stderr_by_method[primary_method].value
+                if primary_method is not None
+                else None
+            )
+            stderr_method = primary_method
+            stderr_extra = self._unselected_stderr_details(
+                stderr_by_method, primary_method
             )
 
             stddev_value = next(
@@ -286,6 +334,7 @@ class InspectAIAdapter(BaseEvaluationAdapter):
                     generation_config=generation_config,
                     stderr_value=None if describes_itself else stderr_value,
                     stderr_method=None if describes_itself else stderr_method,
+                    stderr_extra=None if describes_itself else stderr_extra,
                     stddev_value=None if describes_itself else stddev_value,
                     num_samples=scored_samples,
                 )

--- a/every_eval_ever/converters/inspect/adapter.py
+++ b/every_eval_ever/converters/inspect/adapter.py
@@ -104,7 +104,11 @@ logger = logging.getLogger(__name__)
 # Inspect metrics that the schema carries inside `uncertainty` instead of as a
 # score of their own. `var` is deliberately absent: there is no field for a
 # variance, so dropping it as a score would lose the number.
-_UNCERTAINTY_METRICS = frozenset({'std', 'stddev', 'stderr'})
+_STDDEV_METRICS = frozenset({'std', 'stddev'})
+# Inspect's `stderr` is the analytic standard error of the mean; its
+# `bootstrap_stderr` resamples, which the schema records as the method.
+_STDERR_METHODS = {'stderr': 'analytic', 'bootstrap_stderr': 'bootstrap'}
+_UNCERTAINTY_METRICS = _STDDEV_METRICS | frozenset(_STDERR_METHODS)
 
 
 class InspectAIAdapter(BaseEvaluationAdapter):
@@ -131,13 +135,18 @@ class InspectAIAdapter(BaseEvaluationAdapter):
     def _extract_uncertainty(
         self,
         stderr_value: float | None,
+        stderr_method: str | None,
         stddev_value: float | None,
         num_samples: int | None,
-    ) -> Uncertainty:
+    ) -> Uncertainty | None:
+        if stderr_value is None and stddev_value is None and not num_samples:
+            return None
         return Uncertainty(
             # A standard error of exactly 0.0 is what a task every sample
             # scores identically reports, so it is a value, not an absence.
-            standard_error=StandardError(value=stderr_value)
+            standard_error=StandardError(
+                value=stderr_value, method=stderr_method
+            )
             if stderr_value is not None
             else None,
             standard_deviation=stddev_value,
@@ -154,8 +163,9 @@ class InspectAIAdapter(BaseEvaluationAdapter):
         evaluation_timestamp: str,
         generation_config: GenerationConfig,
         stderr_value: float | None = None,
+        stderr_method: str | None = None,
         stddev_value: float | None = None,
-        num_samples: int = 0,
+        num_samples: int | None = None,
     ) -> EvaluationResult:
         return EvaluationResult(
             evaluation_result_id=evaluation_result_id(
@@ -173,7 +183,7 @@ class InspectAIAdapter(BaseEvaluationAdapter):
             score_details=ScoreDetails(
                 score=metric_info.value,
                 uncertainty=self._extract_uncertainty(
-                    stderr_value, stddev_value, num_samples
+                    stderr_value, stderr_method, stddev_value, num_samples
                 ),
             ),
             generation_config=generation_config,
@@ -215,22 +225,30 @@ class InspectAIAdapter(BaseEvaluationAdapter):
                     ),
                 )
 
-            stderr_value = next(
+            stderr_value, stderr_method = next(
                 (
-                    m.value
+                    (m.value, _STDERR_METHODS[m.name])
                     for m in scorer.metrics.values()
-                    if m.name == 'stderr'
+                    if m.name in _STDERR_METHODS
                 ),
-                None,
+                (None, None),
             )
 
             stddev_value = next(
                 (
                     m.value
                     for m in scorer.metrics.values()
-                    if m.name in {'std', 'stddev'}
+                    if m.name in _STDDEV_METRICS
                 ),
                 None,
+            )
+
+            # Inspect computes a scorer's metrics over the samples it could
+            # score, and states how many those were. The run-wide count includes
+            # the samples this scorer returned no value for, and is what a log
+            # from before Inspect reported this per scorer leaves us with.
+            scored_samples = (
+                getattr(scorer, 'scored_samples', None) or num_samples
             )
 
             # Inspect reports dispersion as a metric of the scorer, and the
@@ -247,6 +265,10 @@ class InspectAIAdapter(BaseEvaluationAdapter):
 
             for metric_info in scored_metrics:
                 scorer_name = scorer.name or scorer.scorer
+                # A dispersion metric that had to stay a score is the value of
+                # this result, so repeating it as the result's own uncertainty
+                # would state the same number twice.
+                describes_itself = metric_info.name in _UNCERTAINTY_METRICS
 
                 result = self._build_evaluation_result(
                     evaluation_task_name=evaluation_task_name,
@@ -256,9 +278,10 @@ class InspectAIAdapter(BaseEvaluationAdapter):
                     source_data=source_data,
                     evaluation_timestamp=timestamp,
                     generation_config=generation_config,
-                    stderr_value=stderr_value,
-                    stddev_value=stddev_value,
-                    num_samples=num_samples,
+                    stderr_value=None if describes_itself else stderr_value,
+                    stderr_method=None if describes_itself else stderr_method,
+                    stddev_value=None if describes_itself else stddev_value,
+                    num_samples=scored_samples,
                 )
                 results.append(result)
 

--- a/every_eval_ever/converters/inspect/adapter.py
+++ b/every_eval_ever/converters/inspect/adapter.py
@@ -49,7 +49,10 @@ from every_eval_ever.converters.common.adapter import (
     SupportedLibrary,
 )
 from every_eval_ever.converters.common.error import AdapterError
-from every_eval_ever.converters.common.metrics import metric_config_fields
+from every_eval_ever.converters.common.metrics import (
+    count_unknown_bounds,
+    metric_config_fields,
+)
 from every_eval_ever.converters.common.utils import (
     convert_timestamp_to_unix_format,
     get_current_unix_timestamp,
@@ -643,21 +646,6 @@ class InspectAIAdapter(BaseEvaluationAdapter):
                 evaluator_relationship
             )
 
-        source_metadata = SourceMetadata(
-            source_name='inspect_ai',
-            source_type=SourceType.evaluation_run,
-            source_organization_name=metadata_args.get(
-                'source_organization_name', 'unknown'
-            ),
-            source_organization_url=metadata_args.get(
-                'source_organization_url'
-            ),
-            source_organization_logo_url=metadata_args.get(
-                'source_organization_logo_url'
-            ),
-            evaluator_relationship=evaluator_relationship,
-        )
-
         source_data = self._extract_source_data(
             eval_spec.dataset, eval_spec.task
         )
@@ -723,6 +711,31 @@ class InspectAIAdapter(BaseEvaluationAdapter):
             model_info=model_info,
             evaluation_results=evaluation_results,
             supplemental_eval_details=supplemental_eval_details,
+        )
+
+        # Built here rather than beside `eval_library` because the count needs
+        # the finished results, including anything a supplement replaced.
+        unknown_bounds_count = count_unknown_bounds(
+            result.metric_config for result in evaluation_results
+        )
+        source_metadata = SourceMetadata(
+            source_name='inspect_ai',
+            source_type=SourceType.evaluation_run,
+            source_organization_name=metadata_args.get(
+                'source_organization_name', 'unknown'
+            ),
+            source_organization_url=metadata_args.get(
+                'source_organization_url'
+            ),
+            source_organization_logo_url=metadata_args.get(
+                'source_organization_logo_url'
+            ),
+            evaluator_relationship=evaluator_relationship,
+            additional_details=(
+                {'metrics_with_unknown_bounds': str(unknown_bounds_count)}
+                if unknown_bounds_count
+                else None
+            ),
         )
 
         evaluation_id = f'{source_data.dataset_name}/{model_path.replace("/", "_")}/{evaluation_unix_timestamp}'

--- a/every_eval_ever/converters/inspect/adapter.py
+++ b/every_eval_ever/converters/inspect/adapter.py
@@ -49,6 +49,7 @@ from every_eval_ever.converters.common.adapter import (
     SupportedLibrary,
 )
 from every_eval_ever.converters.common.error import AdapterError
+from every_eval_ever.converters.common.metrics import metric_bounds_fields
 from every_eval_ever.converters.common.utils import (
     convert_timestamp_to_unix_format,
     get_current_unix_timestamp,
@@ -83,7 +84,6 @@ from every_eval_ever.eval_types import (
     ModelInfo,
     Sandbox,
     ScoreDetails,
-    ScoreType,
     SourceDataHf,
     SourceDataPrivate,
     SourceMetadata,
@@ -100,6 +100,11 @@ from every_eval_ever.helpers.io import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Inspect metrics that the schema carries inside `uncertainty` instead of as a
+# score of their own. `var` is deliberately absent: there is no field for a
+# variance, so dropping it as a score would lose the number.
+_UNCERTAINTY_METRICS = frozenset({'std', 'stddev', 'stderr'})
 
 
 class InspectAIAdapter(BaseEvaluationAdapter):
@@ -124,11 +129,16 @@ class InspectAIAdapter(BaseEvaluationAdapter):
         return SupportedLibrary.INSPECT_AI
 
     def _extract_uncertainty(
-        self, stderr_value: float, stddev_value: float, num_samples: int
+        self,
+        stderr_value: float | None,
+        stddev_value: float | None,
+        num_samples: int | None,
     ) -> Uncertainty:
         return Uncertainty(
+            # A standard error of exactly 0.0 is what a task every sample
+            # scores identically reports, so it is a value, not an absence.
             standard_error=StandardError(value=stderr_value)
-            if stderr_value
+            if stderr_value is not None
             else None,
             standard_deviation=stddev_value,
             num_samples=num_samples,
@@ -157,11 +167,8 @@ class InspectAIAdapter(BaseEvaluationAdapter):
             metric_config=MetricConfig(
                 evaluation_description=f'{metric_info.name} from scorer {scorer_name}',
                 metric_name=metric_info.name,
-                lower_is_better=False,  # no metadata available
-                score_type=ScoreType.continuous,
-                min_score=0,
-                max_score=1,
                 llm_scoring=llm_grader,
+                **metric_bounds_fields(metric_info.name),
             ),
             score_details=ScoreDetails(
                 score=metric_info.value,
@@ -226,10 +233,19 @@ class InspectAIAdapter(BaseEvaluationAdapter):
                 None,
             )
 
-            for _, metric_info in scorer.metrics.items():
-                if metric_info.name == 'stderr':
-                    continue
+            # Inspect reports dispersion as a metric of the scorer, and the
+            # schema carries it on the score it describes rather than beside it.
+            # Emitting it as its own score as well would repeat the number and
+            # claim a direction ("a higher standard deviation is better") that
+            # does not apply to it. It stays a score when it is the only thing
+            # the scorer reported, so that a run is never left with none.
+            scored_metrics = [
+                metric_info
+                for metric_info in scorer.metrics.values()
+                if metric_info.name not in _UNCERTAINTY_METRICS
+            ] or list(scorer.metrics.values())
 
+            for metric_info in scored_metrics:
                 scorer_name = scorer.name or scorer.scorer
 
                 result = self._build_evaluation_result(
@@ -622,7 +638,6 @@ class InspectAIAdapter(BaseEvaluationAdapter):
 
         model_path = eval_spec.model
 
-        num_samples = len(raw_eval_log.samples) if raw_eval_log.samples else 0
         single_sample = (
             raw_eval_log.samples[0] if raw_eval_log.samples else single_sample
         )
@@ -647,6 +662,17 @@ class InspectAIAdapter(BaseEvaluationAdapter):
         )
 
         results: EvalResults | None = raw_eval_log.results
+
+        # The scores were computed over the samples that completed, which the
+        # results header states. `raw_eval_log.samples` is only populated when
+        # the log was read with its samples, so its length is a fallback: for a
+        # header-only log it is 0, which would understate every score's
+        # num_samples rather than leave it unstated.
+        num_samples = (
+            results.completed_samples or results.total_samples
+            if results
+            else None
+        ) or (len(raw_eval_log.samples) if raw_eval_log.samples else None)
 
         evaluation_task_name = eval_spec.task_display_name or eval_spec.task
 

--- a/every_eval_ever/converters/inspect/adapter.py
+++ b/every_eval_ever/converters/inspect/adapter.py
@@ -49,7 +49,7 @@ from every_eval_ever.converters.common.adapter import (
     SupportedLibrary,
 )
 from every_eval_ever.converters.common.error import AdapterError
-from every_eval_ever.converters.common.metrics import metric_bounds_fields
+from every_eval_ever.converters.common.metrics import metric_config_fields
 from every_eval_ever.converters.common.utils import (
     convert_timestamp_to_unix_format,
     get_current_unix_timestamp,
@@ -60,6 +60,7 @@ from every_eval_ever.converters.inspect.instance_level_adapter import (
     evaluation_result_id,
 )
 from every_eval_ever.converters.inspect.utils import (
+    INSPECT_HARNESS_ID,
     apply_supplemental_eval_details,
     extract_model_info_from_model_path,
     parse_supplemental_eval_details,
@@ -178,7 +179,9 @@ class InspectAIAdapter(BaseEvaluationAdapter):
                 evaluation_description=f'{metric_info.name} from scorer {scorer_name}',
                 metric_name=metric_info.name,
                 llm_scoring=llm_grader,
-                **metric_bounds_fields(metric_info.name),
+                **metric_config_fields(
+                    metric_info.name, harness=INSPECT_HARNESS_ID
+                ),
             ),
             score_details=ScoreDetails(
                 score=metric_info.value,

--- a/every_eval_ever/converters/inspect/supplemental_eval_details.py
+++ b/every_eval_ever/converters/inspect/supplemental_eval_details.py
@@ -34,6 +34,10 @@ class SupplementalMetricConfig(_StrictSupplementalModel):
     has_unknown_level: bool | None = None
     min_score: float | None = None
     max_score: float | None = None
+    metric_id: str | None = None
+    metric_kind: str | None = None
+    metric_unit: str | None = None
+    metric_parameters: dict[str, str | float | bool | None] | None = None
     additional_details: dict[str, Any] | None = None
 
 class SupplementalForEvaluationResults(_StrictSupplementalModel):

--- a/every_eval_ever/converters/inspect/utils.py
+++ b/every_eval_ever/converters/inspect/utils.py
@@ -328,6 +328,15 @@ def extract_model_info_from_model_path(model_path: str) -> ModelInfo:
     return handler_class(model_path).handle()
 
 
+# The slug that namespaces the metric ids Inspect reports which the registry does
+# not carry. Inspect has no registry harness entry of its own yet, so this is the
+# name the converter already publishes as `eval_library.name`.
+INSPECT_HARNESS_ID = "inspect_ai"
+
+# Fields the converter derives rather than reads out of the log, so a caller who
+# knows better may override them. A field absent here is dropped in silence, which
+# is why anything resolved from a table in `converters/common/metrics.py` has to be
+# listed: the caller can see the value is wrong but could not replace it.
 SYNTHETIC_METRIC_CONFIG_FIELDS = {
     "evaluation_description",
     "lower_is_better",
@@ -337,6 +346,10 @@ SYNTHETIC_METRIC_CONFIG_FIELDS = {
     "has_unknown_level",
     "min_score",
     "max_score",
+    "metric_id",
+    "metric_kind",
+    "metric_unit",
+    "metric_parameters",
 }
 
 

--- a/every_eval_ever/converters/lm_eval/adapter.py
+++ b/every_eval_ever/converters/lm_eval/adapter.py
@@ -42,8 +42,11 @@ from .utils import (
     LM_EVAL_METRIC_BOUNDS,
     MODEL_TYPE_TO_INFERENCE_ENGINE,
     MODEL_TYPE_TO_INFERENCE_PLATFORM,
+    aggregations_by_metric,
+    bootstrap_resamples,
     evaluation_result_id,
     parse_model_args,
+    standard_error_method,
 )
 
 
@@ -220,6 +223,7 @@ class LMEvalAdapter(BaseEvaluationAdapter):
             task_name, {}
         )
         n_samples = raw_data.get('n-samples', {}).get(task_name, {})
+        aggregations = aggregations_by_metric(task_config)
         bootstrap_iters = raw_data.get('config', {}).get('bootstrap_iters')
         if not isinstance(bootstrap_iters, int):
             bootstrap_iters = None
@@ -253,9 +257,11 @@ class LMEvalAdapter(BaseEvaluationAdapter):
 
             stderr_key = f'{metric_name}_stderr,{filter_name}'
             stderr_val = task_results.get(stderr_key)
-            # lm-eval emits the string 'N/A' for stderr when it is not bootstrapped
-            # (e.g. aggregated or custom metrics). Treat any non-numeric value as
-            # absent so the StandardError (which requires a float) is simply omitted.
+            # lm-eval writes the string 'N/A' when it computed no standard error
+            # for a metric: its aggregation has no standard-error routine, or the
+            # task has a single item, or the run set bootstrap_iters to 0. Treat
+            # any non-numeric value as absent so the StandardError, which
+            # requires a float, is simply omitted.
             if not isinstance(stderr_val, (int, float)):
                 stderr_val = None
 
@@ -285,15 +291,23 @@ class LMEvalAdapter(BaseEvaluationAdapter):
                 or task_results.get('sample_len')
             )
             if stderr_val is not None or num_samples:
+                aggregation = aggregations.get(metric_name)
                 uncertainty = Uncertainty(
                     standard_error=(
-                        StandardError(value=stderr_val, method='bootstrap')
+                        StandardError(
+                            value=stderr_val,
+                            method=standard_error_method(aggregation),
+                        )
                         if stderr_val is not None
                         else None
                     ),
                     num_samples=num_samples,
                     num_bootstrap_samples=(
-                        bootstrap_iters if stderr_val is not None else None
+                        bootstrap_resamples(
+                            metric_name, aggregation, bootstrap_iters
+                        )
+                        if stderr_val is not None
+                        else None
                     ),
                 )
 

--- a/every_eval_ever/converters/lm_eval/adapter.py
+++ b/every_eval_ever/converters/lm_eval/adapter.py
@@ -10,6 +10,10 @@ from every_eval_ever.converters.common.adapter import (
     BaseEvaluationAdapter,
     SupportedLibrary,
 )
+from every_eval_ever.converters.common.metrics import (
+    count_unknown_bounds,
+    metric_bounds_fields,
+)
 from every_eval_ever.converters.common.utils import get_current_unix_timestamp
 from every_eval_ever.eval_types import (
     EvalLibrary,
@@ -22,7 +26,6 @@ from every_eval_ever.eval_types import (
     MetricConfig,
     ModelInfo,
     ScoreDetails,
-    ScoreType,
     SourceDataHf,
     SourceDataPrivate,
     SourceMetadata,
@@ -36,7 +39,7 @@ from every_eval_ever.helpers.io import (
 )
 
 from .utils import (
-    KNOWN_METRIC_BOUNDS,
+    LM_EVAL_METRIC_BOUNDS,
     MODEL_TYPE_TO_INFERENCE_ENGINE,
     MODEL_TYPE_TO_INFERENCE_PLATFORM,
     evaluation_result_id,
@@ -256,32 +259,24 @@ class LMEvalAdapter(BaseEvaluationAdapter):
             if not isinstance(stderr_val, (int, float)):
                 stderr_val = None
 
-            is_higher_better = higher_is_better.get(metric_name, True)
-
-            bounds = KNOWN_METRIC_BOUNDS.get(metric_name)
-
             description = metric_name
             if filter_name != 'none':
                 description = f'{metric_name} (filter: {filter_name})'
 
-            if bounds is None:
-                # Preserve metrics whose mathematical range is not yet known
-                # without falsely declaring them continuous and unbounded.
-                metric_config = MetricConfig(
-                    evaluation_description=description,
-                    metric_name=metric_name,
-                    lower_is_better=not is_higher_better,
-                    additional_details={'bounds_status': 'unknown'},
-                )
-            else:
-                metric_config = MetricConfig(
-                    evaluation_description=description,
-                    metric_name=metric_name,
-                    lower_is_better=not is_higher_better,
-                    score_type=ScoreType.continuous,
-                    min_score=bounds[0],
-                    max_score=bounds[1],
-                )
+            metric_fields = metric_bounds_fields(
+                metric_name, LM_EVAL_METRIC_BOUNDS
+            )
+            stated_direction = higher_is_better.get(metric_name)
+            if isinstance(stated_direction, bool):
+                # The log states the direction, which beats inferring it from
+                # the metric's name.
+                metric_fields['lower_is_better'] = not stated_direction
+
+            metric_config = MetricConfig(
+                evaluation_description=description,
+                metric_name=metric_name,
+                **metric_fields,
+            )
 
             uncertainty = None
             num_samples = (
@@ -355,11 +350,8 @@ class LMEvalAdapter(BaseEvaluationAdapter):
             or metadata_args.get('eval_library_version', 'unknown'),
         )
 
-        unknown_bounds_count = sum(
-            result.metric_config.additional_details is not None
-            and result.metric_config.additional_details.get('bounds_status')
-            == 'unknown'
-            for result in evaluation_results
+        unknown_bounds_count = count_unknown_bounds(
+            result.metric_config for result in evaluation_results
         )
         source_metadata = SourceMetadata(
             source_name='lm-evaluation-harness',

--- a/every_eval_ever/converters/lm_eval/adapter.py
+++ b/every_eval_ever/converters/lm_eval/adapter.py
@@ -12,7 +12,7 @@ from every_eval_ever.converters.common.adapter import (
 )
 from every_eval_ever.converters.common.metrics import (
     count_unknown_bounds,
-    metric_bounds_fields,
+    metric_config_fields,
 )
 from every_eval_ever.converters.common.utils import get_current_unix_timestamp
 from every_eval_ever.eval_types import (
@@ -39,6 +39,7 @@ from every_eval_ever.helpers.io import (
 )
 
 from .utils import (
+    LM_EVAL_HARNESS_ID,
     LM_EVAL_METRIC_BOUNDS,
     MODEL_TYPE_TO_INFERENCE_ENGINE,
     MODEL_TYPE_TO_INFERENCE_PLATFORM,
@@ -269,8 +270,10 @@ class LMEvalAdapter(BaseEvaluationAdapter):
             if filter_name != 'none':
                 description = f'{metric_name} (filter: {filter_name})'
 
-            metric_fields = metric_bounds_fields(
-                metric_name, LM_EVAL_METRIC_BOUNDS
+            metric_fields = metric_config_fields(
+                metric_name,
+                harness=LM_EVAL_HARNESS_ID,
+                bounds_table=LM_EVAL_METRIC_BOUNDS,
             )
             stated_direction = higher_is_better.get(metric_name)
             if isinstance(stated_direction, bool):

--- a/every_eval_ever/converters/lm_eval/utils.py
+++ b/every_eval_ever/converters/lm_eval/utils.py
@@ -63,17 +63,12 @@ MODEL_TYPE_TO_INFERENCE_ENGINE = {
     'gguf': 'llama.cpp',
 }
 
-# Known metric bounds: metric_name -> (min_score, max_score)
-# Infinite bounds are serialized as the JSON strings "Infinity"/"-Infinity".
-KNOWN_METRIC_BOUNDS = {
-    'acc': (0.0, 1.0),
-    'acc_norm': (0.0, 1.0),
-    'exact_match': (0.0, 1.0),
-    'f1': (0.0, 1.0),
-    'em': (0.0, 1.0),
+# Bounds for the metrics lm-eval spells its own way, layered over
+# converters/common/metrics.py::SHARED_METRIC_BOUNDS. lm-eval's `bleu` is
+# sacrebleu, which reports 0-100 rather than the 0-1 of nltk's sentence_bleu.
+LM_EVAL_METRIC_BOUNDS = {
     'mc1': (0.0, 1.0),
     'mc2': (0.0, 1.0),
-    'mcc': (-1.0, 1.0),
     'bleu': (0.0, 100.0),
     'rouge1': (0.0, 1.0),
     'rouge2': (0.0, 1.0),
@@ -84,5 +79,4 @@ KNOWN_METRIC_BOUNDS = {
     'byte_perplexity': (1.0, float('inf')),
     'perplexity': (1.0, float('inf')),
     'bits_per_byte': (0.0, float('inf')),
-    'brier_score': (0.0, 1.0),
 }

--- a/every_eval_ever/converters/lm_eval/utils.py
+++ b/every_eval_ever/converters/lm_eval/utils.py
@@ -126,13 +126,20 @@ MODEL_TYPE_TO_INFERENCE_ENGINE = {
     'gguf': 'llama.cpp',
 }
 
+# The registry's canonical slug for this harness, which is what namespaces the
+# metric ids it reports that the registry does not carry.
+LM_EVAL_HARNESS_ID = 'lm-evaluation-harness'
+
 # Bounds for the metrics lm-eval spells its own way, layered over
-# converters/common/metrics.py::SHARED_METRIC_BOUNDS. lm-eval's `bleu` is
-# sacrebleu, which reports 0-100 rather than the 0-1 of nltk's sentence_bleu.
+# converters/common/metrics.py::SHARED_METRIC_BOUNDS. lm-eval's `bleu`, `chrf`
+# and `ter` are sacrebleu's, which report 0-100 rather than the 0-1 of nltk's
+# sentence_bleu; `ter` has no ceiling, since a hypothesis can need more edits
+# than the reference has tokens.
 LM_EVAL_METRIC_BOUNDS = {
     'mc1': (0.0, 1.0),
     'mc2': (0.0, 1.0),
     'bleu': (0.0, 100.0),
+    'chrf': (0.0, 100.0),
     'rouge1': (0.0, 1.0),
     'rouge2': (0.0, 1.0),
     'rougeL': (0.0, 1.0),

--- a/every_eval_ever/converters/lm_eval/utils.py
+++ b/every_eval_ever/converters/lm_eval/utils.py
@@ -16,6 +16,69 @@ def evaluation_result_id(metric_name: str, filter_name: str) -> str:
     return f'{metric_name}:{filter_name}'
 
 
+# How a metric's standard error was computed follows from its *aggregation*, not
+# from its name: `stderr_for_metric` in lm_eval/api/metrics.py bootstraps these
+# aggregations, gives `mean` and `acc_all` an analytic standard error
+# (`sample_stddev / sqrt(n)`), and computes none at all for anything else.
+BOOTSTRAP_AGGREGATIONS: frozenset[str] = frozenset(
+    {
+        'bleu',
+        'chrf',
+        'f1_score',
+        'matthews_corrcoef',
+        'median',
+        'nanmean',
+        'perplexity',
+        'ter',
+    }
+)
+ANALYTIC_AGGREGATIONS: frozenset[str] = frozenset({'acc_all', 'mean'})
+
+# lm-eval resamples these three at `min(bootstrap_iters, 100)`, whatever the run
+# configured, so the configured value is not the number that was used.
+CAPPED_BOOTSTRAP_METRICS: frozenset[str] = frozenset({'bleu', 'chrf', 'ter'})
+BOOTSTRAP_ITERS_CAP = 100
+
+
+def aggregations_by_metric(task_config: Dict) -> Dict[str, str]:
+    """The aggregation each metric of a task was reduced with, where stated.
+
+    lm-eval resolves an unstated aggregation from its own registry at load time
+    and dumps the task's config as written, so a metric absent here has an
+    aggregation we cannot read off the log.
+    """
+    aggregations: Dict[str, str] = {}
+    for entry in task_config.get('metric_list') or []:
+        if not isinstance(entry, dict):
+            continue
+        metric, aggregation = entry.get('metric'), entry.get('aggregation')
+        if isinstance(metric, str) and isinstance(aggregation, str):
+            aggregations[metric] = aggregation
+    return aggregations
+
+
+def standard_error_method(aggregation: Optional[str]) -> Optional[str]:
+    """How lm-eval computed the standard error of a metric aggregated this way."""
+    if aggregation in BOOTSTRAP_AGGREGATIONS:
+        return 'bootstrap'
+    if aggregation in ANALYTIC_AGGREGATIONS:
+        return 'analytic'
+    return None
+
+
+def bootstrap_resamples(
+    metric_name: str,
+    aggregation: Optional[str],
+    configured_iters: Optional[int],
+) -> Optional[int]:
+    """How many resamples went into a bootstrapped standard error."""
+    if configured_iters is None or aggregation not in BOOTSTRAP_AGGREGATIONS:
+        return None
+    if metric_name in CAPPED_BOOTSTRAP_METRICS:
+        return min(configured_iters, BOOTSTRAP_ITERS_CAP)
+    return configured_iters
+
+
 def parse_model_args(model_args: str | None) -> Dict[str, str]:
     """Parse lm-eval model_args string (comma-separated key=value pairs).
 

--- a/tests/converter_cases.py
+++ b/tests/converter_cases.py
@@ -44,6 +44,10 @@ class ConverterCase:
     # belongs in this field rather than in `evaluation_name` or the description, and a
     # converter that leaves it unset shows up here as `None` in the set.
     metric_names: frozenset[str] | None = None
+    # The `score_details.uncertainty` keys, unioned over every result. Setting this
+    # also requires every result to carry an uncertainty, since dropping the standard
+    # error from a score leaves a record that still validates.
+    uncertainty_keys: frozenset[str] | None = None
     extra_argv: tuple[str, ...] = ()
     # Upstream key paths the converter cannot work without, `*` matching any one key.
     required_source_paths: tuple[str, ...] = ()
@@ -71,6 +75,7 @@ CASES: tuple[ConverterCase, ...] = (
             'math_perturbed_full/exact_match': 0.0,
             'math_rephrased_full/exact_match': 0.0004,
         },
+        uncertainty_keys=frozenset({'standard_error', 'num_samples'}),
         required_source_paths=(
             'config.model',
             'config.model_args',
@@ -99,6 +104,7 @@ CASES: tuple[ConverterCase, ...] = (
             'vul_exploit_scorer:std': 0.3115628730565127,
         },
         metric_names=frozenset({'accuracy', 'mean', 'std'}),
+        uncertainty_keys=frozenset({'standard_deviation', 'num_samples'}),
         required_source_paths=(
             'eval.model',
             'eval.task',
@@ -139,6 +145,7 @@ CASES: tuple[ConverterCase, ...] = (
                 'quasi_prefix_exact_match@5',
             }
         ),
+        uncertainty_keys=frozenset({'standard_deviation', 'num_samples'}),
         # `--log_path` is a HELM run directory, not one file, so there is no single
         # payload for `missing_paths` to address. The gate and the counts above are
         # what cover this converter.

--- a/tests/converter_cases.py
+++ b/tests/converter_cases.py
@@ -76,9 +76,9 @@ CASES: tuple[ConverterCase, ...] = (
             'math_rephrased_full/exact_match': 0.0004,
         },
         metric_names=frozenset({'exact_match'}),
-        uncertainty_keys=frozenset(
-            {'standard_error', 'num_samples', 'num_bootstrap_samples'}
-        ),
+        # No `num_bootstrap_samples`: `exact_match` aggregates with `mean`, whose
+        # standard error lm-eval computes analytically rather than by resampling.
+        uncertainty_keys=frozenset({'standard_error', 'num_samples'}),
         required_source_paths=(
             'config.model',
             'config.model_args',

--- a/tests/converter_cases.py
+++ b/tests/converter_cases.py
@@ -44,6 +44,11 @@ class ConverterCase:
     # belongs in this field rather than in `evaluation_name` or the description, and a
     # converter that leaves it unset shows up here as `None` in the set.
     metric_names: frozenset[str] | None = None
+    # Distinct `metric_config.metric_id` values, which is what a consumer joins on
+    # across sources. Listed per converter rather than derived, because the whole
+    # question is whether this converter's spelling of a metric reaches the same id
+    # another converter's does — a rule that generates both sides cannot answer it.
+    metric_ids: frozenset[str] | None = None
     # The `score_details.uncertainty` keys, unioned over every result. Setting this
     # also requires every result to carry an uncertainty, since dropping the standard
     # error from a score leaves a record that still validates.
@@ -76,6 +81,9 @@ CASES: tuple[ConverterCase, ...] = (
             'math_rephrased_full/exact_match': 0.0004,
         },
         metric_names=frozenset({'exact_match'}),
+        # The registry carries exact match, so this joins with HELM's `exact_match`
+        # and with any adapter reporting `em`.
+        metric_ids=frozenset({'exact-match'}),
         # No `num_bootstrap_samples`: `exact_match` aggregates with `mean`, whose
         # standard error lm-eval computes analytically rather than by resampling.
         uncertainty_keys=frozenset({'standard_error', 'num_samples'}),
@@ -107,6 +115,9 @@ CASES: tuple[ConverterCase, ...] = (
             'vul_exploit_scorer:mean': 0.38108974358974357,
         },
         metric_names=frozenset({'accuracy', 'mean'}),
+        # `mean` is not a metric the registry can carry: it names an aggregation, and
+        # what it averaged is the scorer's business, so it stays namespaced.
+        metric_ids=frozenset({'accuracy', 'inspect_ai.mean'}),
         uncertainty_keys=frozenset({'standard_deviation', 'num_samples'}),
         required_source_paths=(
             'eval.model',
@@ -146,6 +157,21 @@ CASES: tuple[ConverterCase, ...] = (
                 'prefix_exact_match@5',
                 'quasi_prefix_exact_match',
                 'quasi_prefix_exact_match@5',
+            }
+        ),
+        # Only plain `exact_match` resolves; HELM's near-miss variants and its
+        # best-of-k forms have no registry entry yet, so seven of the eight are
+        # namespaced. This set is the concrete list of gaps to file upstream.
+        metric_ids=frozenset(
+            {
+                'exact-match',
+                'helm.exact_match@5',
+                'helm.quasi_exact_match',
+                'helm.quasi_exact_match@5',
+                'helm.prefix_exact_match',
+                'helm.prefix_exact_match@5',
+                'helm.quasi_prefix_exact_match',
+                'helm.quasi_prefix_exact_match@5',
             }
         ),
         # No standard deviation: HELM's spread is over train trials, and this run,

--- a/tests/converter_cases.py
+++ b/tests/converter_cases.py
@@ -75,7 +75,10 @@ CASES: tuple[ConverterCase, ...] = (
             'math_perturbed_full/exact_match': 0.0,
             'math_rephrased_full/exact_match': 0.0004,
         },
-        uncertainty_keys=frozenset({'standard_error', 'num_samples'}),
+        metric_names=frozenset({'exact_match'}),
+        uncertainty_keys=frozenset(
+            {'standard_error', 'num_samples', 'num_bootstrap_samples'}
+        ),
         required_source_paths=(
             'config.model',
             'config.model_args',
@@ -90,20 +93,20 @@ CASES: tuple[ConverterCase, ...] = (
         aggregates=1,
         sidecars=1,
         # One scorer reporting three metrics, which is what makes this fixture worth
-        # using: a converter that collapses them to one result fails here.
-        results=3,
-        # One sample, three aggregate results, so three rows.
-        sidecar_rows=3,
+        # using: a converter that collapses them to one result fails here. The third
+        # is the scorer's `std`, which belongs in `uncertainty`, not in a score of
+        # its own.
+        results=2,
+        # One sample, two aggregate results, so two rows.
+        sidecar_rows=2,
         model_id='mistral/mistral-large-latest',
         scores={
             'inspect_evals/cyse2_vulnerability_exploit/'
             'vul_exploit_scorer:accuracy': 0.38108974358974373,
             'inspect_evals/cyse2_vulnerability_exploit/'
             'vul_exploit_scorer:mean': 0.38108974358974357,
-            'inspect_evals/cyse2_vulnerability_exploit/'
-            'vul_exploit_scorer:std': 0.3115628730565127,
         },
-        metric_names=frozenset({'accuracy', 'mean', 'std'}),
+        metric_names=frozenset({'accuracy', 'mean'}),
         uncertainty_keys=frozenset({'standard_deviation', 'num_samples'}),
         required_source_paths=(
             'eval.model',
@@ -145,7 +148,9 @@ CASES: tuple[ConverterCase, ...] = (
                 'quasi_prefix_exact_match@5',
             }
         ),
-        uncertainty_keys=frozenset({'standard_deviation', 'num_samples'}),
+        # No standard deviation: HELM's spread is over train trials, and this run,
+        # like nearly every published HELM run, has one.
+        uncertainty_keys=frozenset({'num_samples'}),
         # `--log_path` is a HELM run directory, not one file, so there is no single
         # payload for `missing_paths` to address. The gate and the counts above are
         # what cover this converter.

--- a/tests/test_converter_conversion.py
+++ b/tests/test_converter_conversion.py
@@ -221,6 +221,38 @@ def test_every_metric_id_is_either_canonical_or_openly_namespaced(
     )
 
 
+def test_unknown_bounds_are_counted_in_the_source_metadata(case, tmp_path):
+    """A record has to say how many of its metrics came out without a range.
+
+    Omitting `min_score`/`max_score` is the honest answer for a metric no bounds
+    table carries, but it is invisible without opening every result, so the count
+    goes in `source_metadata.additional_details`. Derived on both sides here
+    deliberately: the question is whether the converter wired the count up at all,
+    which is how the inspect converter was found reporting `null` while publishing
+    an unbounded metric. Applies to every case, so a converter added later
+    inherits it.
+    """
+    for path in convert(case, tmp_path):
+        if path.suffix != '.json':
+            continue
+        log = json.loads(path.read_text(encoding='utf-8'))
+        unbounded = [
+            result['metric_config'].get('metric_name')
+            for result in log['evaluation_results']
+            if result['metric_config'].get('min_score') is None
+            and result['metric_config'].get('max_score') is None
+        ]
+        details = log['source_metadata'].get('additional_details') or {}
+        reported = details.get('metrics_with_unknown_bounds')
+        expected = str(len(unbounded)) if unbounded else None
+        assert reported == expected, (
+            f'{case.source} published {len(unbounded)} metric(s) with no bounds '
+            f'({unbounded}) but source_metadata reports {reported!r}. Pass the '
+            'results through converters/common/metrics.py::count_unknown_bounds '
+            'when building SourceMetadata.'
+        )
+
+
 def test_required_source_paths_are_present_in_the_fixture(case):
     """The keys the converter reads must still exist in the committed log.
 

--- a/tests/test_converter_conversion.py
+++ b/tests/test_converter_conversion.py
@@ -18,6 +18,7 @@ import json
 
 import pytest
 
+from every_eval_ever.converters.common.metrics import CANONICAL_METRIC_IDS
 from tests.converter_cases import (
     CASES,
     ConverterCase,
@@ -99,6 +100,18 @@ def test_conversion_yields_the_expected_records(case, tmp_path):
             '`metric_config.metric_name`; `None` here means the converter left it '
             'unset, and `evaluation_name` is for the evaluation.'
         )
+    if case.metric_ids is not None:
+        converted = {
+            result['metric_config'].get('metric_id')
+            for log in logs
+            for result in log['evaluation_results']
+        }
+        assert converted == case.metric_ids, (
+            f'{case.source} identified its metrics as '
+            f'{sorted(converted, key=str)}, expected {sorted(case.metric_ids)}. '
+            'This is the field consumers join on across sources, so a change '
+            'here silently splits or merges a query nobody here will run.'
+        )
     if case.uncertainty_keys is not None:
         results = [
             result for log in logs for result in log['evaluation_results']
@@ -158,6 +171,54 @@ def test_conversion_yields_the_expected_records(case, tmp_path):
         assert written == declared, (
             f'{case.source} wrote {written} row(s) but reported {declared}'
         )
+
+
+def test_every_metric_id_is_either_canonical_or_openly_namespaced(
+    case, tmp_path
+):
+    """No converter may mint a global id the registry has not granted.
+
+    An id with no dot claims to be the canonical name for that quantity
+    everywhere, so it has to be one the registry actually carries; anything else
+    says which harness it came from and marks itself unregistered. A bare
+    `quasi_exact_match` would look canonical while joining to nothing, which is
+    the failure this rule exists to prevent. Applies to every case, so a converter
+    added later inherits it without declaring anything.
+    """
+    logs = [
+        json.loads(path.read_text(encoding='utf-8'))
+        for path in convert(case, tmp_path)
+        if path.suffix == '.json'
+    ]
+    canonical = set(CANONICAL_METRIC_IDS.values())
+
+    offenders = []
+    for log in logs:
+        for result in log['evaluation_results']:
+            config = result['metric_config']
+            metric_id = config.get('metric_id')
+            details = config.get('additional_details') or {}
+            unregistered = details.get('metric_id_status') == 'unregistered'
+            if not metric_id:
+                offenders.append(f'{config.get("metric_name")}: no metric_id')
+            elif '.' in metric_id:
+                if not unregistered:
+                    offenders.append(f'{metric_id}: namespaced but unmarked')
+            elif metric_id not in canonical:
+                offenders.append(
+                    f'{metric_id}: bare id, not in the registry map'
+                )
+            elif unregistered:
+                offenders.append(
+                    f'{metric_id}: canonical but marked unregistered'
+                )
+
+    assert not offenders, (
+        f'{case.source} published metric ids that claim more than they can '
+        f'deliver: {offenders}. Map the name in '
+        'converters/common/metrics.py::CANONICAL_METRIC_IDS if the registry '
+        'carries it, and otherwise leave it namespaced.'
+    )
 
 
 def test_required_source_paths_are_present_in_the_fixture(case):

--- a/tests/test_converter_conversion.py
+++ b/tests/test_converter_conversion.py
@@ -99,6 +99,30 @@ def test_conversion_yields_the_expected_records(case, tmp_path):
             '`metric_config.metric_name`; `None` here means the converter left it '
             'unset, and `evaluation_name` is for the evaluation.'
         )
+    if case.uncertainty_keys is not None:
+        results = [
+            result for log in logs for result in log['evaluation_results']
+        ]
+        bare = [
+            f'{result["evaluation_name"]}/'
+            f'{result.get("evaluation_result_id") or result["metric_config"].get("metric_name")}'
+            for result in results
+            if not result['score_details'].get('uncertainty')
+        ]
+        assert not bare, (
+            f'{case.source} published {len(bare)} score(s) with no uncertainty at '
+            f'all: {bare}. The record still validates without one, which is why '
+            'this is asserted here.'
+        )
+        converted = {
+            key
+            for result in results
+            for key in result['score_details']['uncertainty']
+        }
+        assert converted == case.uncertainty_keys, (
+            f'{case.source} reported uncertainty as {sorted(converted)}, expected '
+            f'{sorted(case.uncertainty_keys)}.'
+        )
 
     for log, path in zip(logs, aggregates, strict=True):
         detailed = log.get('detailed_evaluation_results')

--- a/tests/test_converter_metric_bounds.py
+++ b/tests/test_converter_metric_bounds.py
@@ -18,6 +18,9 @@ from every_eval_ever.converters.helm.metrics import (
     metric_bounds_name,
     metric_parameters,
 )
+from every_eval_ever.converters.inspect.supplemental_eval_details import (
+    SupplementalMetricConfig,
+)
 from every_eval_ever.converters.inspect.utils import (
     INSPECT_HARNESS_ID,
     SYNTHETIC_METRIC_CONFIG_FIELDS,
@@ -78,12 +81,38 @@ def test_an_unknown_metric_gets_no_range_at_all():
 
     assert config.min_score is None
     assert config.max_score is None
-    assert config.additional_details == {'bounds_status': 'unknown'}
+    assert config.additional_details == {
+        'polarity': 'unknown',
+        'bounds_status': 'unknown',
+    }
 
 
 def test_a_metric_whose_definition_fixes_its_direction_says_so():
     assert _config('word_perplexity').lower_is_better is True
     assert _config('exact_match').lower_is_better is False
+
+
+def test_an_unknown_direction_metric_marks_its_fallback_a_guess():
+    """`lower_is_better` is required, so an unrecognized metric serializes False.
+
+    A `polarity: unknown` marker keeps that from reading as an asserted
+    higher-is-better, the same way `bounds_status` keeps a missing range from
+    reading as [0, 1]. A metric whose direction its definition fixes, or one
+    for which direction does not apply, is stated rather than hedged.
+    """
+    unknown = _config('semantic_similarity_v3')
+    assert unknown.lower_is_better is False
+    assert unknown.additional_details['polarity'] == 'unknown'
+
+    # Known direction, still without a resolved range: no hedge.
+    known = _config('word_perplexity')
+    assert known.lower_is_better is True
+    assert 'polarity' not in (known.additional_details or {})
+
+    # A recognized higher-is-better metric is a claim, not a guess.
+    accuracy = _config('accuracy')
+    assert accuracy.lower_is_better is False
+    assert accuracy.additional_details is None
 
 
 def test_a_dispersion_metric_claims_no_direction():
@@ -252,7 +281,10 @@ def test_a_derived_field_can_be_corrected_by_a_caller():
     """Inspect drops a supplied `metric_config` field that it does not synthesize.
 
     Every field resolved from a table here is therefore listed as synthetic, or a
-    caller could see a wrong id without being able to replace it.
+    caller could see a wrong id without being able to replace it. A listed field
+    the strict supplement model forbids is the same dead end from the other side
+    -- the allowlist waves it through but the caller can never supply it -- so
+    every overridable field must also be a `SupplementalMetricConfig` field.
     """
     assert {
         'metric_id',
@@ -260,6 +292,9 @@ def test_a_derived_field_can_be_corrected_by_a_caller():
         'metric_unit',
         'metric_parameters',
     } <= SYNTHETIC_METRIC_CONFIG_FIELDS
+    assert SYNTHETIC_METRIC_CONFIG_FIELDS <= set(
+        SupplementalMetricConfig.model_fields
+    )
 
 
 def test_every_canonical_id_is_shaped_like_a_registry_slug():

--- a/tests/test_converter_metric_bounds.py
+++ b/tests/test_converter_metric_bounds.py
@@ -6,14 +6,26 @@ up as one failure with a name rather than as three unrelated ones.
 """
 
 from every_eval_ever.converters.common.metrics import (
+    CANONICAL_METRIC_IDS,
+    METRIC_ID_REGISTRY_REVISION,
     count_unknown_bounds,
     metric_bounds_fields,
+    metric_config_fields,
 )
 from every_eval_ever.converters.helm.metrics import (
+    HELM_HARNESS_ID,
     HELM_METRIC_BOUNDS,
     metric_bounds_name,
+    metric_parameters,
 )
-from every_eval_ever.converters.lm_eval.utils import LM_EVAL_METRIC_BOUNDS
+from every_eval_ever.converters.inspect.utils import (
+    INSPECT_HARNESS_ID,
+    SYNTHETIC_METRIC_CONFIG_FIELDS,
+)
+from every_eval_ever.converters.lm_eval.utils import (
+    LM_EVAL_HARNESS_ID,
+    LM_EVAL_METRIC_BOUNDS,
+)
 from every_eval_ever.eval_types import MetricConfig, ScoreType
 
 
@@ -23,6 +35,28 @@ def _config(metric_name: str, bounds_table=None) -> MetricConfig:
         evaluation_description=metric_name,
         metric_name=metric_name,
         **metric_bounds_fields(metric_name, bounds_table),
+    )
+
+
+def _identified(
+    metric_name: str,
+    *,
+    harness: str = 'test_harness',
+    bounds_table=None,
+    lookup_name: str | None = None,
+    metric_parameters=None,
+) -> MetricConfig:
+    """Build the MetricConfig a converter builds once identity is included."""
+    return MetricConfig(
+        evaluation_description=metric_name,
+        metric_name=metric_name,
+        **metric_config_fields(
+            metric_name,
+            harness=harness,
+            bounds_table=bounds_table,
+            lookup_name=lookup_name,
+            metric_parameters=metric_parameters,
+        ),
     )
 
 
@@ -96,3 +130,131 @@ def test_unknown_bounds_are_countable_for_the_record_they_end_up_in():
     configs = [_config('accuracy'), _config('vibes'), _config('more_vibes')]
 
     assert count_unknown_bounds(configs) == 2
+
+
+def test_a_registry_metric_is_published_under_its_canonical_id():
+    config = _identified('accuracy')
+
+    assert config.metric_id == 'accuracy'
+    assert config.metric_kind == 'accuracy'
+    assert config.metric_unit == 'proportion'
+    assert config.additional_details == {
+        'metric_id_registry_revision': METRIC_ID_REGISTRY_REVISION
+    }
+
+
+def test_a_metric_the_registry_lacks_is_namespaced_rather_than_invented():
+    """A bare id claims a global identity the registry has not granted.
+
+    The namespaced form still joins within the harness, and the marker is what
+    lists the metrics owed a registry entry.
+    """
+    config = _identified('quasi_exact_match', harness='helm')
+
+    assert config.metric_id == 'helm.quasi_exact_match'
+    assert config.additional_details['metric_id_status'] == 'unregistered'
+    # Dated, so a reader can tell whether the entry has been added since.
+    assert config.additional_details['metric_id_registry_revision'] == (
+        METRIC_ID_REGISTRY_REVISION
+    )
+
+
+def test_two_spellings_of_one_metric_join_on_the_same_id():
+    """The whole point of the field: same quantity, same id, whatever it was called."""
+    assert _identified('em').metric_id == _identified('exact_match').metric_id
+    assert _identified('f1_score').metric_id == _identified('f1').metric_id
+    assert _identified('rouge_l').metric_id == _identified('rougeL').metric_id
+
+
+def test_a_parameter_in_the_name_keeps_the_bounds_but_not_the_id():
+    """`exact_match@5` is exact match over the best of five completions.
+
+    That is a different and higher quantity than `exact_match`, and the registry
+    gives such metrics a slug of their own (`pass-at-1`, `recall-at-5`), so
+    sharing `exact-match` would average the two in exactly the join this field
+    exists for. The scale is unaffected, so the bounds still resolve.
+    """
+    config = _identified(
+        'exact_match@5',
+        harness=HELM_HARNESS_ID,
+        bounds_table=HELM_METRIC_BOUNDS,
+        lookup_name=metric_bounds_name('exact_match@5'),
+        metric_parameters=metric_parameters('exact_match@5'),
+    )
+
+    assert config.metric_id == 'helm.exact_match@5'
+    assert (config.min_score, config.max_score) == (0.0, 1.0)
+    assert config.metric_kind == 'accuracy'
+    assert config.metric_parameters == {'k': 5}
+
+
+def test_the_unit_follows_the_scale_the_harness_actually_reported():
+    """lm-eval's `bleu` is sacrebleu's 0-100, HELM's `bleu_1` nltk's 0-1.
+
+    Both are BLEU and both say so in `metric_kind`; the unit is what keeps a
+    consumer from averaging 31.4 with 0.314.
+    """
+    lm_eval_bleu = _identified(
+        'bleu', harness=LM_EVAL_HARNESS_ID, bounds_table=LM_EVAL_METRIC_BOUNDS
+    )
+    helm_bleu = _identified(
+        'bleu_1', harness=HELM_HARNESS_ID, bounds_table=HELM_METRIC_BOUNDS
+    )
+
+    assert lm_eval_bleu.metric_unit == 'percent'
+    assert helm_bleu.metric_unit == 'proportion'
+    assert lm_eval_bleu.metric_kind == helm_bleu.metric_kind == 'text_overlap'
+
+
+def test_a_metric_with_no_resolved_range_claims_no_unit():
+    config = _identified('semantic_similarity_v3')
+
+    assert config.metric_unit is None
+    assert config.additional_details['bounds_status'] == 'unknown'
+    assert config.additional_details['metric_id_status'] == 'unregistered'
+
+
+def test_identity_does_not_cost_a_dispersion_metric_its_caveat():
+    config = _identified('std')
+
+    assert config.additional_details['polarity'] == 'not_applicable'
+    assert config.metric_kind == 'dispersion'
+
+
+def test_the_namespace_is_the_slug_the_registry_knows_the_harness_by():
+    """Renaming one of these rewrites every id that converter has ever published.
+
+    `lm-evaluation-harness` and `helm` are the registry's own harness slugs.
+    `inspect_ai` is not: the registry carries no entry for Inspect yet, so this is
+    the name the converter already publishes as `eval_library.name`, and it should
+    become the registry slug once that entry exists.
+    """
+    assert LM_EVAL_HARNESS_ID == 'lm-evaluation-harness'
+    assert HELM_HARNESS_ID == 'helm'
+    assert INSPECT_HARNESS_ID == 'inspect_ai'
+
+
+def test_a_derived_field_can_be_corrected_by_a_caller():
+    """Inspect drops a supplied `metric_config` field that it does not synthesize.
+
+    Every field resolved from a table here is therefore listed as synthetic, or a
+    caller could see a wrong id without being able to replace it.
+    """
+    assert {
+        'metric_id',
+        'metric_kind',
+        'metric_unit',
+        'metric_parameters',
+    } <= SYNTHETIC_METRIC_CONFIG_FIELDS
+
+
+def test_every_canonical_id_is_shaped_like_a_registry_slug():
+    """Cheap guard against a hand-written id that no registry entry can match.
+
+    The registry's slugs are lowercase and hyphen-separated; a dot would make one
+    indistinguishable from the `<harness>.<name>` fallback.
+    """
+    for name, metric_id in CANONICAL_METRIC_IDS.items():
+        assert metric_id == metric_id.lower(), name
+        assert '.' not in metric_id, name
+        assert '_' not in metric_id, name

--- a/tests/test_converter_metric_bounds.py
+++ b/tests/test_converter_metric_bounds.py
@@ -1,0 +1,98 @@
+"""What `converters/common/metrics.py` promises to every converter that uses it.
+
+The three harness converters each have their own tests for the records they
+produce; these pin the shared rules those records rely on, so a change here shows
+up as one failure with a name rather than as three unrelated ones.
+"""
+
+from every_eval_ever.converters.common.metrics import (
+    count_unknown_bounds,
+    metric_bounds_fields,
+)
+from every_eval_ever.converters.helm.metrics import (
+    HELM_METRIC_BOUNDS,
+    metric_bounds_name,
+)
+from every_eval_ever.converters.lm_eval.utils import LM_EVAL_METRIC_BOUNDS
+from every_eval_ever.eval_types import MetricConfig, ScoreType
+
+
+def _config(metric_name: str, bounds_table=None) -> MetricConfig:
+    """Build the MetricConfig a converter would build for this metric."""
+    return MetricConfig(
+        evaluation_description=metric_name,
+        metric_name=metric_name,
+        **metric_bounds_fields(metric_name, bounds_table),
+    )
+
+
+def test_a_known_metric_gets_its_range_and_its_direction():
+    config = _config('accuracy')
+
+    assert (config.min_score, config.max_score) == (0.0, 1.0)
+    assert config.score_type == ScoreType.continuous
+    assert config.lower_is_better is False
+    assert config.additional_details is None
+
+
+def test_an_unknown_metric_gets_no_range_at_all():
+    """`min_score`/`max_score` are nullable, so "not provided" is available and true.
+
+    [0, 1] on a metric whose scale we have not checked is not.
+    """
+    config = _config('semantic_similarity_v3')
+
+    assert config.min_score is None
+    assert config.max_score is None
+    assert config.additional_details == {'bounds_status': 'unknown'}
+
+
+def test_a_metric_whose_definition_fixes_its_direction_says_so():
+    assert _config('word_perplexity').lower_is_better is True
+    assert _config('exact_match').lower_is_better is False
+
+
+def test_a_dispersion_metric_claims_no_direction():
+    """`lower_is_better` is required, so `False` is what an inapplicable direction
+    serializes as, and the marker is what carries the caveat."""
+    config = _config('std')
+
+    assert (config.min_score, config.max_score) == (0.0, float('inf'))
+    assert config.additional_details == {'polarity': 'not_applicable'}
+
+
+def test_the_same_metric_name_can_mean_two_scales():
+    """lm-eval's `bleu` is sacrebleu's 0-100; HELM's `bleu_1` is nltk's 0-1.
+
+    This is why the bounds are layered per harness rather than kept in one table
+    keyed by a bare metric name.
+    """
+    lm_eval_bleu = _config('bleu', LM_EVAL_METRIC_BOUNDS)
+    helm_bleu = _config('bleu_1', HELM_METRIC_BOUNDS)
+
+    assert (lm_eval_bleu.min_score, lm_eval_bleu.max_score) == (0.0, 100.0)
+    assert (helm_bleu.min_score, helm_bleu.max_score) == (0.0, 1.0)
+
+
+def test_a_harness_table_can_override_the_shared_bounds():
+    shared = _config('accuracy')
+    overridden = _config('accuracy', {'accuracy': (0.0, 100.0)})
+
+    assert shared.max_score == 1.0
+    assert overridden.max_score == 100.0
+
+
+def test_helm_at_k_suffix_does_not_cost_a_metric_its_bounds():
+    assert metric_bounds_name('exact_match@5') == 'exact_match'
+    assert metric_bounds_name('exact_match') == 'exact_match'
+
+    config = _config(
+        metric_bounds_name('quasi_exact_match@5'), HELM_METRIC_BOUNDS
+    )
+    assert (config.min_score, config.max_score) == (0.0, 1.0)
+
+
+def test_unknown_bounds_are_countable_for_the_record_they_end_up_in():
+    configs = [_config('accuracy'), _config('vibes'), _config('more_vibes')]
+
+    assert count_unknown_bounds(configs) == 2

--- a/tests/test_converter_metric_bounds.py
+++ b/tests/test_converter_metric_bounds.py
@@ -108,6 +108,20 @@ def test_the_same_metric_name_can_mean_two_scales():
     assert (helm_bleu.min_score, helm_bleu.max_score) == (0.0, 1.0)
 
 
+def test_a_multi_class_brier_score_is_allowed_its_full_range():
+    """A Brier score over `n` classes runs to 2.0, not to 1.0.
+
+    lm-eval computes `mean(sum((softmax(lls) - one_hot(gold)) ** 2))`, so a model
+    putting all its mass on one wrong class scores 2.0. Declaring `[0, 1]` makes
+    the validator warn that a legitimate score is out of range, which the
+    converter suite treats as a failure.
+    """
+    config = _config('brier_score')
+
+    assert (config.min_score, config.max_score) == (0.0, 2.0)
+    assert config.lower_is_better is True
+
+
 def test_a_harness_table_can_override_the_shared_bounds():
     shared = _config('accuracy')
     overridden = _config('accuracy', {'accuracy': (0.0, 100.0)})

--- a/tests/test_helm_adapter.py
+++ b/tests/test_helm_adapter.py
@@ -302,8 +302,12 @@ def test_num_samples_follows_the_split_a_score_was_computed_on():
     }
 
 
-def test_single_trial_run_reports_no_standard_deviation():
-    """A stat over one trial has a stddev of 0.0 by construction, not by measurement."""
+def test_helm_spread_is_not_the_schemas_standard_deviation():
+    """`standard_deviation` is the spread of the per-sample scores; HELM's is the
+    spread across train trials, which is 0.0 by construction on one trial.
+
+    It is reported as itself, next to the trial count that gives it meaning.
+    """
     import json
 
     stats = json.loads((Path(HELLASWAG_RUN) / 'stats.json').read_text())
@@ -323,6 +327,82 @@ def test_single_trial_run_reports_no_standard_deviation():
         result.score_details.uncertainty.standard_deviation is None
         for result in converted_eval.evaluation_results
     )
+    assert {
+        result.score_details.details['stddev_across_train_trials']
+        for result in converted_eval.evaluation_results
+    } == {'0.0'}
+
+
+def test_multi_trial_spread_is_still_reported_as_a_trial_spread():
+    """A run over several trials has a spread that is not 0.0, and it is still a
+    spread across trials rather than across samples."""
+    adapter = HELMAdapter()
+
+    def three_trials(stats):
+        for stat in stats:
+            if stat.get('count'):
+                stat['count'] = 3
+                stat['stddev'] = 0.05
+        return stats
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        converted_eval = _load_eval(
+            adapter,
+            _run_with_rewritten_stats(tmpdir, three_trials),
+            {
+                'source_organization_name': 'TestOrg',
+                'evaluator_relationship': EvaluatorRelationship.first_party,
+            },
+        )
+
+    for result in converted_eval.evaluation_results:
+        assert result.score_details.uncertainty.standard_deviation is None
+        details = result.score_details.details
+        assert details['num_train_trials'] == '3'
+        assert details['stddev_across_train_trials'] == '0.05'
+        # The samples behind the score are unaffected by how many trials it took.
+        assert result.score_details.uncertainty.num_samples == 10
+
+
+def test_sample_count_survives_a_run_without_per_instance_stats():
+    """HELM reports `num_instances` per split, which is the only sample count left
+    when a run carries no per-instance stats.
+
+    Falling back to the run's own instance count instead would report all 10 of
+    this run's instances for a score computed on the 9 of them in `test`.
+    """
+    import json
+    import shutil
+
+    adapter = HELMAdapter()
+    source = Path(
+        'tests/data/helm/mmlu:subject=philosophy,'
+        'method=multiple_choice_joint,model=openai_gpt2'
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_path = Path(tmpdir) / 'run'
+        shutil.copytree(source, run_path)
+        stats_path = run_path / 'per_instance_stats.json'
+        assert stats_path.exists()
+        stats_path.write_text(json.dumps([]), encoding='utf-8')
+
+        converted_eval = _load_eval(
+            adapter,
+            run_path,
+            {
+                'source_organization_name': 'TestOrg',
+                'evaluator_relationship': EvaluatorRelationship.first_party,
+            },
+        )
+
+    by_split = {}
+    for result in converted_eval.evaluation_results:
+        by_split.setdefault(result.score_details.details['split'], set()).add(
+            result.score_details.uncertainty.num_samples
+        )
+
+    assert by_split == {'test': {9}, 'valid': {1}}
 
 
 def test_metric_bounds_are_claimed_only_where_they_are_known():

--- a/tests/test_helm_adapter.py
+++ b/tests/test_helm_adapter.py
@@ -227,6 +227,185 @@ def test_evaluation_name_is_the_benchmark_and_the_metric_is_named():
     } == {'', 'robustness', 'fairness'}
 
 
+def _run_with_rewritten_stats(tmpdir, rewrite):
+    """Copy the hellaswag run into `tmpdir` with `rewrite` applied to its stats."""
+    import json
+    import shutil
+
+    destination = Path(tmpdir) / 'run'
+    shutil.copytree(Path(HELLASWAG_RUN), destination)
+    stats_path = destination / 'stats.json'
+    stats_path.write_text(
+        json.dumps(rewrite(json.loads(stats_path.read_text()))),
+        encoding='utf-8',
+    )
+    return destination
+
+
+def test_num_samples_counts_instances_not_train_trials():
+    """The run has 10 instances, and HELM's own `count` on each stat is 1.
+
+    HELM aggregates by averaging one value per train trial, so `count` is the
+    number of trials. Reporting it as `num_samples` would tell a reader that
+    every score in every single-trial HELM run rests on one example.
+    """
+    adapter = HELMAdapter()
+    converted_eval = _load_eval(
+        adapter,
+        HELLASWAG_RUN,
+        {
+            'source_organization_name': 'TestOrg',
+            'evaluator_relationship': EvaluatorRelationship.first_party,
+        },
+    )
+    results = converted_eval.evaluation_results
+
+    assert results[0].source_data.samples_number == 10
+    assert {
+        result.score_details.uncertainty.num_samples for result in results
+    } == {10}
+    assert {
+        result.score_details.details['num_train_trials'] for result in results
+    } == {'1'}
+
+
+def test_num_samples_follows_the_split_a_score_was_computed_on():
+    """This run's 10 instances are 9 `test` and 1 `valid`, and HELM scores both.
+
+    A run-wide count would overstate every split-specific score. The worst-case
+    perturbation stats carry no per-instance stats of their own, and are computed
+    over the instances of their split, so they take that split's count too.
+    """
+    adapter = HELMAdapter()
+    converted_eval = _load_eval(
+        adapter,
+        'tests/data/helm/mmlu:subject=philosophy,'
+        'method=multiple_choice_joint,model=openai_gpt2',
+        {
+            'source_organization_name': 'TestOrg',
+            'evaluator_relationship': EvaluatorRelationship.first_party,
+        },
+    )
+
+    by_split = {}
+    for result in converted_eval.evaluation_results:
+        details = result.score_details.details
+        by_split.setdefault(
+            (details['split'], bool(details['perturbation'])), set()
+        ).add(result.score_details.uncertainty.num_samples)
+
+    assert by_split == {
+        ('test', False): {9},
+        ('test', True): {9},
+        ('valid', False): {1},
+        ('valid', True): {1},
+    }
+
+
+def test_single_trial_run_reports_no_standard_deviation():
+    """A stat over one trial has a stddev of 0.0 by construction, not by measurement."""
+    import json
+
+    stats = json.loads((Path(HELLASWAG_RUN) / 'stats.json').read_text())
+    assert {stat['stddev'] for stat in stats if stat.get('count')} == {0.0}
+
+    adapter = HELMAdapter()
+    converted_eval = _load_eval(
+        adapter,
+        HELLASWAG_RUN,
+        {
+            'source_organization_name': 'TestOrg',
+            'evaluator_relationship': EvaluatorRelationship.first_party,
+        },
+    )
+
+    assert all(
+        result.score_details.uncertainty.standard_deviation is None
+        for result in converted_eval.evaluation_results
+    )
+
+
+def test_metric_bounds_are_claimed_only_where_they_are_known():
+    """`exact_match@5` is still exact match; `bleu_2` is a scale we have not checked.
+
+    The `@k` suffix says how many completions were considered, so it must not cost
+    a metric its bounds. A metric that is on the allowlist but in no bounds table
+    gets none, and the count of them is published so a reader can see it.
+    """
+    adapter = HELMAdapter()
+
+    def rename_first_exact_match(stats):
+        for stat in stats:
+            if stat['name']['name'] == 'exact_match' and not stat['name'].get(
+                'perturbation'
+            ):
+                stat['name']['name'] = 'bleu_2'
+                break
+        return stats
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_path = _run_with_rewritten_stats(tmpdir, rename_first_exact_match)
+        converted_eval = _load_eval(
+            adapter,
+            run_path,
+            {
+                'source_organization_name': 'TestOrg',
+                'evaluator_relationship': EvaluatorRelationship.first_party,
+            },
+        )
+
+    by_metric = {
+        result.metric_config.metric_name: result.metric_config
+        for result in converted_eval.evaluation_results
+    }
+
+    assert by_metric['exact_match@5'].min_score == 0.0
+    assert by_metric['exact_match@5'].max_score == 1.0
+
+    assert by_metric['bleu_2'].min_score is None
+    assert by_metric['bleu_2'].max_score is None
+    assert by_metric['bleu_2'].additional_details == {
+        'bounds_status': 'unknown'
+    }
+    assert converted_eval.source_metadata.additional_details == {
+        'metrics_with_unknown_bounds': '1'
+    }
+
+
+def test_run_without_a_benchmark_metric_is_reported_not_raised():
+    """One unconvertible run should not take the rest of the invocation with it.
+
+    HELM emits bookkeeping stats (token counts, runtimes) alongside scores, and a
+    run that has only those has nothing to publish. The converter has to say so
+    per run, so a directory of runs still converts the ones that do have scores.
+    """
+    adapter = HELMAdapter()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_path = _run_with_rewritten_stats(
+            tmpdir,
+            lambda stats: [
+                stat
+                for stat in stats
+                if stat['name']['name'].startswith('num_')
+            ],
+        )
+        result = adapter.transform_from_directory_result(
+            run_path,
+            metadata_args={
+                'source_organization_name': 'TestOrg',
+                'evaluator_relationship': EvaluatorRelationship.first_party,
+            },
+        )
+
+    assert result.records == []
+    assert len(result.failures) == 1
+    reason = result.failures[0].reason
+    assert 'no metric this converter recognizes' in reason
+    assert 'num_prompt_tokens' in reason
+    assert 'CORE_METRIC_PREFIXES' in reason
+
+
 def test_instance_rows_join_the_aggregate_results_they_belong_to():
     """A sample row the aggregate cannot be joined to is a row nobody can read."""
     import json

--- a/tests/test_helm_adapter.py
+++ b/tests/test_helm_adapter.py
@@ -444,9 +444,7 @@ def test_metric_bounds_are_claimed_only_where_they_are_known():
 
     assert by_metric['bleu_2'].min_score is None
     assert by_metric['bleu_2'].max_score is None
-    assert by_metric['bleu_2'].additional_details == {
-        'bounds_status': 'unknown'
-    }
+    assert by_metric['bleu_2'].additional_details['bounds_status'] == 'unknown'
     assert converted_eval.source_metadata.additional_details == {
         'metrics_with_unknown_bounds': '1'
     }

--- a/tests/test_inspect_adapter.py
+++ b/tests/test_inspect_adapter.py
@@ -12,6 +12,9 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from every_eval_ever.converters.common.error import AdapterError
+from every_eval_ever.converters.common.metrics import (
+    METRIC_ID_REGISTRY_REVISION,
+)
 from every_eval_ever.converters.inspect.adapter import InspectAIAdapter
 from every_eval_ever.converters.inspect.utils import (
     extract_model_info_from_model_path,
@@ -410,7 +413,7 @@ def test_metric_bounds_are_claimed_only_where_they_are_known():
 
     assert by_metric['mean'].min_score is None
     assert by_metric['mean'].max_score is None
-    assert by_metric['mean'].additional_details == {'bounds_status': 'unknown'}
+    assert by_metric['mean'].additional_details['bounds_status'] == 'unknown'
 
 
 def test_num_samples_comes_from_the_results_header():
@@ -604,9 +607,9 @@ def test_a_scorer_reporting_only_dispersion_does_not_repeat_it():
     assert result.metric_config.metric_name == 'std'
     assert result.score_details.score == 0.3
     assert result.score_details.uncertainty.standard_deviation is None
-    assert result.metric_config.additional_details == {
-        'polarity': 'not_applicable'
-    }
+    assert result.metric_config.additional_details['polarity'] == (
+        'not_applicable'
+    )
 
 
 def test_extract_evaluation_results_two_scorers_two_metrics_each():
@@ -776,7 +779,12 @@ def test_supplemental_eval_details_fill_only_top_level_fields():
     # Converter-synthetic defaults are override-eligible.
     assert result.metric_config.lower_is_better is True
     assert result.metric_config.evaluation_description == 'should_not_overwrite'
-    assert result.metric_config.additional_details == {'normalization': 'none'}
+    # Exhaustive: supplied details merge with what the converter resolved rather
+    # than replacing it, and nothing else leaks in.
+    assert result.metric_config.additional_details == {
+        'normalization': 'none',
+        'metric_id_registry_revision': METRIC_ID_REGISTRY_REVISION,
+    }
 
 
 def test_supplemental_eval_details_applies_top_level_score_details():

--- a/tests/test_inspect_adapter.py
+++ b/tests/test_inspect_adapter.py
@@ -68,9 +68,17 @@ def _make_metric(name: str, value: float):
     return SimpleNamespace(name=name, value=value)
 
 
-def _make_scorer(scorer_name: str, metrics: dict[str, object]):
+def _make_scorer(
+    scorer_name: str,
+    metrics: dict[str, object],
+    scored_samples: int | None = None,
+):
     return SimpleNamespace(
-        name=scorer_name, scorer=scorer_name, params=None, metrics=metrics
+        name=scorer_name,
+        scorer=scorer_name,
+        params=None,
+        metrics=metrics,
+        scored_samples=scored_samples,
     )
 
 
@@ -495,6 +503,110 @@ def test_extract_evaluation_results_one_scorer_with_two_metrics():
         'choice:f1',
     }
     assert result_ids_by_scorer == {'choice': ['choice:accuracy', 'choice:f1']}
+
+
+def test_each_scorer_counts_the_samples_it_could_score():
+    """Inspect computes a scorer's metrics over the samples that scorer scored, and
+    says how many those were; the run-wide count includes the ones it skipped."""
+    adapter = InspectAIAdapter()
+    scores = [
+        _make_scorer(
+            'strict',
+            {'accuracy': _make_metric('accuracy', 0.5)},
+            scored_samples=7,
+        ),
+        _make_scorer('lenient', {'accuracy': _make_metric('accuracy', 0.9)}),
+    ]
+
+    results, _ = adapter._extract_evaluation_results(
+        evaluation_task_name='synthetic/task',
+        scores=scores,
+        source_data=SourceDataHf(
+            dataset_name='synthetic_ds', source_type='hf_dataset'
+        ),
+        generation_config=GenerationConfig(),
+        num_samples=10,
+        timestamp='1234567890',
+    )
+
+    by_id = {
+        result.evaluation_result_id: result.score_details.uncertainty
+        for result in results
+    }
+    assert by_id['strict:accuracy'].num_samples == 7
+    # No count of its own, so the run's stands in.
+    assert by_id['lenient:accuracy'].num_samples == 10
+
+
+def test_standard_error_says_how_inspect_computed_it():
+    """`stderr` is the analytic standard error of the mean and `bootstrap_stderr`
+    resamples, so neither should be published without saying which it was."""
+    adapter = InspectAIAdapter()
+    scores = [
+        _make_scorer(
+            'analytic',
+            {
+                'accuracy': _make_metric('accuracy', 0.5),
+                'stderr': _make_metric('stderr', 0.05),
+            },
+        ),
+        _make_scorer(
+            'resampled',
+            {
+                'accuracy': _make_metric('accuracy', 0.5),
+                'bootstrap_stderr': _make_metric('bootstrap_stderr', 0.06),
+            },
+        ),
+    ]
+
+    results, _ = adapter._extract_evaluation_results(
+        evaluation_task_name='synthetic/task',
+        scores=scores,
+        source_data=SourceDataHf(
+            dataset_name='synthetic_ds', source_type='hf_dataset'
+        ),
+        generation_config=GenerationConfig(),
+        num_samples=10,
+        timestamp='1234567890',
+    )
+
+    # Neither dispersion metric is a score of its own.
+    assert {result.evaluation_result_id for result in results} == {
+        'analytic:accuracy',
+        'resampled:accuracy',
+    }
+    by_id = {
+        result.evaluation_result_id: result.score_details.uncertainty
+        for result in results
+    }
+    assert by_id['analytic:accuracy'].standard_error.method == 'analytic'
+    assert by_id['resampled:accuracy'].standard_error.value == 0.06
+    assert by_id['resampled:accuracy'].standard_error.method == 'bootstrap'
+
+
+def test_a_scorer_reporting_only_dispersion_does_not_repeat_it():
+    """`std` stays a score when it is all the scorer reported, so that the run is
+    not left with none; carrying it as its own uncertainty would say it twice."""
+    adapter = InspectAIAdapter()
+
+    results, _ = adapter._extract_evaluation_results(
+        evaluation_task_name='synthetic/task',
+        scores=[_make_scorer('spread', {'std': _make_metric('std', 0.3)})],
+        source_data=SourceDataHf(
+            dataset_name='synthetic_ds', source_type='hf_dataset'
+        ),
+        generation_config=GenerationConfig(),
+        num_samples=10,
+        timestamp='1234567890',
+    )
+
+    [result] = results
+    assert result.metric_config.metric_name == 'std'
+    assert result.score_details.score == 0.3
+    assert result.score_details.uncertainty.standard_deviation is None
+    assert result.metric_config.additional_details == {
+        'polarity': 'not_applicable'
+    }
 
 
 def test_extract_evaluation_results_two_scorers_two_metrics_each():

--- a/tests/test_inspect_adapter.py
+++ b/tests/test_inspect_adapter.py
@@ -587,6 +587,40 @@ def test_standard_error_says_how_inspect_computed_it():
     assert by_id['resampled:accuracy'].standard_error.method == 'bootstrap'
 
 
+def test_both_stderrs_prefer_analytic_and_keep_the_bootstrap_value():
+    """A scorer that reports both the analytic stderr and a bootstrap resample of
+    it should publish the analytic one as the standard error and keep the bootstrap
+    value in the score details, not let dict order pick one and drop the other."""
+    adapter = InspectAIAdapter()
+    results, _ = adapter._extract_evaluation_results(
+        evaluation_task_name='synthetic/task',
+        scores=[
+            _make_scorer(
+                'both',
+                {
+                    'accuracy': _make_metric('accuracy', 0.5),
+                    # bootstrap first, so the old order-dependent pick took it.
+                    'bootstrap_stderr': _make_metric('bootstrap_stderr', 0.06),
+                    'stderr': _make_metric('stderr', 0.05),
+                },
+            )
+        ],
+        source_data=SourceDataHf(
+            dataset_name='synthetic_ds', source_type='hf_dataset'
+        ),
+        generation_config=GenerationConfig(),
+        num_samples=10,
+        timestamp='1234567890',
+    )
+
+    [result] = results
+    assert result.metric_config.metric_name == 'accuracy'
+    standard_error = result.score_details.uncertainty.standard_error
+    assert (standard_error.value, standard_error.method) == (0.05, 'analytic')
+    # The bootstrap value is preserved, not silently dropped.
+    assert result.score_details.details['bootstrap_stderr'] == '0.06'
+
+
 def test_a_scorer_reporting_only_dispersion_does_not_repeat_it():
     """`std` stays a score when it is all the scorer reported, so that the run is
     not left with none; carrying it as its own uncertainty would say it twice."""

--- a/tests/test_inspect_adapter.py
+++ b/tests/test_inspect_adapter.py
@@ -344,7 +344,11 @@ def test_gaia_eval():
 
 
 def test_evaluation_name_is_the_benchmark_and_the_metric_is_named():
-    """One scorer reporting three metrics: same eval, three named metrics."""
+    """One scorer reporting three metrics: same eval, two named scores.
+
+    The third is the scorer's `std`, which the schema carries as uncertainty on
+    the scores it describes.
+    """
     adapter = InspectAIAdapter()
     metadata_args = {
         'source_organization_name': 'TestOrg',
@@ -358,19 +362,84 @@ def test_evaluation_name_is_the_benchmark_and_the_metric_is_named():
     )
 
     results = converted_eval.evaluation_results
-    assert len(results) == 3
+    assert len(results) == 2
     assert {result.evaluation_name for result in results} == {
         'inspect_evals/cyse2_vulnerability_exploit'
     }
     assert {result.metric_config.metric_name for result in results} == {
         'accuracy',
         'mean',
-        'std',
     }
     for result in results:
         assert result.evaluation_result_id == (
             f'vul_exploit_scorer:{result.metric_config.metric_name}'
         )
+        # The scorer's `std` metric, carried where the schema puts dispersion.
+        assert result.score_details.uncertainty.standard_deviation == (
+            0.3115628730565127
+        )
+
+
+def test_metric_bounds_are_claimed_only_where_they_are_known():
+    """`accuracy` is a proportion; `mean` is a mean of whatever the scorer returns."""
+    adapter = InspectAIAdapter()
+    converted_eval = _load_eval(
+        adapter,
+        'tests/data/inspect/data_cyse2_vuln_exploit_challenges.json',
+        {
+            'source_organization_name': 'TestOrg',
+            'evaluator_relationship': EvaluatorRelationship.first_party,
+        },
+    )
+    by_metric = {
+        result.metric_config.metric_name: result.metric_config
+        for result in converted_eval.evaluation_results
+    }
+
+    assert by_metric['accuracy'].min_score == 0.0
+    assert by_metric['accuracy'].max_score == 1.0
+    assert by_metric['accuracy'].score_type == ScoreType.continuous
+
+    assert by_metric['mean'].min_score is None
+    assert by_metric['mean'].max_score is None
+    assert by_metric['mean'].additional_details == {'bounds_status': 'unknown'}
+
+
+def test_num_samples_comes_from_the_results_header():
+    """The scores cover every completed sample, not only the samples in the log.
+
+    A log read without its samples carries none, so counting them would report
+    a handful of samples for a run over thousands.
+    """
+    adapter = InspectAIAdapter()
+    converted_eval = _load_eval(
+        adapter,
+        'tests/data/inspect/data_cyse2_vuln_exploit_challenges.json',
+        {
+            'source_organization_name': 'TestOrg',
+            'evaluator_relationship': EvaluatorRelationship.first_party,
+        },
+    )
+
+    for result in converted_eval.evaluation_results:
+        assert result.score_details.uncertainty.num_samples == 2340
+
+
+def test_standard_error_of_zero_is_reported():
+    """A task every sample scores identically has a stderr of 0.0, not of none."""
+    adapter = InspectAIAdapter()
+    converted_eval = _load_eval(
+        adapter,
+        'tests/data/inspect/data_pubmedqa_gpt4o_mini.json',
+        {
+            'source_organization_name': 'TestOrg',
+            'evaluator_relationship': EvaluatorRelationship.first_party,
+        },
+    )
+
+    uncertainty = converted_eval.evaluation_results[0].score_details.uncertainty
+    assert uncertainty.standard_error is not None
+    assert uncertainty.standard_error.value == 0.0
 
 
 def test_humaneval_eval():
@@ -700,7 +769,7 @@ def test_supplemental_eval_details_matches_all_results_of_an_evaluation():
                     'score_details': {'details': {'reviewed': 'yes'}},
                 },
                 {
-                    'evaluation_result_id': 'vul_exploit_scorer:std',
+                    'evaluation_result_id': 'vul_exploit_scorer:mean',
                     'score_details': {'details': {'reviewed': 'separately'}},
                 },
             ],
@@ -720,11 +789,8 @@ def test_supplemental_eval_details_matches_all_results_of_an_evaluation():
     assert details_by_result_id['vul_exploit_scorer:accuracy'] == {
         'reviewed': 'yes'
     }
-    assert details_by_result_id['vul_exploit_scorer:mean'] == {
-        'reviewed': 'yes'
-    }
     # The specific key wins over the evaluation-wide one.
-    assert details_by_result_id['vul_exploit_scorer:std'] == {
+    assert details_by_result_id['vul_exploit_scorer:mean'] == {
         'reviewed': 'separately'
     }
 

--- a/tests/test_inspect_adapter.py
+++ b/tests/test_inspect_adapter.py
@@ -787,6 +787,54 @@ def test_supplemental_eval_details_fill_only_top_level_fields():
     }
 
 
+def test_supplemental_eval_details_can_correct_a_resolved_metric_identity():
+    """The identity a converter resolves from a table is a caller-overrideable value.
+
+    `metric_id`, `metric_kind`, `metric_unit` and `metric_parameters` are listed
+    as synthetic so a caller who can see a wrong value may replace it. That path
+    is only real if the supplement model accepts those fields; a strict model
+    that forbids them rejects the supplement before the allowlist runs, leaving
+    the listing dead. Overriding them here has to reach the output.
+    """
+    adapter = InspectAIAdapter()
+    metadata_args = {
+        'source_organization_name': 'TestOrg',
+        'evaluator_relationship': EvaluatorRelationship.first_party,
+        'supplemental_eval_details': {
+            'evaluation_results': [
+                {
+                    'evaluation_result_id': 'choice:accuracy',
+                    'metric_config': {
+                        'metric_id': 'accuracy-corrected',
+                        'metric_kind': 'classification',
+                        'metric_unit': 'percent',
+                        'metric_parameters': {'strategy': 'greedy'},
+                    },
+                },
+            ],
+        },
+    }
+
+    converted_eval = _load_eval(
+        adapter,
+        'tests/data/inspect/data_pubmedqa_gpt4o_mini.json',
+        metadata_args,
+    )
+    result = next(
+        r
+        for r in converted_eval.evaluation_results
+        if r.evaluation_result_id == 'choice:accuracy'
+    )
+
+    # Each override differs from what the converter resolves for `accuracy`
+    # (`accuracy` / `accuracy` / `proportion` / no params), so a value that
+    # survived is one the override replaced, not one that happened to match.
+    assert result.metric_config.metric_id == 'accuracy-corrected'
+    assert result.metric_config.metric_kind == 'classification'
+    assert result.metric_config.metric_unit == 'percent'
+    assert result.metric_config.metric_parameters == {'strategy': 'greedy'}
+
+
 def test_supplemental_eval_details_applies_top_level_score_details():
     adapter = InspectAIAdapter()
     metadata_args = {

--- a/tests/test_inspect_instance_level_adapter.py
+++ b/tests/test_inspect_instance_level_adapter.py
@@ -197,11 +197,13 @@ def test_gaia_instance_level():
 
 
 def test_instance_rows_join_the_aggregate_results_they_belong_to():
-    """One sample, three aggregate metrics: three rows, one per result.
+    """One sample, two scored metrics: two rows, one per result.
 
     The instance schema asks for a record per aggregate result a sample
     contributed to, and `evaluation_result_id` is the only field that says
-    which result a row belongs to.
+    which result a row belongs to. The fixture's third metric is the scorer's
+    `std`, which becomes uncertainty on the other two rather than a result of
+    its own, so no row points at it.
     """
     adapter = InspectAIAdapter()
 
@@ -223,7 +225,7 @@ def test_instance_rows_join_the_aggregate_results_they_belong_to():
         result.evaluation_result_id
         for result in converted_eval.evaluation_results
     }
-    assert len(instance_logs) == 3
+    assert len(instance_logs) == 2
     assert {log.sample_id for log in instance_logs} == {'1'}
     assert {
         log.evaluation_result_id for log in instance_logs
@@ -231,7 +233,7 @@ def test_instance_rows_join_the_aggregate_results_they_belong_to():
     assert {log.evaluation_name for log in instance_logs} == {
         result.evaluation_name for result in converted_eval.evaluation_results
     }
-    assert converted_eval.detailed_evaluation_results.total_rows == 3
+    assert converted_eval.detailed_evaluation_results.total_rows == 2
 
 
 def test_multiple_scorers_report_their_own_score_on_their_own_row():

--- a/tests/test_lm_eval_adapter.py
+++ b/tests/test_lm_eval_adapter.py
@@ -499,9 +499,7 @@ def test_unknown_metric_is_preserved_without_invented_bounds():
     assert result.metric_config.score_type is None
     assert result.metric_config.min_score is None
     assert result.metric_config.max_score is None
-    assert result.metric_config.additional_details == {
-        'bounds_status': 'unknown'
-    }
+    assert result.metric_config.additional_details['bounds_status'] == 'unknown'
 
 
 def test_unknown_metric_count_is_recorded_on_the_log():

--- a/tests/test_lm_eval_adapter.py
+++ b/tests/test_lm_eval_adapter.py
@@ -158,17 +158,75 @@ def test_transform_from_file_evaluation_results():
 
 
 def test_transform_from_file_uncertainty():
+    """This task aggregates with `mean`, whose standard error lm-eval computes
+    analytically (`sample_stddev / sqrt(n)`), never by resampling."""
     adapter = LMEvalAdapter()
     logs = adapter.transform_from_file(RESULTS_FILE, _make_metadata_args())
 
     uncertainty = logs[1].evaluation_results[0].score_details.uncertainty
     assert uncertainty is not None
     assert uncertainty.standard_error.value == 0.0002828144211304471
-    assert uncertainty.standard_error.method == 'bootstrap'
+    assert uncertainty.standard_error.method == 'analytic'
     assert uncertainty.num_samples == 5000
-    # The resamples the standard error came from, distinct from the 5000
-    # documents the score came from.
-    assert uncertainty.num_bootstrap_samples == 100000
+    # The run configured bootstrap_iters=100000, but none of them were spent on
+    # this metric, so claiming them would overstate how the error was obtained.
+    assert uncertainty.num_bootstrap_samples is None
+
+
+def test_bootstrapped_metric_reports_the_resamples_lm_eval_actually_used():
+    """Only some aggregations are bootstrapped, and `bleu` is resampled at
+    `min(bootstrap_iters, 100)` however many the run configured."""
+    adapter = LMEvalAdapter()
+    raw_data = {
+        'results': {
+            'mytask': {
+                'bleu,none': 12.5,
+                'bleu_stderr,none': 0.4,
+                'acc,none': 0.5,
+                'acc_stderr,none': 0.01,
+            }
+        },
+        'configs': {
+            'mytask': {
+                'task': 'mytask',
+                'metric_list': [
+                    {'metric': 'bleu', 'aggregation': 'bleu'},
+                    {'metric': 'acc', 'aggregation': 'mean'},
+                ],
+            }
+        },
+        'config': {'bootstrap_iters': 100000},
+        'n-samples': {'mytask': {'effective': 40}},
+    }
+
+    by_metric = {
+        result.metric_config.metric_name: result.score_details.uncertainty
+        for result in adapter._build_evaluation_results(raw_data, 'mytask')
+    }
+
+    assert by_metric['bleu'].standard_error.method == 'bootstrap'
+    assert by_metric['bleu'].num_bootstrap_samples == 100
+    assert by_metric['acc'].standard_error.method == 'analytic'
+    assert by_metric['acc'].num_bootstrap_samples is None
+
+
+def test_unstated_aggregation_claims_no_standard_error_method():
+    """lm-eval resolves an unstated aggregation from its own registry, which the
+    log does not record, so the method is unknown rather than assumed."""
+    adapter = LMEvalAdapter()
+    raw_data = {
+        'results': {'mytask': {'acc,none': 0.5, 'acc_stderr,none': 0.01}},
+        'configs': {'mytask': {'task': 'mytask', 'metric_list': ['acc']}},
+        'config': {'bootstrap_iters': 100000},
+        'n-samples': {'mytask': {'effective': 40}},
+    }
+
+    [result] = adapter._build_evaluation_results(raw_data, 'mytask')
+    uncertainty = result.score_details.uncertainty
+
+    assert uncertainty.standard_error.value == 0.01
+    assert uncertainty.standard_error.method is None
+    assert uncertainty.num_bootstrap_samples is None
 
 
 def test_transform_from_file_generation_config():

--- a/tools/verify_metric_ids.py
+++ b/tools/verify_metric_ids.py
@@ -23,12 +23,33 @@ from pathlib import Path
 from every_eval_ever.converters.common.metrics import (
     CANONICAL_METRIC_IDS,
     DISPERSION_METRICS,
+    LOWER_IS_BETTER,
     METRIC_ID_REGISTRY_REVISION,
     METRIC_KINDS,
+    METRIC_UNITS,
+    SHARED_METRIC_BOUNDS,
 )
-from every_eval_ever.converters.helm.metrics import HELM_HARNESS_ID
+from every_eval_ever.converters.helm.metrics import (
+    HELM_HARNESS_ID,
+    HELM_METRIC_BOUNDS,
+)
 from every_eval_ever.converters.inspect.utils import INSPECT_HARNESS_ID
-from every_eval_ever.converters.lm_eval.utils import LM_EVAL_HARNESS_ID
+from every_eval_ever.converters.lm_eval.utils import (
+    LM_EVAL_HARNESS_ID,
+    LM_EVAL_METRIC_BOUNDS,
+)
+
+# Every table a converter looks a metric name up in. A name in any of them is a
+# name we can publish, so it is a name that needs an id — including one that has
+# bounds but no `metric_kind`, which is how `mc2` escaped this check.
+LOOKUP_TABLES: tuple[dict, ...] = (
+    CANONICAL_METRIC_IDS,
+    METRIC_KINDS,
+    METRIC_UNITS,
+    SHARED_METRIC_BOUNDS,
+    HELM_METRIC_BOUNDS,
+    LM_EVAL_METRIC_BOUNDS,
+)
 
 
 def normalize(surface: str) -> str:
@@ -103,8 +124,9 @@ def main(argv: list[str] | None = None) -> int:
 
     harnesses = args.seed.parent / 'harnesses.yaml'
     index = registry_index(args.seed)
-    # Every name the converters can look up, mapped or not.
-    known_names = set(CANONICAL_METRIC_IDS) | set(METRIC_KINDS)
+    # Every name the converters can look up, mapped or not. LOWER_IS_BETTER is a
+    # set rather than a table, so it is unioned separately.
+    known_names = set(LOWER_IS_BETTER).union(*LOOKUP_TABLES)
 
     stale: list[str] = []
     ambiguous: list[str] = []

--- a/tools/verify_metric_ids.py
+++ b/tools/verify_metric_ids.py
@@ -145,13 +145,22 @@ def main(argv: list[str] | None = None) -> int:
             )
 
     # Dispersion belongs in `score_details.uncertainty`, not in the registry as a
-    # metric of its own, so its absence is not a gap.
+    # metric of its own, so its absence is not counted as a gap -- but a converter
+    # can still publish one namespaced (Inspect does for `var` and lone dispersion
+    # metrics), so list them separately rather than dropping them from the report.
+    dispersion_unregistered = sorted(
+        (known_names & DISPERSION_METRICS) - set(CANONICAL_METRIC_IDS)
+    )
     unregistered = sorted(
         known_names - set(CANONICAL_METRIC_IDS) - DISPERSION_METRICS
     )
 
     print(f'registry seed: {args.seed}')
-    print(f'ids resolved against revision {METRIC_ID_REGISTRY_REVISION}')
+    print(
+        f"ids resolved against the map's pinned revision "
+        f'{METRIC_ID_REGISTRY_REVISION} (the seed file above is read as given; '
+        f'its own checkout revision is not verified)'
+    )
     print(
         f'{len(CANONICAL_METRIC_IDS)} mapped, {len(known_names)} names checked'
     )
@@ -168,6 +177,13 @@ def main(argv: list[str] | None = None) -> int:
     # publish them namespaced in the meantime.
     print(f'\nNAMESPACED, WANTING A REGISTRY ENTRY: {len(unregistered)}')
     for name in unregistered:
+        print(f'  {name}')
+    print(
+        f'\nDISPERSION, NAMESPACED WHEN PUBLISHED '
+        f'(belongs in uncertainty, not a registry gap): '
+        f'{len(dispersion_unregistered)}'
+    )
+    for name in dispersion_unregistered:
         print(f'  {name}')
     print(f'\nHARNESS SLUGS: {harness_report(harnesses)}')
 

--- a/tools/verify_metric_ids.py
+++ b/tools/verify_metric_ids.py
@@ -1,0 +1,156 @@
+"""Check the converters' canonical metric ids against an eval-card-registry checkout.
+
+`CANONICAL_METRIC_IDS` in `converters/common/metrics.py` is resolved by hand so a
+converter needs no network and gives the same answer every run. This re-does that
+resolution against a registry `seed/metrics.yaml` and reports three things: a
+mapped id the registry no longer carries, a name that now resolves but is still
+namespaced, and a name that resolves ambiguously (two canonical ids claim it,
+which is a registry-side collision rather than anything to fix here).
+
+    uv run python -m tools.verify_metric_ids --seed ../eval-card-registry/seed/metrics.yaml
+
+Exits non-zero when anything disagrees, so it can gate a registry bump. Not part
+of the test suite: it needs a checkout of a different repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from every_eval_ever.converters.common.metrics import (
+    CANONICAL_METRIC_IDS,
+    DISPERSION_METRICS,
+    METRIC_ID_REGISTRY_REVISION,
+    METRIC_KINDS,
+)
+from every_eval_ever.converters.helm.metrics import HELM_HARNESS_ID
+from every_eval_ever.converters.inspect.utils import INSPECT_HARNESS_ID
+from every_eval_ever.converters.lm_eval.utils import LM_EVAL_HARNESS_ID
+
+
+def normalize(surface: str) -> str:
+    """Fold case and separators, keeping the characters that name a metric.
+
+    `+` stays: chrF and chrF++ are different metrics, and dropping it makes the
+    registry's `chrF++` answer to a plain `chrF`. This is deliberately stricter
+    than the registry's own resolver — a verification pass should under-claim
+    matches rather than invent them.
+    """
+    return re.sub(r'[^a-z0-9+]', '', str(surface).lower())
+
+
+def registry_index(seed_path: Path) -> dict[str, set[str]]:
+    """Every surface form in the registry, mapped to the canonical ids using it."""
+    import yaml
+
+    loaded = yaml.safe_load(seed_path.read_text(encoding='utf-8'))
+    entries = (
+        loaded['metrics']
+        if isinstance(loaded, dict) and 'metrics' in loaded
+        else loaded
+    )
+
+    index: dict[str, set[str]] = {}
+    for entry in entries:
+        surfaces = [entry['id'], entry.get('display_name')]
+        surfaces.extend(entry.get('aliases') or [])
+        for surface in surfaces:
+            if surface:
+                index.setdefault(normalize(surface), set()).add(entry['id'])
+    return index
+
+
+def harness_report(harnesses_path: Path) -> str:
+    """Which converters' namespaces the registry knows as harnesses.
+
+    A namespace the registry does not carry still works as a join key inside that
+    harness; it just says so, rather than implying the registry blessed it.
+    """
+    if not harnesses_path.exists():
+        return f'{harnesses_path.name} not found beside the metric seed'
+
+    import yaml
+
+    loaded = yaml.safe_load(harnesses_path.read_text(encoding='utf-8'))
+    entries = (
+        loaded['harnesses']
+        if isinstance(loaded, dict) and 'harnesses' in loaded
+        else loaded
+    )
+    known = {normalize(entry['id']) for entry in entries}
+    return ', '.join(
+        f'{slug} {"ok" if normalize(slug) in known else "NOT IN REGISTRY"}'
+        for slug in (
+            LM_EVAL_HARNESS_ID,
+            HELM_HARNESS_ID,
+            INSPECT_HARNESS_ID,
+        )
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--seed',
+        type=Path,
+        required=True,
+        help="path to the registry's seed/metrics.yaml",
+    )
+    args = parser.parse_args(argv)
+
+    harnesses = args.seed.parent / 'harnesses.yaml'
+    index = registry_index(args.seed)
+    # Every name the converters can look up, mapped or not.
+    known_names = set(CANONICAL_METRIC_IDS) | set(METRIC_KINDS)
+
+    stale: list[str] = []
+    ambiguous: list[str] = []
+    newly_resolvable: list[str] = []
+
+    for name in sorted(known_names):
+        hits = index.get(normalize(name), set())
+        mapped = CANONICAL_METRIC_IDS.get(name)
+        if len(hits) > 1:
+            ambiguous.append(f'{name} -> {sorted(hits)}')
+        if mapped is None and hits:
+            newly_resolvable.append(f'{name} -> {sorted(hits)[0]}')
+        elif mapped is not None and mapped not in hits:
+            stale.append(
+                f'{name} -> {mapped} (registry now says {sorted(hits) or "nothing"})'
+            )
+
+    # Dispersion belongs in `score_details.uncertainty`, not in the registry as a
+    # metric of its own, so its absence is not a gap.
+    unregistered = sorted(
+        known_names - set(CANONICAL_METRIC_IDS) - DISPERSION_METRICS
+    )
+
+    print(f'registry seed: {args.seed}')
+    print(f'ids resolved against revision {METRIC_ID_REGISTRY_REVISION}')
+    print(
+        f'{len(CANONICAL_METRIC_IDS)} mapped, {len(known_names)} names checked'
+    )
+    for label, rows in (
+        ('MAPPED ID NO LONGER IN THE REGISTRY', stale),
+        ('NOW RESOLVABLE, STILL NAMESPACED', newly_resolvable),
+        ('AMBIGUOUS IN THE REGISTRY', ambiguous),
+    ):
+        print(f'\n{label}: {len(rows)}')
+        for row in rows:
+            print(f'  {row}')
+
+    # Not a failure: these are the entries to propose upstream, and the converters
+    # publish them namespaced in the meantime.
+    print(f'\nNAMESPACED, WANTING A REGISTRY ENTRY: {len(unregistered)}')
+    for name in unregistered:
+        print(f'  {name}')
+    print(f'\nHARNESS SLUGS: {harness_report(harnesses)}')
+
+    return 1 if stale or newly_resolvable or ambiguous else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
> Stacked on #245 (`fix/converter-metric-naming-3fields`), which is itself stacked on #244. **Review those first**; diff against the naming branch, not main.

## What / source

The three harness converters were each *asserting* things about their metrics that the upstream logs never say. This PR makes each converter report what its harness actually computed, and say "unknown" where the harness does not know.

Four groups of change, all funnelling through one new module (`converters/common/metrics.py`) so a rule is stated once for every converter:

**1. Bounds and direction, only where they are known.** Every HELM and Inspect metric was published as `continuous` on `[0, 1]` with `lower_is_better: false`, so a perplexity, a standard deviation and an accuracy all came out looking like accuracies. Now a metric's range comes from its *name*, layered per harness — lm-eval's `bleu` is sacrebleu's 0–100 while HELM's `bleu_1` is nltk's `sentence_bleu` 0–1, so a bare name cannot carry a range. A metric in no table gets **no bounds** and an `additional_details.bounds_status: unknown` marker, because `min_score`/`max_score` are nullable and "not provided" is true, while `[0, 1]` on an unbounded metric is not. Each record counts its unknown-bounds metrics in `source_metadata.additional_details`, so the gap is visible without reopening every file — and `test_unknown_bounds_are_counted_in_the_source_metadata` derives that count from the published results for every case, which is how the Inspect converter was caught reporting `null` while publishing an unbounded metric.

Dispersion metrics (`std`, `stderr`, `bootstrap_stderr`, `var`) get `polarity: not_applicable`: `lower_is_better` is a required boolean with no "does not apply" value, and a standard deviation is not better when small.

One of the ranges this PR introduced was itself wrong and is fixed here: `brier_score` was declared `[0, 1]`, the two-class definition. lm-eval computes `mean(sum((softmax(loglikelihoods) - one_hot(gold)) ** 2))` (`api/task.py`), which over `n` classes reaches **2.0** when all the mass sits on one wrong class. Since `validation_core.py` warns on a score outside its declared range and the converter suite requires zero warnings, the too-narrow bound would have failed the merge gate on a legitimate score. Now `[0, 2]`, pinned by `test_a_multi_class_brier_score_is_allowed_its_full_range`.

**2. Sample counts that count samples.** HELM took `num_samples` from a stat's `count`, which is its **train-trial** count — 1 for nearly every published run, whatever the instance count. It now counts per-instance stats keyed per split and perturbation, falls back to HELM's own per-split `num_instances` for the worst-case perturbation stats that have none, and moves the trial count to `score_details.details.num_train_trials`. Inspect took `num_samples` from the length of a sample list that a header-only log does not populate; it now reads the results header.

**3. Uncertainty, as each harness computed it — and never dropped.** HELM republished the 0.0 spread *over a single train trial* as a measured `standard_deviation`; the schema defines that field over per-sample scores, so it is now omitted rather than reported as zero. Inspect dropped a standard error of exactly `0.0` as if it were absent (falsy, not missing), routed nothing for `bootstrap_stderr`, and emitted a scorer's `std` as a **score of its own** alongside the score it describes — it now carries it as `uncertainty.standard_deviation` on those scores, unless `std` is all that scorer reported. lm-eval derives the standard-error method from the aggregation its log records instead of asserting `'bootstrap'`, and reports a resample count only for aggregations that are actually resampled.

`bootstrap_stderr` was in neither the shared bounds nor `DISPERSION_METRICS` while `stderr` was in both, so a converter publishing the former claimed an unknown range and an applicable direction. It is a standard error computed by resampling rather than in closed form — same bounds, same polarity.

**4. `metric_id`, so a consumer can join across harnesses.** The previous PR gave every result a `metric_name`; nothing tied lm-eval's `exact_match` to HELM's. `metric_config_fields` now resolves a metric name to the **eval-card-registry's canonical slug** where the registry carries one (18 of 45 names), and to `<harness>.<name>` where it does not — marked `metric_id_status: unregistered`, so a namespaced id claims a stable join key *within* the harness and no global identity. Both forms record the registry revision they were resolved against (`8b83e9c`, that repo's `main`), because an `unregistered` marker with no revision beside it does not tell a reader whether the entry has since been added.

`metric_kind` (the family a metric aggregates safely within) and `metric_unit` come along because they answer what an id alone leaves open. The unit is **derived from the resolved bounds**, not listed: lm-eval's sacrebleu `bleu` reports `percent` and HELM's nltk `bleu_1` reports `proportion` from their bounds alone, with neither spelled out.

## Why the map is hand-resolved, and how you check it

A converter has to run offline and give the same answer on every run, so `CANONICAL_METRIC_IDS` is 18 hand-verified entries against a pinned revision rather than a network call to the registry's resolver. `tools/verify_metric_ids.py` re-does the resolution against a registry checkout and fails (exit 1) on the three ways the map can rot:

```
$ uv run python -m tools.verify_metric_ids --seed ../eval-card-registry/seed/metrics.yaml
ids resolved against revision 8b83e9c
18 mapped, 45 names checked

MAPPED ID NO LONGER IN THE REGISTRY: 0
NOW RESOLVABLE, STILL NAMESPACED: 0
AMBIGUOUS IN THE REGISTRY: 0

NAMESPACED, WANTING A REGISTRY ENTRY: 22
  acc_norm, bits_per_byte, brier_score, byte_perplexity, calibration_error,
  chain_of_thought_correctness, chrf, classification_macro_f1,
  classification_micro_f1, ece, ifeval_strict_accuracy, math_equiv,
  math_equiv_chain_of_thought, mc1, mc2, mcc, prefix_exact_match,
  quasi_exact_match, quasi_prefix_exact_match, rougeLsum, ter, word_perplexity

HARNESS SLUGS: lm-evaluation-harness ok, helm ok, inspect_ai NOT IN REGISTRY
```

That last list is not a failure — it is the content of a follow-up **eval-card-registry PR**, together with an `@k` slug family for HELM's best-of-k metrics and an `inspect_ai` harness entry. It is a tool rather than a test because it needs a sibling repo checkout, which CI does not have.

Two matching rules in it are worth a second of your attention: normalization keeps `+`, so `chrF++` never answers to `chrf`; and `chrf` (plain) is in the gap list *because* the registry's `chrf-plus-plus` is a different metric.

**Interaction with #222.** That PR adds `check_metric_identity`, which warns on a missing `metric_id`, a semantically-empty one (`score`, `mean`, `overall`, …) and one equal to `evaluation_name`. I ran that branch's validator over all six files these three converters publish: **6 files, 0 complaints, exit 0**, then set one `metric_id` to `'score'` as a tripwire and confirmed the check fires. Namespaced ids survive because `_normalize_metric_id` maps `-`→`_` but leaves `.` alone, so `inspect_ai.mean` is never generic. Since all three converters now always set an id, this PR *removes* #222's "missing" finding for them.

## Checklist

- [x] `uv run python -m every_eval_ever validate <files>` clean, **no warnings**, at the final `data/<collection>/<dev>/<model>/` path — 6 files, 0 complaints, exit 0; asserted by the stack's harness on every run
- [x] every unconvertible source row is in `adapter_reports/` with a non-zero exit — and one case improves: a HELM run whose stats are all bookkeeping is now reported *per run* instead of failing the whole invocation from inside the publisher
- [x] offline unit test added + full `uv run pytest tests` green — core 438 passed / 39 skipped, full 524 passed / 1 skipped
- [x] `uv run ruff check` clean
- [x] **model/benchmark/metric ids resolve in the registry** — 18 resolve against `8b83e9c`; the other 22 are namespaced, marked `unregistered`, and listed above for the registry PR. `tests/test_converter_conversion.py::test_every_metric_id_is_either_canonical_or_openly_namespaced` is the enforcement: an id is either in the verified map or carries its harness prefix, never a bare unqualified guess.
- [x] content spot-checked — no answer leakage, nothing double-counted, `evaluation_id` unaffected. `tests/test_converter_metric_bounds.py` (16 tests) pins the shared rules directly.

## Review lane

- [ ] Fast
- [x] **Needs a human** — a material change in outcome. `min_score`/`max_score`/`score_type` disappear from metrics whose range is unknown, `num_samples` changes value for HELM, a HELM `standard_deviation` disappears, an Inspect `std` stops being a score and becomes an uncertainty field, and every result gains a `metric_id`. Same scores, different metadata about them.

Design agreed in: not yet. The specific calls I would want a maintainer to confirm, in order of how much they would cost to change later:

1. **Namespaced ids as the fallback.** `helm.quasi_exact_match` is data that a later registry entry supersedes — every one of those 22 becomes a canonical id in a follow-up, and any record already published under the namespaced form then needs remapping. The alternative is a null `metric_id` until the registry catches up, which is honest but makes the field useless for the harnesses' most common metrics.
2. **Omitting bounds rather than defaulting to [0, 1].** This is the `AGENTS.md` "report, don't interpret" principle applied literally. Of the 45 names the tables carry, 41 get a range and 4 deliberately do not (`calibration_error`, `cer`, `ece`, `wer` — an error rate with no upper bound in the general case); any metric outside every table also gets none, where before HELM and Inspect stamped `[0, 1]` on it. On these fixtures that is 1 of 28 results (Inspect's `mean`). If any downstream consumer treats a null `max_score` as an error rather than as unknown, they will feel it there first.
3. **An Inspect `std` is no longer a score.** It is the one place where a result *count* changes for a reason other than naming.

## Decisions & coverage

- Decision / where: a metric absent from every bounds table gets no bounds plus `bounds_status: unknown`, in `converters/common/metrics.py::metric_bounds_fields`.
  Chose / instead of: keeping `[0, 1]`, which is what HELM and Inspect did and what makes every record look complete.
  Confidence: high — a wrong range is worse than a missing one; the schema makes both fields nullable precisely for this, and the count in `source_metadata` keeps the gap measurable.
  General? yes — this is the rule any converter should follow.
- Decision / where: bounds are layered per harness on top of `SHARED_METRIC_BOUNDS`, in each converter's own table.
  Chose / instead of: one global name→range map.
  Confidence: high — `bleu` is the counterexample that forces it: sacrebleu 0–100 in lm-eval, nltk 0–1 for HELM's `bleu_1`/`bleu_4`. One map would have to be wrong for one of them.
  General? yes.
- Decision / where: `metric_unit` derived from the resolved bounds, with `METRIC_UNITS` holding only the metrics whose bounds cannot show their scale (`bits_per_byte`, `chrf`, `ter`).
  Chose / instead of: listing a unit per metric name.
  Confidence: high — a listed unit and a listed range can disagree; a derived one cannot.
  General? yes.
- Decision / where: a parameter the harness spells into a name takes bounds from the undecorated name but never the id, in `metric_config_fields` (`lookup_name`).
  Chose / instead of: resolving `exact_match@5` to `exact-match`.
  Confidence: high — best-of-five exact match is a different and systematically higher quantity, and the registry gives such metrics their own slug (`pass-at-1`, `recall-at-5`). Sharing `exact-match` would silently average the two in any cross-source query.
  General? yes — it is the general rule for `@k`, `_norm` and similar decorations.
- Decision / where: the registry revision is recorded on **resolved** ids too, not only unregistered ones (`_ID_REVISION`).
  Chose / instead of: marking only the gaps.
  Confidence: high — both are claims about a registry state; a reader of an old record needs to know which state.
  General? yes.
- Decision / where: id resolution is a hand-verified map + an offline `tools/` checker.
  Chose / instead of: calling the registry's resolver at conversion time.
  Confidence: high — converters must run offline and be reproducible; a network lookup makes last month's conversion unrepeatable.
  General? yes.
- Decision / where: a HELM run with no usable stats is reported as a per-run failure rather than raising inside the publisher.
  Chose / instead of: leaving the exception, which fails the whole `--log_path` directory.
  Confidence: high — `SourceConversionResult` + `save_failure_report` + non-zero exit is the repo's documented contract for exactly this.
  General? yes.

**Coverage:** 28 results over the three fixtures — 2 lm_eval, 2 inspect (was 3 — an Inspect `std` becomes an uncertainty field on the scores it describes rather than a score of its own), 24 helm. Nothing silently dropped; 1 of the 28 comes out without bounds and says so, and 22 of the 45 distinct metric names carry a namespaced rather than canonical id, listed above rather than hidden.

**Operator asked about policy calls?** Yes — new canonical ids and unbounded metrics, which is why this is needs-a-human. Both listed under "Design agreed in" above: whether namespaced `<harness>.<name>` ids are acceptable as published data pending registry entries, and whether omitting bounds for a metric no table carries is preferred over the previous `[0, 1]` default.
