### PR TITLE
[Feature] DRAFT/DO NOT MERGE - Add a daily adapter refresh cron

### DIFF
--- a/.github/workflows/adapter_cron.yml
+++ b/.github/workflows/adapter_cron.yml
@@ -31,17 +31,9 @@ permissions:
   contents: read
 
 env:
-  # One place for the credentials both planning and refreshing need. An
-  # adapter's requires_env name must appear here (tests enforce it).
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
-  ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
-  LLM_STATS_API_KEY: ${{ secrets.LLM_STATS_API_KEY }}
+  # Not a secret; safe at workflow scope. Secrets are deliberately passed only
+  # to the command steps that use them, never to checkout/setup/artifact steps.
   EEE_RAW_REPO_ID: ${{ vars.EEE_RAW_REPO_ID || 'evaleval/EEE_raw' }}
-
-concurrency:
-  # Never let two refreshes of the same adapter race for its pull request.
-  group: adapter-cron
-  cancel-in-progress: false
 
 jobs:
   plan:
@@ -62,6 +54,11 @@ jobs:
       - name: Check credentials and destinations
         env:
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # Adapter keys are present so preflight reports which adapters are
+          # held back. requires_env names must appear here (tests enforce it).
+          ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
+          LLM_STATS_API_KEY: ${{ secrets.LLM_STATS_API_KEY }}
         run: |
           uv run python -m every_eval_ever.cron preflight \
             --raw-repo-id "$EEE_RAW_REPO_ID" \
@@ -72,6 +69,10 @@ jobs:
         env:
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
           REQUESTED: ${{ inputs.adapter }}
+          # Presence-only: the schedule uses these to tell a credentialed
+          # adapter apart from an unconfigured one.
+          ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
+          LLM_STATS_API_KEY: ${{ secrets.LLM_STATS_API_KEY }}
         run: |
           set -euo pipefail
           if [ -n "${REQUESTED}" ]; then
@@ -94,6 +95,14 @@ jobs:
     name: ${{ matrix.adapter }}
     needs: plan
     if: needs.plan.outputs.adapters != '[]'
+    # Scoped to one adapter and one mode: two publishes of the same adapter
+    # must never race for its pull request, but unrelated adapters, and dry
+    # runs against publishes, should not queue behind each other — GitHub also
+    # keeps only one pending run per group and silently replaces the older one,
+    # so a wide group can drop a refresh entirely.
+    concurrency:
+      group: adapter-cron-${{ matrix.adapter }}-${{ inputs.dry_run && 'dry-run' || 'publish' }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     # Well under the 6-hour job ceiling: an adapter that hangs should fail
     # today rather than burn a runner and collide with tomorrow's run.
@@ -118,6 +127,10 @@ jobs:
       - name: Refresh ${{ matrix.adapter }}
         env:
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # Each adapter job receives only its own source credential.
+          ARTIFICIAL_ANALYSIS_API_KEY: ${{ matrix.adapter == 'artificial_analysis' && secrets.ARTIFICIAL_ANALYSIS_API_KEY || '' }}
+          LLM_STATS_API_KEY: ${{ matrix.adapter == 'llm_stats' && secrets.LLM_STATS_API_KEY || '' }}
         run: |
           set -uo pipefail
           # The default shell is `bash -e`, which would abort the step before
@@ -166,15 +179,15 @@ jobs:
                    "invocation(s) failed; published \(.records) record(s)"
                  else empty end' "$summary"
 
-      # A short-lived convenience copy. Permanent retention is the raw dataset;
-      # this is here so a failed run's reports are one click away.
+      # Reports and the run summary only — never cron-work/raw: artifacts on a
+      # public repository are downloadable by anyone signed in, and raw source
+      # bodies belong solely in the private raw dataset.
       - name: Upload reports and summary
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: cron-${{ matrix.adapter }}-${{ github.run_number }}
           path: |
-            ${{ runner.temp }}/cron-work/raw/
             ${{ runner.temp }}/cron-work/adapter_reports/
             ${{ runner.temp }}/cron-work/summary.json
           if-no-files-found: warn

--- a/.github/workflows/adapter_cron.yml
+++ b/.github/workflows/adapter_cron.yml
@@ -30,6 +30,14 @@ on:
 permissions:
   contents: read
 
+env:
+  # One place for the credentials both planning and refreshing need. An
+  # adapter's requires_env name must appear here (tests enforce it).
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
+  LLM_STATS_API_KEY: ${{ secrets.LLM_STATS_API_KEY }}
+  EEE_RAW_REPO_ID: ${{ vars.EEE_RAW_REPO_ID || 'evaleval/EEE_raw' }}
+
 concurrency:
   # Never let two refreshes of the same adapter race for its pull request.
   group: adapter-cron
@@ -54,22 +62,15 @@ jobs:
       - name: Check credentials and destinations
         env:
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
-          LLM_STATS_API_KEY: ${{ secrets.LLM_STATS_API_KEY }}
         run: |
           uv run python -m every_eval_ever.cron preflight \
-            --raw-repo-id "${{ vars.EEE_RAW_REPO_ID || 'evaleval/EEE_raw' }}" \
+            --raw-repo-id "$EEE_RAW_REPO_ID" \
             --markdown "$GITHUB_STEP_SUMMARY"
 
       - name: Decide which adapters to refresh
         id: plan
         env:
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
-          # Present here only so the schedule can tell a credentialed adapter
-          # apart from an unconfigured one.
-          ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
-          LLM_STATS_API_KEY: ${{ secrets.LLM_STATS_API_KEY }}
           REQUESTED: ${{ inputs.adapter }}
         run: |
           set -euo pipefail
@@ -115,32 +116,28 @@ jobs:
         run: uv sync --locked --all-extras
 
       - name: Refresh ${{ matrix.adapter }}
-        id: refresh
         env:
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
-          LLM_STATS_API_KEY: ${{ secrets.LLM_STATS_API_KEY }}
         run: |
           set -uo pipefail
-          # The default shell is `bash -e`, which would abort the step before the
-          # exit code can be read. Exit 2 is a successful no-op, not a failure.
+          # The default shell is `bash -e`, which would abort the step before
+          # the exit code can be read. Exit 3 is a successful no-op ("nothing
+          # new"); anything else non-zero — including argparse's usage-error
+          # exit 2 — must fail the job.
           set +e
           uv run python -m every_eval_ever.cron run "${{ matrix.adapter }}" \
             --work-dir "${{ runner.temp }}/cron-work" \
             --summary "${{ runner.temp }}/cron-work/summary.json" \
-            --raw-repo-id "${{ vars.EEE_RAW_REPO_ID || 'evaleval/EEE_raw' }}" \
+            --raw-repo-id "$EEE_RAW_REPO_ID" \
             --run-id "${{ github.run_id }}-${{ github.run_attempt }}" \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             ${{ inputs.dry_run && '--dry-run' || '' }} \
             ${{ inputs.force && '--force' || '' }}
           code=$?
           set -e
-          case "$code" in
-            0) echo 'published=true' >> "$GITHUB_OUTPUT" ;;
-            2) echo 'published=false' >> "$GITHUB_OUTPUT" ;;
-            *) echo 'published=false' >> "$GITHUB_OUTPUT"; exit "$code" ;;
-          esac
+          if [ "$code" -ne 0 ] && [ "$code" -ne 3 ]; then
+            exit "$code"
+          fi
 
       - name: Summarise the run
         if: always()

--- a/.github/workflows/adapter_cron.yml
+++ b/.github/workflows/adapter_cron.yml
@@ -1,9 +1,10 @@
 name: Daily adapter refresh
 
-# Refreshes each source adapter once a day and sends its records to that
-# adapter's own datastore pull request. One matrix job per adapter, so each has
-# its own 6-hour job budget, its own failure, and its own PR: a slow or broken
-# adapter cannot hold up the others.
+# Refreshes each source adapter once a day, stores what it fetched in the
+# private raw dataset, and sends its records to that adapter's own datastore
+# pull request. One matrix job per adapter, so each has its own 6-hour job
+# budget, its own failure, and its own PR: a slow or broken adapter cannot hold
+# up the others.
 #
 # Design notes and how to add an adapter: every_eval_ever/cron/README.md
 
@@ -100,14 +101,6 @@ jobs:
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
         run: uv sync --locked --all-extras
 
-      - name: Restore the previous run fingerprint
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ runner.temp }}/fingerprint
-          key: eee-cron-fingerprint-${{ matrix.adapter }}-${{ github.run_id }}
-          restore-keys: |
-            eee-cron-fingerprint-${{ matrix.adapter }}-
-
       - name: Refresh ${{ matrix.adapter }}
         id: refresh
         env:
@@ -122,8 +115,9 @@ jobs:
           set +e
           uv run python -m every_eval_ever.cron run "${{ matrix.adapter }}" \
             --work-dir "${{ runner.temp }}/cron-work" \
-            --fingerprint "${{ runner.temp }}/fingerprint/${{ matrix.adapter }}" \
             --summary "${{ runner.temp }}/cron-work/summary.json" \
+            --raw-repo-id "${{ vars.EEE_RAW_REPO_ID || 'evaleval/EEE_raw' }}" \
+            --run-id "${{ github.run_id }}-${{ github.run_attempt }}" \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             ${{ inputs.dry_run && '--dry-run' || '' }} \
             ${{ inputs.force && '--force' || '' }}
@@ -145,10 +139,12 @@ jobs:
             echo
             jq -r '"- Status: **\(.status)** — \(.detail)",
                    "- Records: \(.records) in \(.collections | join(", "))",
-                   "- Raw payloads archived: \(.raw_payloads) (\(.raw_bytes) bytes, policy \(.raw_policy))",
+                   "- Raw payloads captured: \(.raw_payloads) (\(.raw_bytes) bytes, policy \(.raw_policy))",
+                   "- Raw archive: \(.raw_archive.status)" +
+                     (if .raw_archive.ledger_path then " → `\(.raw_archive.repo_id)` `\(.raw_archive.ledger_path)` (\(.raw_archive.uploaded) new, \(.raw_archive.reused) reused)" else "" end),
                    "- Fingerprint source: \(.fingerprint_source // "n/a")"' "$summary"
-            jq -r 'if (.defaulted_fields | length) > 0
-                   then "- Defaulted to unknown: " + ([.defaulted_fields | to_entries[] | "\(.key) (\(.value))"] | join(", "))
+            jq -r 'if (.unknown_inferred_fields | length) > 0
+                   then "- Inferred axes still unknown: " + ([.unknown_inferred_fields | to_entries[] | "\(.key) (\(.value))"] | join(", "))
                    else empty end' "$summary"
             jq -r 'if .pr_url then "- Pull request: \(.pr_url)" else empty end' "$summary"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -160,7 +156,9 @@ jobs:
                    "invocation(s) failed; published \(.records) record(s)"
                  else empty end' "$summary"
 
-      - name: Upload raw data, reports, and summary
+      # A short-lived convenience copy. Permanent retention is the raw dataset;
+      # this is here so a failed run's reports are one click away.
+      - name: Upload reports and summary
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -171,10 +169,3 @@ jobs:
             ${{ runner.temp }}/cron-work/summary.json
           if-no-files-found: warn
           retention-days: 90
-
-      - name: Store the fingerprint for tomorrow
-        if: steps.refresh.outputs.published == 'true' && !inputs.dry_run
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ runner.temp }}/fingerprint
-          key: eee-cron-fingerprint-${{ matrix.adapter }}-${{ github.run_id }}

--- a/.github/workflows/adapter_cron.yml
+++ b/.github/workflows/adapter_cron.yml
@@ -49,6 +49,19 @@ jobs:
         env:
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
         run: uv sync --locked
+      # Runs first because the refresh fails closed: a token that cannot store
+      # raw data would otherwise fail every adapter at its last step.
+      - name: Check credentials and destinations
+        env:
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
+          LLM_STATS_API_KEY: ${{ secrets.LLM_STATS_API_KEY }}
+        run: |
+          uv run python -m every_eval_ever.cron preflight \
+            --raw-repo-id "${{ vars.EEE_RAW_REPO_ID || 'evaleval/EEE_raw' }}" \
+            --markdown "$GITHUB_STEP_SUMMARY"
+
       - name: Decide which adapters to refresh
         id: plan
         env:

--- a/.github/workflows/adapter_cron.yml
+++ b/.github/workflows/adapter_cron.yml
@@ -69,10 +69,6 @@ jobs:
         env:
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
           REQUESTED: ${{ inputs.adapter }}
-          # Presence-only: the schedule uses these to tell a credentialed
-          # adapter apart from an unconfigured one.
-          ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
-          LLM_STATS_API_KEY: ${{ secrets.LLM_STATS_API_KEY }}
         run: |
           set -euo pipefail
           if [ -n "${REQUESTED}" ]; then
@@ -162,7 +158,7 @@ jobs:
             echo
             jq -r '"- Status: **\(.status)** — \(.detail)",
                    "- Records: \(.records) in \(.collections | join(", "))",
-                   "- Raw payloads captured: \(.raw_payloads) (\(.raw_bytes) bytes, policy \(.raw_policy))",
+                   "- Raw payloads captured: \(.raw_payloads) (\(.raw_bytes) bytes, policy \(.raw_policy); \(.raw_skipped) over-ceiling, \(.capture_errors | length) capture error(s))",
                    "- Raw archive: \(.raw_archive.status)" +
                      (if .raw_archive.ledger_path then " → `\(.raw_archive.repo_id)` `\(.raw_archive.ledger_path)` (\(.raw_archive.uploaded) new, \(.raw_archive.reused) reused)" else "" end),
                    "- Fingerprint source: \(.fingerprint_source // "n/a")"' "$summary"
@@ -179,16 +175,15 @@ jobs:
                    "invocation(s) failed; published \(.records) record(s)"
                  else empty end' "$summary"
 
-      # Reports and the run summary only — never cron-work/raw: artifacts on a
-      # public repository are downloadable by anyone signed in, and raw source
-      # bodies belong solely in the private raw dataset.
-      - name: Upload reports and summary
+      # The run summary only. Raw bodies live solely in the private raw
+      # dataset, and adapter failure reports go there too — they embed raw
+      # source rows, and artifacts on a public repository are downloadable by
+      # anyone signed in.
+      - name: Upload the run summary
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: cron-${{ matrix.adapter }}-${{ github.run_number }}
-          path: |
-            ${{ runner.temp }}/cron-work/adapter_reports/
-            ${{ runner.temp }}/cron-work/summary.json
+          path: ${{ runner.temp }}/cron-work/summary.json
           if-no-files-found: warn
           retention-days: 90

--- a/.github/workflows/adapter_cron.yml
+++ b/.github/workflows/adapter_cron.yml
@@ -1,0 +1,180 @@
+name: Daily adapter refresh
+
+# Refreshes each source adapter once a day and sends its records to that
+# adapter's own datastore pull request. One matrix job per adapter, so each has
+# its own 6-hour job budget, its own failure, and its own PR: a slow or broken
+# adapter cannot hold up the others.
+#
+# Design notes and how to add an adapter: every_eval_ever/cron/README.md
+
+on:
+  schedule:
+    # 04:17 UTC. Off the hour, where scheduled-workflow queues are shortest.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+    inputs:
+      adapter:
+        description: 'Single adapter to refresh (blank = every scheduled adapter)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Run everything except the datastore commit'
+        type: boolean
+        default: false
+      force:
+        description: 'Publish even if the source has not changed since the last run'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never let two refreshes of the same adapter race for its pull request.
+  group: adapter-cron
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      adapters: ${{ steps.plan.outputs.adapters }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: astral-sh/setup-uv@v7.6.0
+      - name: Install dependencies
+        env:
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
+        run: uv sync --locked
+      - name: Decide which adapters to refresh
+        id: plan
+        env:
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
+          # Present here only so the schedule can tell a credentialed adapter
+          # apart from an unconfigured one.
+          ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
+          LLM_STATS_API_KEY: ${{ secrets.LLM_STATS_API_KEY }}
+          REQUESTED: ${{ inputs.adapter }}
+        run: |
+          set -euo pipefail
+          if [ -n "${REQUESTED}" ]; then
+            printf 'adapters=["%s"]\n' "${REQUESTED}" >> "$GITHUB_OUTPUT"
+            echo "Refreshing only ${REQUESTED} (manual dispatch)." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          uv run python -m every_eval_ever.cron list > plan.json
+          jq -c '.adapters' plan.json | sed 's/^/adapters=/' >> "$GITHUB_OUTPUT"
+          {
+            echo '## Planned refresh'
+            echo
+            echo "Adapters: $(jq -r '.adapters | join(", ")' plan.json)"
+            echo
+            echo '### Not run today'
+            jq -r '.skipped | to_entries[] | "- **\(.key)**: \(.value)"' plan.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  refresh:
+    name: ${{ matrix.adapter }}
+    needs: plan
+    if: needs.plan.outputs.adapters != '[]'
+    runs-on: ubuntu-latest
+    # Well under the 6-hour job ceiling: an adapter that hangs should fail
+    # today rather than burn a runner and collide with tomorrow's run.
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      # Raise this to widen the daily wave; it only exists so a refresh leaves
+      # runner capacity for pull request CI.
+      max-parallel: 6
+      matrix:
+        adapter: ${{ fromJSON(needs.plan.outputs.adapters) }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: astral-sh/setup-uv@v7.6.0
+      - name: Install dependencies
+        # --all-extras because three adapters read HuggingFace datasets through
+        # `datasets`, which reaches the lock only via the helm extra.
+        env:
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
+        run: uv sync --locked --all-extras
+
+      - name: Restore the previous run fingerprint
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/fingerprint
+          key: eee-cron-fingerprint-${{ matrix.adapter }}-${{ github.run_id }}
+          restore-keys: |
+            eee-cron-fingerprint-${{ matrix.adapter }}-
+
+      - name: Refresh ${{ matrix.adapter }}
+        id: refresh
+        env:
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
+          LLM_STATS_API_KEY: ${{ secrets.LLM_STATS_API_KEY }}
+        run: |
+          set -uo pipefail
+          # The default shell is `bash -e`, which would abort the step before the
+          # exit code can be read. Exit 2 is a successful no-op, not a failure.
+          set +e
+          uv run python -m every_eval_ever.cron run "${{ matrix.adapter }}" \
+            --work-dir "${{ runner.temp }}/cron-work" \
+            --fingerprint "${{ runner.temp }}/fingerprint/${{ matrix.adapter }}" \
+            --summary "${{ runner.temp }}/cron-work/summary.json" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            ${{ inputs.dry_run && '--dry-run' || '' }} \
+            ${{ inputs.force && '--force' || '' }}
+          code=$?
+          set -e
+          case "$code" in
+            0) echo 'published=true' >> "$GITHUB_OUTPUT" ;;
+            2) echo 'published=false' >> "$GITHUB_OUTPUT" ;;
+            *) echo 'published=false' >> "$GITHUB_OUTPUT"; exit "$code" ;;
+          esac
+
+      - name: Summarise the run
+        if: always()
+        run: |
+          summary="${{ runner.temp }}/cron-work/summary.json"
+          [ -f "$summary" ] || { echo "No summary written." >> "$GITHUB_STEP_SUMMARY"; exit 0; }
+          {
+            echo "## ${{ matrix.adapter }}"
+            echo
+            jq -r '"- Status: **\(.status)** — \(.detail)",
+                   "- Records: \(.records) in \(.collections | join(", "))",
+                   "- Raw payloads archived: \(.raw_payloads) (\(.raw_bytes) bytes, policy \(.raw_policy))",
+                   "- Fingerprint source: \(.fingerprint_source // "n/a")"' "$summary"
+            jq -r 'if (.defaulted_fields | length) > 0
+                   then "- Defaulted to unknown: " + ([.defaulted_fields | to_entries[] | "\(.key) (\(.value))"] | join(", "))
+                   else empty end' "$summary"
+            jq -r 'if .pr_url then "- Pull request: \(.pr_url)" else empty end' "$summary"
+          } >> "$GITHUB_STEP_SUMMARY"
+          # A partial refresh publishes real data, so the job is green. Annotate
+          # it anyway, or a source that half-converts every day goes unnoticed.
+          jq -r 'if (.failed_invocations | length) > 0 then
+                   "::warning title=Partial refresh::\(.adapter): " +
+                   "\(.failed_invocations | length) of \(.invocations) " +
+                   "invocation(s) failed; published \(.records) record(s)"
+                 else empty end' "$summary"
+
+      - name: Upload raw data, reports, and summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cron-${{ matrix.adapter }}-${{ github.run_number }}
+          path: |
+            ${{ runner.temp }}/cron-work/raw/
+            ${{ runner.temp }}/cron-work/adapter_reports/
+            ${{ runner.temp }}/cron-work/summary.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Store the fingerprint for tomorrow
+        if: steps.refresh.outputs.published == 'true' && !inputs.dry_run
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/fingerprint
+          key: eee-cron-fingerprint-${{ matrix.adapter }}-${{ github.run_id }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ convert external eval sources into it.
 - `every_eval_ever/instance_level_types.py` + `instance_level_eval.schema.json` — instance log.
 - `every_eval_ever/adapters/<name>/adapter.py` — one-off source adapters (run via `uv run python -m every_eval_ever.adapters.<name>.adapter`).
 - `every_eval_ever/converters/` — in-tree converters (`inspect`/`helm`/`lm_eval`, plus `alpaca_eval`; shared code in `common`), run via `uv run python -m every_eval_ever convert <inspect|helm|lm_eval> ...`.
+- `every_eval_ever/cron/` — the daily adapter refresh: `schedule.py` says which adapters
+  run and how, `runner.py` runs one end to end. See its `README.md`.
 - `every_eval_ever/validator/` — the schema + **semantic** merge gate (path shape, UUID4 names,
   companion pairing, score bounds, deployment axes). `REGISTERED_CHECKS` is the list.
 - Validate: `uv run python -m every_eval_ever validate <files-or-glob>` (`.json`→aggregate,

--- a/every_eval_ever/adapters/README.md
+++ b/every_eval_ever/adapters/README.md
@@ -14,6 +14,11 @@ re-validates those templates against the live validator, so they stay current.
 
 Each adapter is run with `uv run python -m every_eval_ever.adapters.<name>.adapter`.
 
+Most of these also run on a daily schedule, which archives what they fetch and
+sends each adapter's records to its own datastore pull request — see
+[`every_eval_ever/cron/README.md`](../cron/README.md). Adding an adapter here
+means deciding whether it belongs on that schedule; a test fails until you do.
+
 ## Adapters
 
 | Adapter | Data Source | Description |

--- a/every_eval_ever/cron/README.md
+++ b/every_eval_ever/cron/README.md
@@ -95,8 +95,10 @@ state/<adapter>.json                   # what the last successful publish was
 ```
 
 Privacy is enforced, not assumed: preflight fails if the raw dataset is public,
-and the archive re-checks visibility immediately before every commit and
-refuses to write to a public dataset.
+the archive re-checks visibility immediately before every commit and refuses to
+write to a public dataset, and the workflow's artifact carries only reports and
+the run summary — never captured payloads, which on a public repository anyone
+signed in could download.
 
 Payloads are **content-addressed**, so a source that has not changed since
 yesterday costs nothing but a ledger row — which is what makes keeping every day
@@ -118,9 +120,9 @@ date rather than only on the days something changed.
 
 Archiving happens **before** anything is published, and a failure to archive
 stops the run. Records should not reach the datastore without their raw
-provenance stored. The workflow also uploads raw payloads and
-`adapter_reports/` as a 90-day artifact, but that is a convenience copy, not the
-retention mechanism.
+provenance stored. The workflow also uploads `adapter_reports/` and the run summary as a 90-day
+artifact for debugging; raw payloads deliberately never leave the private
+dataset.
 
 **An unchanged source publishes nothing.** A run fingerprints the source and
 stops if it matches the previous run — using the verbatim response bodies where
@@ -138,10 +140,20 @@ ledger is written before publishing, which is why it cannot be the gate). A run
 that failed to publish leaves the old state, so its records are retried the
 next day instead of skipped as "unchanged" and silently lost. And a partial
 publish records `partial: true`, which the next run treats as "publish
-regardless", so the records that failed conversion get another attempt — at the
-cost of re-adding the ones that succeeded, which is the correct side of that
-trade. If the state cannot be read, the run publishes: the safe direction,
-since it can only add a duplicate, never lose a record.
+regardless", so the records that failed conversion get another attempt. A
+*persistently identical* partial run — same output fingerprint **and** same
+failure identity — is skipped, so a source that is half-broken for a month does
+not re-add its successful records daily; any change on either side publishes.
+
+State that is confirmed absent means a first run and publishes. State that
+exists but cannot be read or parsed **fails the run** instead: guessing "first
+run" there would republish an entire unchanged record set, and a failed run
+simply retries tomorrow.
+
+Every record published without its raw source archived is a provenance gap, so
+a declared-capture adapter whose run produced records but recorded a capture
+failure — or captured nothing at all — fails before publishing. Capture
+failures survive the adapter subprocess as error rows in the manifest.
 
 ## Known gaps
 

--- a/every_eval_ever/cron/README.md
+++ b/every_eval_ever/cron/README.md
@@ -1,7 +1,7 @@
 # Daily adapter refresh
 
-A scheduled refresh of the source adapters. Each adapter runs on its own,
-archives what it fetched, marks its records as cron-produced, validates them,
+A scheduled refresh of the source adapters. Each adapter runs on its own, stores
+what it fetched permanently, marks its records as cron-produced, validates them,
 and commits them to that adapter's own pull request on the
 [datastore](https://huggingface.co/datasets/evaleval/EEE_datastore).
 
@@ -23,7 +23,9 @@ nothing new to publish, `1` failed. Generated records go under
 `<work-dir>/data/`, raw payloads under `<work-dir>/raw/`, and the run summary to
 `<work-dir>/summary.json`.
 
-Publishing for real needs `HF_TOKEN` with write access to the datastore.
+Publishing for real needs `HF_TOKEN` with write access to both the datastore and
+the private raw dataset. `--no-archive-raw` keeps a local run from writing to the
+raw dataset at all.
 
 ## Adding an adapter to the schedule
 
@@ -67,10 +69,38 @@ carries `type_of_addition: cron`, `cron_run_date`, `cron_adapter`, and
 name them in `cron_unknown_inferred_fields`, which is how a later pass finds the
 records still needing a real value.
 
-**Raw data is kept.** Payloads land in the workflow run's artifact, which is
-where the run summary and any `adapter_reports/` go too. Artifacts expire after
-90 days — a durable home for raw data is the obvious next step, not something
-this solves.
+**Raw data is kept permanently.** Payloads go to a private dataset of their own,
+`evaleval/EEE_raw` (override with the `EEE_RAW_REPO_ID` repository variable), laid
+out as:
+
+```
+blobs/<ab>/<sha256>.<ext>              # one copy per distinct payload, ever
+ledger/<adapter>/<date>-<run>.jsonl    # one row per payload per run
+```
+
+Payloads are **content-addressed**, so a source that has not changed since
+yesterday costs nothing but a ledger row — which is what makes keeping every day
+affordable. The ledger is the index, and it is a dataset in its own right:
+
+```python
+from datasets import load_dataset
+
+ledger = load_dataset(
+    'json', data_files='ledger/**/*.jsonl', ...  # from evaleval/EEE_raw
+)
+```
+
+Each row carries the adapter, run date, run URL, source URL, SHA-256, byte
+count, and the blob it landed in — so any record traces back to the exact bytes
+it came from. A row is written even for a payload too large to store, and even
+for a run that published nothing, so the ledger says what was fetched on every
+date rather than only on the days something changed.
+
+Archiving happens **before** anything is published, and a failure to archive
+stops the run. Records should not reach the datastore without their raw
+provenance stored. The workflow also uploads raw payloads and
+`adapter_reports/` as a 90-day artifact, but that is a convenience copy, not the
+retention mechanism.
 
 **An unchanged source publishes nothing.** A run fingerprints the source and
 stops if it matches the previous run — using the verbatim response bodies where
@@ -81,13 +111,14 @@ produced or nothing at all, so no individual record is ever dropped.
 Record-level de-duplication is still open, and it is why the high-volume
 `hfopenllm_v2` adapter is not scheduled yet.
 
-The fingerprint lives in the workflow's cache. A cache miss means the run
-publishes — the safe direction, since it can only ever add a duplicate, never
+The fingerprint is read back from the ledger, so the memory of what the source
+looked like last night is as durable as the raw data itself — not a build cache
+that can be evicted and take a whole adapter's set with it. If it cannot be read,
+the run publishes: the safe direction, since it can only add a duplicate, never
 lose a record.
 
 ## Known gaps
 
-- Raw payloads expire with the workflow artifact after 90 days.
 - `hal`, `lexam`, and `mt_bench` archive no raw data: they call an HTTP client
   directly and expose no raw-dump flag. They fall back to the output
   fingerprint, so they still will not republish unchanged records.

--- a/every_eval_ever/cron/README.md
+++ b/every_eval_ever/cron/README.md
@@ -27,6 +27,19 @@ Publishing for real needs `HF_TOKEN` with write access to both the datastore and
 the private raw dataset. `--no-archive-raw` keeps a local run from writing to the
 raw dataset at all.
 
+Check the credentials without running anything:
+
+```bash
+uv run python -m every_eval_ever.cron preflight
+```
+
+It reports the token identity, whether both destinations are reachable, creates
+the private raw dataset if it is missing, and names any adapter held back by a
+missing API key. The scheduled workflow runs this first, because the refresh
+fails closed — a token that cannot store raw data would otherwise fail every
+adapter at its last step. Note that a `--dry-run` refresh does not archive, so
+preflight is the only thing that exercises raw-dataset access without publishing.
+
 ## Adding an adapter to the schedule
 
 Add a `CronAdapter` to `CRON_ADAPTERS` in [`schedule.py`](schedule.py). An

--- a/every_eval_ever/cron/README.md
+++ b/every_eval_ever/cron/README.md
@@ -1,0 +1,101 @@
+# Daily adapter refresh
+
+A scheduled refresh of the source adapters. Each adapter runs on its own,
+archives what it fetched, marks its records as cron-produced, validates them,
+and commits them to that adapter's own pull request on the
+[datastore](https://huggingface.co/datasets/evaleval/EEE_datastore).
+
+Workflow: [`.github/workflows/adapter_cron.yml`](../../.github/workflows/adapter_cron.yml).
+
+## Running it by hand
+
+```bash
+uv run python -m every_eval_ever.cron list
+
+uv run python -m every_eval_ever.cron run vals_ai \
+    --work-dir /tmp/cron-vals-ai \
+    --dry-run
+```
+
+`--dry-run` does everything except the commit, which makes it the way to check
+an adapter before letting the schedule near it. Exit codes: `0` published, `2`
+nothing new to publish, `1` failed. Generated records go under
+`<work-dir>/data/`, raw payloads under `<work-dir>/raw/`, and the run summary to
+`<work-dir>/summary.json`.
+
+Publishing for real needs `HF_TOKEN` with write access to the datastore.
+
+## Adding an adapter to the schedule
+
+Add a `CronAdapter` to `CRON_ADAPTERS` in [`schedule.py`](schedule.py). An
+adapter directory that is in neither `CRON_ADAPTERS` nor `EXCLUDED_ADAPTERS`
+fails `tests/test_cron_schedule.py`, so a new adapter has to be a decision
+rather than an oversight.
+
+The runner invokes an adapter with the scratch tree as its working directory and
+lets it write to its own default `data/` path. It does not pass `--output-dir`,
+because adapters disagree about whether that flag names the base directory or
+the collection directory.
+
+Declare `raw_policy` honestly — it is what the run reports as archived:
+
+| Policy | Meaning |
+|---|---|
+| `VIA_FETCH_HELPERS` | Fetches through `helpers.fetch`, so the shared hook archives the response body as served |
+| `VIA_ADAPTER_FLAG` | Archived by the adapter's own `--save-raw-*` flag, named in `raw_args` |
+| `UPSTREAM_VERSIONED` | A HuggingFace dataset revision or a git commit; deliberately not re-archived |
+| `NOT_CAPTURED` | The adapter calls an HTTP client directly and exposes no flag — a gap |
+
+A `VIA_ADAPTER_FLAG` dump is archived but does **not** decide whether the source
+moved. Those files are derived: `hle`'s wraps the payload in a `fetched_at`
+timestamp and `vals_ai`'s is a normalized form, so comparing them across runs
+reports a change every single day. Only a body stored exactly as the server sent
+it counts, which in practice means the shared hook.
+
+## What the cron guarantees
+
+**One adapter cannot break another.** Every adapter is a separate workflow job
+with its own timeout, so a hang or a failure is confined to it. Within one
+adapter, an invocation that fails does not stop the remaining ones, and the
+records that did convert are still published — an adapter reports a *partial*
+conversion by writing every valid record and then exiting non-zero, so a
+non-zero exit is reported, never treated as a reason to discard data.
+
+**Every record says where it came from.** `source_metadata.additional_details`
+carries `type_of_addition: cron`, `cron_run_date`, `cron_adapter`, and
+`cron_run_url`. Records whose inferred deployment axes came out `unknown` also
+name them in `cron_unknown_inferred_fields`, which is how a later pass finds the
+records still needing a real value.
+
+**Raw data is kept.** Payloads land in the workflow run's artifact, which is
+where the run summary and any `adapter_reports/` go too. Artifacts expire after
+90 days — a durable home for raw data is the obvious next step, not something
+this solves.
+
+**An unchanged source publishes nothing.** A run fingerprints the source and
+stops if it matches the previous run — using the verbatim response bodies where
+it has them, and otherwise the generated records with per-run values
+(`retrieved_timestamp`, `evaluation_id`, the record UUID, the cron stamp)
+stripped out. This is run-level, not record-level: a run publishes everything it
+produced or nothing at all, so no individual record is ever dropped.
+Record-level de-duplication is still open, and it is why the high-volume
+`hfopenllm_v2` adapter is not scheduled yet.
+
+The fingerprint lives in the workflow's cache. A cache miss means the run
+publishes — the safe direction, since it can only ever add a duplicate, never
+lose a record.
+
+## Known gaps
+
+- Raw payloads expire with the workflow artifact after 90 days.
+- `hal`, `lexam`, and `mt_bench` archive no raw data: they call an HTTP client
+  directly and expose no raw-dump flag. They fall back to the output
+  fingerprint, so they still will not republish unchanged records.
+- `hle`, `terminal_bench_2`, and `vals_ai` archive raw data through their own
+  flags, which is enough to keep it but not to compare runs, so they are gated
+  on their output too. Routing them through `helpers.fetch` would fix that.
+- Records accumulate in each adapter's pull request until someone merges it.
+  Nothing here de-duplicates against what the datastore already holds.
+- The workflow installs `--all-extras` because three adapters read HuggingFace
+  datasets through `datasets`, which reaches the lock only via the `helm` extra.
+  A dedicated extra would be lighter.

--- a/every_eval_ever/cron/README.md
+++ b/every_eval_ever/cron/README.md
@@ -17,9 +17,11 @@ uv run python -m every_eval_ever.cron run vals_ai \
     --dry-run
 ```
 
-`--dry-run` does everything except the commit, which makes it the way to check
-an adapter before letting the schedule near it. Exit codes: `0` published, `2`
-nothing new to publish, `1` failed. Generated records go under
+`--dry-run` does everything except the commits, which makes it the way to check
+an adapter before letting the schedule near it. Exit codes: `0` published, `3`
+nothing new to publish, `1` failed. (`3` rather than `2`: argparse exits `2` on
+a usage error, and the workflow treats the nothing-new code as success — a flag
+typo must fail loudly, not read as a quiet day.) Generated records go under
 `<work-dir>/data/`, raw payloads under `<work-dir>/raw/`, and the run summary to
 `<work-dir>/summary.json`.
 
@@ -82,14 +84,19 @@ carries `type_of_addition: cron`, `cron_run_date`, `cron_adapter`, and
 name them in `cron_unknown_inferred_fields`, which is how a later pass finds the
 records still needing a real value.
 
-**Raw data is kept permanently.** Payloads go to a private dataset of their own,
-`evaleval/EEE_raw` (override with the `EEE_RAW_REPO_ID` repository variable), laid
-out as:
+**Raw data is kept permanently, and privately.** Payloads go to a private
+dataset of their own, `evaleval/EEE_raw` (override with the `EEE_RAW_REPO_ID`
+repository variable), laid out as:
 
 ```
 blobs/<ab>/<sha256>.<ext>              # one copy per distinct payload, ever
 ledger/<adapter>/<date>-<run>.jsonl    # one row per payload per run
+state/<adapter>.json                   # what the last successful publish was
 ```
+
+Privacy is enforced, not assumed: preflight fails if the raw dataset is public,
+and the archive re-checks visibility immediately before every commit and
+refuses to write to a public dataset.
 
 Payloads are **content-addressed**, so a source that has not changed since
 yesterday costs nothing but a ledger row — which is what makes keeping every day
@@ -124,11 +131,17 @@ produced or nothing at all, so no individual record is ever dropped.
 Record-level de-duplication is still open, and it is why the high-volume
 `hfopenllm_v2` adapter is not scheduled yet.
 
-The fingerprint is read back from the ledger, so the memory of what the source
-looked like last night is as durable as the raw data itself — not a build cache
-that can be evicted and take a whole adapter's set with it. If it cannot be read,
-the run publishes: the safe direction, since it can only add a duplicate, never
-lose a record.
+The previous fingerprint is read from `state/<adapter>.json`, which is written
+**only after a successful publish** — three properties hang off that one
+sentence. A run can never compare against a fingerprint it wrote itself (the
+ledger is written before publishing, which is why it cannot be the gate). A run
+that failed to publish leaves the old state, so its records are retried the
+next day instead of skipped as "unchanged" and silently lost. And a partial
+publish records `partial: true`, which the next run treats as "publish
+regardless", so the records that failed conversion get another attempt — at the
+cost of re-adding the ones that succeeded, which is the correct side of that
+trade. If the state cannot be read, the run publishes: the safe direction,
+since it can only add a duplicate, never lose a record.
 
 ## Known gaps
 

--- a/every_eval_ever/cron/README.md
+++ b/every_eval_ever/cron/README.md
@@ -91,14 +91,24 @@ repository variable), laid out as:
 ```
 blobs/<ab>/<sha256>.<ext>              # one copy per distinct payload, ever
 ledger/<adapter>/<date>-<run>.jsonl    # one row per payload per run
+reports/<adapter>/<date>-<run>/…       # adapter failure reports (raw rows)
 state/<adapter>.json                   # what the last successful publish was
+state/<adapter>.attempt.json           # a publish in flight (cleared on success)
 ```
 
 Privacy is enforced, not assumed: preflight fails if the raw dataset is public,
 the archive re-checks visibility immediately before every commit and refuses to
-write to a public dataset, and the workflow's artifact carries only reports and
-the run summary — never captured payloads, which on a public repository anyone
-signed in could download.
+write to a public dataset, and the workflow's artifact carries only the run
+summary. Captured payloads *and adapter failure reports* — which embed raw
+source rows — go exclusively to the private dataset (`reports/<adapter>/…`),
+because artifacts on a public repository are downloadable by anyone signed in.
+
+The adapter subprocess never holds the cron's write-capable `HF_TOKEN`: it is
+scrubbed from the child environment, which does all its fetching with source
+credentials only. A source that genuinely needs authenticated Hugging Face
+*read* access declares `source_hf_token` in the schedule and receives the
+separate `EEE_SOURCE_HF_TOKEN` — a least-privilege read token — as its
+`HF_TOKEN`.
 
 Payloads are **content-addressed**, so a source that has not changed since
 yesterday costs nothing but a ledger row — which is what makes keeping every day
@@ -153,7 +163,24 @@ simply retries tomorrow.
 Every record published without its raw source archived is a provenance gap, so
 a declared-capture adapter whose run produced records but recorded a capture
 failure — or captured nothing at all — fails before publishing. Capture
-failures survive the adapter subprocess as error rows in the manifest.
+failures survive the adapter subprocess as error rows in the manifest, and the
+archive happens *before* the failure returns, so the successful sibling
+captures and the error evidence are already permanent when the job goes red.
+
+A publish is batched, and a batch can die midway with earlier batches already
+on the pull request. Before the first batch, the run records the exact paths it
+is about to add (`state/<adapter>.attempt.json`); a later run finds that
+dangling attempt, deletes whichever of its files reached the pull request, and
+republishes — one copy of each record, not a stack of retries. The attempt
+record is cleared in the same commit that records the publish state, so the two
+can never disagree. If recording the state fails even after a retry, the run
+exits non-zero with the pull request URL in the summary: the records are
+published, only the gate is stale, and the next run reconciles.
+
+An enabled adapter missing its credential **fails its own job** rather than
+being quietly dropped from the matrix — a red job names the missing variable,
+while the other adapters' jobs proceed. Quiet skips are reserved for adapters
+deliberately declared disabled.
 
 ## Known gaps
 

--- a/every_eval_ever/cron/__init__.py
+++ b/every_eval_ever/cron/__init__.py
@@ -1,0 +1,23 @@
+"""Scheduled adapter refreshes for the Every Eval Ever datastore.
+
+``schedule`` declares which adapters run and how; ``runner`` runs one of them
+end to end. See ``README.md`` in this directory.
+"""
+
+from every_eval_ever.cron.schedule import (
+    CRON_ADAPTERS,
+    EXCLUDED_ADAPTERS,
+    CronAdapter,
+    RawPolicy,
+    get_adapter,
+    scheduled_adapters,
+)
+
+__all__ = [
+    'CRON_ADAPTERS',
+    'EXCLUDED_ADAPTERS',
+    'CronAdapter',
+    'RawPolicy',
+    'get_adapter',
+    'scheduled_adapters',
+]

--- a/every_eval_ever/cron/__main__.py
+++ b/every_eval_ever/cron/__main__.py
@@ -1,0 +1,4 @@
+from every_eval_ever.cron.runner import main
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/every_eval_ever/cron/archive.py
+++ b/every_eval_ever/cron/archive.py
@@ -1,0 +1,300 @@
+"""Permanent storage for the raw payloads a refresh fetched.
+
+Raw data lives in its own private Hugging Face dataset, separate from the
+records it produced. Two things go there:
+
+- **blobs** — each payload stored under its own content hash, so a payload that
+  has not changed since the last run costs nothing to keep. This is what makes a
+  daily archive affordable.
+- **a ledger** — one JSONL row per payload per run, naming the adapter, the run,
+  the source URL, and the blob it landed in. The ledger is the queryable index:
+  ``load_dataset('json', data_files='ledger/**/*.jsonl')`` over the repo answers
+  "what did this source look like on that date".
+
+Each run writes its own ledger file, so parallel adapter jobs never contend for
+the same path and nothing is ever rewritten.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
+
+from every_eval_ever.helpers import raw_capture
+
+DEFAULT_RAW_REPO_ID = 'evaleval/EEE_raw'
+
+BLOB_PREFIX = 'blobs'
+LEDGER_PREFIX = 'ledger'
+
+_logger = logging.getLogger(__name__)
+
+
+class ArchiveError(Exception):
+    """Raised when raw payloads could not be archived."""
+
+
+@dataclass
+class ArchiveResult:
+    """What archiving a run's raw payloads did."""
+
+    repo_id: str
+    ledger_path: str
+    uploaded: int = 0
+    reused: int = 0
+    uploaded_bytes: int = 0
+    rows: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def payloads(self) -> int:
+        return self.uploaded + self.reused
+
+
+def blob_path(checksum: str, filename: str) -> str:
+    """Return the content-addressed path for a payload.
+
+    Sharded by the first two hex characters so no single directory grows
+    unbounded, and given the payload's extension so the Hub previews it as the
+    right type.
+    """
+    return f'{BLOB_PREFIX}/{checksum[:2]}/{checksum}{Path(filename).suffix}'
+
+
+def ledger_path(adapter: str, run_date: str, run_id: str) -> str:
+    """Return the ledger file for one run of one adapter."""
+    return f'{LEDGER_PREFIX}/{adapter}/{run_date}-{run_id}.jsonl'
+
+
+def ledger_rows(
+    raw_dir: str | Path,
+    *,
+    adapter: str,
+    run_date: str,
+    run_id: str,
+    run_url: str | None = None,
+    raw_fingerprint: str | None = None,
+    output_fingerprint: str | None = None,
+    gating_fingerprint: str | None = None,
+) -> list[dict[str, Any]]:
+    """Build one ledger row per payload the run captured."""
+    rows = []
+    for entry in raw_capture.read_manifest(raw_dir):
+        filename = entry.get('file')
+        rows.append(
+            {
+                'adapter': adapter,
+                'run_date': run_date,
+                'run_id': run_id,
+                'run_url': run_url,
+                'source_url': entry.get('url'),
+                'capture_source': entry.get('source'),
+                'content_type': entry.get('content_type'),
+                'retrieved_at': entry.get('retrieved_at'),
+                'file_name': filename,
+                'sha256': entry.get('sha256'),
+                'bytes': entry.get('bytes'),
+                'raw_fingerprint': raw_fingerprint,
+                'output_fingerprint': output_fingerprint,
+                # The one compared against the next run to decide whether the
+                # source moved. Read back by last_gating_fingerprint().
+                'gating_fingerprint': gating_fingerprint,
+                'blob_path': (
+                    blob_path(entry['sha256'], filename) if filename else None
+                ),
+                # Set when a payload was fetched but deliberately not stored.
+                'skipped': entry.get('skipped'),
+            }
+        )
+    return rows
+
+
+def archive(
+    raw_dir: str | Path,
+    *,
+    adapter: str,
+    run_date: str,
+    run_id: str,
+    run_url: str | None = None,
+    raw_fingerprint: str | None = None,
+    output_fingerprint: str | None = None,
+    gating_fingerprint: str | None = None,
+    repo_id: str = DEFAULT_RAW_REPO_ID,
+    token: str | None = None,
+    api: HfApi | None = None,
+    create_if_missing: bool = True,
+) -> ArchiveResult:
+    """Store a run's raw payloads and its ledger row permanently.
+
+    A payload already present under its content hash is not re-uploaded, so a
+    source that has not changed costs one small ledger file per run.
+
+    Raises:
+        ArchiveError: if the repository is unreachable or the commit fails.
+            Callers treat this as fatal: records should not reach the datastore
+            without their raw provenance stored somewhere permanent.
+    """
+    raw_dir = Path(raw_dir)
+    api = api or HfApi(token=token)
+
+    rows = ledger_rows(
+        raw_dir,
+        adapter=adapter,
+        run_date=run_date,
+        run_id=run_id,
+        run_url=run_url,
+        raw_fingerprint=raw_fingerprint,
+        output_fingerprint=output_fingerprint,
+        gating_fingerprint=gating_fingerprint,
+    )
+    if not rows:
+        raise ArchiveError(f'no raw payloads to archive under {raw_dir}')
+
+    if create_if_missing:
+        try:
+            # Private: raw source data is kept for provenance, not republished.
+            api.create_repo(
+                repo_id=repo_id,
+                repo_type='dataset',
+                private=True,
+                exist_ok=True,
+            )
+        except Exception as error:
+            raise ArchiveError(
+                f'could not reach or create the raw dataset {repo_id}: {error}'
+            ) from error
+
+    destination = ledger_path(adapter, run_date, run_id)
+    result = ArchiveResult(repo_id=repo_id, ledger_path=destination, rows=rows)
+    operations: list[CommitOperationAdd] = []
+    planned: set[str] = set()
+
+    for row in rows:
+        path_in_repo = row['blob_path']
+        if path_in_repo is None:
+            # Fetched but not stored (over the capture ceiling). The ledger row
+            # still records that it happened, and says so.
+            continue
+        if path_in_repo in planned or _already_stored(
+            api, repo_id, path_in_repo
+        ):
+            result.reused += 1
+            continue
+        payload = raw_dir / row['file_name']
+        if not payload.is_file():
+            raise ArchiveError(
+                f'payload {payload} named in the manifest is gone'
+            )
+        planned.add(path_in_repo)
+        operations.append(
+            CommitOperationAdd(
+                path_in_repo=path_in_repo, path_or_fileobj=str(payload)
+            )
+        )
+        result.uploaded += 1
+        result.uploaded_bytes += row['bytes'] or 0
+
+    body = '\n'.join(json.dumps(row, ensure_ascii=False) for row in rows) + '\n'
+    operations.append(
+        CommitOperationAdd(
+            path_in_repo=destination, path_or_fileobj=body.encode('utf-8')
+        )
+    )
+
+    try:
+        api.create_commit(
+            repo_id=repo_id,
+            repo_type='dataset',
+            operations=operations,
+            commit_message=(
+                f'{adapter}: archive {result.uploaded} new payload(s) '
+                f'({run_date})'
+            ),
+            commit_description=run_url or '',
+        )
+    except Exception as error:
+        raise ArchiveError(
+            f'could not commit raw payloads to {repo_id}: {error}'
+        ) from error
+
+    _logger.info(
+        'archived %d new and %d already-stored payload(s) to %s',
+        result.uploaded,
+        result.reused,
+        repo_id,
+    )
+    return result
+
+
+def _already_stored(api: HfApi, repo_id: str, path_in_repo: str) -> bool:
+    try:
+        return api.file_exists(
+            repo_id=repo_id, filename=path_in_repo, repo_type='dataset'
+        )
+    except Exception as error:
+        raise ArchiveError(
+            f'could not check {path_in_repo} in {repo_id}: {error}'
+        ) from error
+
+
+def last_gating_fingerprint(
+    adapter: str,
+    *,
+    repo_id: str = DEFAULT_RAW_REPO_ID,
+    token: str | None = None,
+    api: HfApi | None = None,
+) -> str | None:
+    """Return the fingerprint this adapter's most recent run recorded.
+
+    The ledger is the durable memory of what the source looked like last time.
+    Reading it here rather than a build cache means a run cannot forget and
+    republish an adapter's whole set because a cache entry was evicted.
+
+    Returns ``None`` when there is nothing to compare against — no ledger, no
+    repository, or no fingerprint recorded — which makes the run publish. That
+    is the safe direction: it can add a duplicate, never lose a record.
+    """
+    api = api or HfApi(token=token)
+    prefix = f'{LEDGER_PREFIX}/{adapter}/'
+    try:
+        files = api.list_repo_files(repo_id=repo_id, repo_type='dataset')
+    except Exception as error:
+        _logger.warning(
+            'could not read the ledger in %s (%s); treating this run as new',
+            repo_id,
+            error,
+        )
+        return None
+
+    # Ledger names start with the run date, so the last one sorted is the most
+    # recent.
+    ledgers = sorted(
+        name
+        for name in files
+        if name.startswith(prefix) and name.endswith('.jsonl')
+    )
+    for name in reversed(ledgers):
+        try:
+            local = hf_hub_download(
+                repo_id=repo_id,
+                filename=name,
+                repo_type='dataset',
+                token=token,
+            )
+            rows = [
+                json.loads(line)
+                for line in Path(local).read_text(encoding='utf-8').splitlines()
+                if line.strip()
+            ]
+        except Exception as error:
+            _logger.warning('could not read ledger %s: %s', name, error)
+            return None
+        for row in rows:
+            fingerprint = row.get('gating_fingerprint')
+            if fingerprint:
+                return fingerprint
+    return None

--- a/every_eval_ever/cron/archive.py
+++ b/every_eval_ever/cron/archive.py
@@ -1,7 +1,7 @@
 """Permanent storage for the raw payloads a refresh fetched.
 
 Raw data lives in its own private Hugging Face dataset, separate from the
-records it produced. Two things go there:
+records it produced. Three things go there:
 
 - **blobs** — each payload stored under its own content hash, so a payload that
   has not changed since the last run costs nothing to keep. This is what makes a
@@ -11,8 +11,16 @@ records it produced. Two things go there:
   ``load_dataset('json', data_files='ledger/**/*.jsonl')`` over the repo answers
   "what did this source look like on that date".
 
+- **state** — one small JSON file per adapter, ``state/<adapter>.json``,
+  overwritten only after a successful publish. It is the durable answer to
+  "what did this adapter last publish": the gating fingerprint the next run
+  compares against, and the adapter's pull request number. The ledger cannot
+  play this role — it is written *before* publishing (so a run that fails to
+  publish must not update the gate) and by every run (so a run would read back
+  its own fingerprint and conclude nothing changed).
+
 Each run writes its own ledger file, so parallel adapter jobs never contend for
-the same path and nothing is ever rewritten.
+the same path.
 """
 
 from __future__ import annotations
@@ -24,6 +32,7 @@ from pathlib import Path
 from typing import Any
 
 from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
+from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
 
 from every_eval_ever.helpers import raw_capture
 
@@ -31,6 +40,7 @@ DEFAULT_RAW_REPO_ID = 'evaleval/EEE_raw'
 
 BLOB_PREFIX = 'blobs'
 LEDGER_PREFIX = 'ledger'
+STATE_PREFIX = 'state'
 
 _logger = logging.getLogger(__name__)
 
@@ -49,10 +59,6 @@ class ArchiveResult:
     reused: int = 0
     uploaded_bytes: int = 0
     rows: list[dict[str, Any]] = field(default_factory=list)
-
-    @property
-    def payloads(self) -> int:
-        return self.uploaded + self.reused
 
 
 def blob_path(checksum: str, filename: str) -> str:
@@ -167,11 +173,17 @@ def archive(
             raise ArchiveError(
                 f'could not reach or create the raw dataset {repo_id}: {error}'
             ) from error
+    _require_private(api, repo_id)
 
     destination = ledger_path(adapter, run_date, run_id)
     result = ArchiveResult(repo_id=repo_id, ledger_path=destination, rows=rows)
     operations: list[CommitOperationAdd] = []
     planned: set[str] = set()
+    stored = _already_stored(
+        api,
+        repo_id,
+        [row['blob_path'] for row in rows if row['blob_path']],
+    )
 
     for row in rows:
         path_in_repo = row['blob_path']
@@ -179,9 +191,7 @@ def archive(
             # Fetched but not stored (over the capture ceiling). The ledger row
             # still records that it happened, and says so.
             continue
-        if path_in_repo in planned or _already_stored(
-            api, repo_id, path_in_repo
-        ):
+        if path_in_repo in planned or path_in_repo in stored:
             result.reused += 1
             continue
         payload = raw_dir / row['file_name']
@@ -230,71 +240,118 @@ def archive(
     return result
 
 
-def _already_stored(api: HfApi, repo_id: str, path_in_repo: str) -> bool:
+def _require_private(api: HfApi, repo_id: str) -> None:
+    """Refuse to archive into a dataset the world can read.
+
+    Checked immediately before every commit, not only at preflight: visibility
+    can change between the two, and raw source payloads are stored here on the
+    promise of privacy.
+    """
     try:
-        return api.file_exists(
-            repo_id=repo_id, filename=path_in_repo, repo_type='dataset'
+        info = api.repo_info(repo_id=repo_id, repo_type='dataset')
+    except Exception as error:
+        raise ArchiveError(
+            f'could not verify that {repo_id} is private: {error}'
+        ) from error
+    if not getattr(info, 'private', False):
+        raise ArchiveError(
+            f'{repo_id} is PUBLIC; refusing to archive raw payloads into it. '
+            'Make it private or point --raw-repo-id at a private dataset.'
+        )
+
+
+def _already_stored(api: HfApi, repo_id: str, paths: list[str]) -> set[str]:
+    """Return which of ``paths`` the raw dataset already holds, in one call."""
+    if not paths:
+        return set()
+    try:
+        found = api.get_paths_info(
+            repo_id=repo_id, paths=paths, repo_type='dataset'
         )
     except Exception as error:
         raise ArchiveError(
-            f'could not check {path_in_repo} in {repo_id}: {error}'
+            f'could not check existing blobs in {repo_id}: {error}'
         ) from error
+    return {entry.path for entry in found}
 
 
-def last_gating_fingerprint(
+def state_path(adapter: str) -> str:
+    """Return the per-adapter state file path in the raw dataset."""
+    return f'{STATE_PREFIX}/{adapter}.json'
+
+
+def read_state(
     adapter: str,
     *,
     repo_id: str = DEFAULT_RAW_REPO_ID,
     token: str | None = None,
     api: HfApi | None = None,
-) -> str | None:
-    """Return the fingerprint this adapter's most recent run recorded.
+) -> dict[str, Any] | None:
+    """Return what this adapter's last successful publish recorded.
 
-    The ledger is the durable memory of what the source looked like last time.
-    Reading it here rather than a build cache means a run cannot forget and
-    republish an adapter's whole set because a cache entry was evicted.
-
-    Returns ``None`` when there is nothing to compare against — no ledger, no
-    repository, or no fingerprint recorded — which makes the run publish. That
-    is the safe direction: it can add a duplicate, never lose a record.
+    The state file is the durable memory of the last publish — the gating
+    fingerprint and the pull request number. Returns ``None`` when there is
+    nothing to compare against: no state yet, no repository, or an unreadable
+    file. That makes the run publish, the safe direction — it can add a
+    duplicate, never lose a record.
     """
-    api = api or HfApi(token=token)
-    prefix = f'{LEDGER_PREFIX}/{adapter}/'
+    del api  # hf_hub_download manages its own client.
     try:
-        files = api.list_repo_files(repo_id=repo_id, repo_type='dataset')
+        local = hf_hub_download(
+            repo_id=repo_id,
+            filename=state_path(adapter),
+            repo_type='dataset',
+            token=token,
+            force_download=True,
+        )
+        return json.loads(Path(local).read_text(encoding='utf-8'))
+    except (RepositoryNotFoundError, EntryNotFoundError):
+        return None
     except Exception as error:
         _logger.warning(
-            'could not read the ledger in %s (%s); treating this run as new',
+            'could not read %s from %s (%s); treating this run as new',
+            state_path(adapter),
             repo_id,
             error,
         )
         return None
 
-    # Ledger names start with the run date, so the last one sorted is the most
-    # recent.
-    ledgers = sorted(
-        name
-        for name in files
-        if name.startswith(prefix) and name.endswith('.jsonl')
-    )
-    for name in reversed(ledgers):
-        try:
-            local = hf_hub_download(
-                repo_id=repo_id,
-                filename=name,
-                repo_type='dataset',
-                token=token,
-            )
-            rows = [
-                json.loads(line)
-                for line in Path(local).read_text(encoding='utf-8').splitlines()
-                if line.strip()
-            ]
-        except Exception as error:
-            _logger.warning('could not read ledger %s: %s', name, error)
-            return None
-        for row in rows:
-            fingerprint = row.get('gating_fingerprint')
-            if fingerprint:
-                return fingerprint
-    return None
+
+def write_state(
+    adapter: str,
+    state: dict[str, Any],
+    *,
+    repo_id: str = DEFAULT_RAW_REPO_ID,
+    token: str | None = None,
+    api: HfApi | None = None,
+) -> None:
+    """Record a successful publish, for the next run to compare against.
+
+    Called only after the datastore commit succeeded: a run that failed to
+    publish must leave the previous state in place, or its records would be
+    skipped as "unchanged" tomorrow and silently never reach the datastore.
+
+    Raises:
+        ArchiveError: if the state cannot be written. The publish already
+            happened, so the caller reports this loudly rather than unwinding —
+            the worst outcome of stale state is a duplicate publish tomorrow.
+    """
+    api = api or HfApi(token=token)
+    body = json.dumps(state, indent=2, sort_keys=True) + '\n'
+    try:
+        api.create_commit(
+            repo_id=repo_id,
+            repo_type='dataset',
+            operations=[
+                CommitOperationAdd(
+                    path_in_repo=state_path(adapter),
+                    path_or_fileobj=body.encode('utf-8'),
+                )
+            ],
+            commit_message=f'{adapter}: record publish state',
+        )
+    except Exception as error:
+        raise ArchiveError(
+            f'could not record publish state for {adapter} in {repo_id}: '
+            f'{error}'
+        ) from error

--- a/every_eval_ever/cron/archive.py
+++ b/every_eval_ever/cron/archive.py
@@ -290,10 +290,16 @@ def read_state(
     """Return what this adapter's last successful publish recorded.
 
     The state file is the durable memory of the last publish — the gating
-    fingerprint and the pull request number. Returns ``None`` when there is
-    nothing to compare against: no state yet, no repository, or an unreadable
-    file. That makes the run publish, the safe direction — it can add a
-    duplicate, never lose a record.
+    fingerprint and the pull request number. Returns ``None`` only when the
+    state is *confirmed* absent (no file yet, or no repository), which is a
+    genuine first run.
+
+    Any other failure — a transient download error, a malformed file — raises:
+    guessing "first run" there would republish an entire unchanged record set
+    into the adapter's pull request, and a failed run simply retries tomorrow.
+
+    Raises:
+        ArchiveError: when the state exists but cannot be read or parsed.
     """
     del api  # hf_hub_download manages its own client.
     try:
@@ -304,17 +310,25 @@ def read_state(
             token=token,
             force_download=True,
         )
-        return json.loads(Path(local).read_text(encoding='utf-8'))
     except (RepositoryNotFoundError, EntryNotFoundError):
         return None
     except Exception as error:
-        _logger.warning(
-            'could not read %s from %s (%s); treating this run as new',
-            state_path(adapter),
-            repo_id,
-            error,
+        raise ArchiveError(
+            f'could not read {state_path(adapter)} from {repo_id}: {error}. '
+            'Not treating this as a first run — that would republish the '
+            'whole set; the run fails and retries instead.'
+        ) from error
+    try:
+        state = json.loads(Path(local).read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ArchiveError(
+            f'{state_path(adapter)} in {repo_id} is unreadable: {error}'
+        ) from error
+    if not isinstance(state, dict):
+        raise ArchiveError(
+            f'{state_path(adapter)} in {repo_id} does not hold a JSON object'
         )
-        return None
+    return state
 
 
 def write_state(

--- a/every_eval_ever/cron/archive.py
+++ b/every_eval_ever/cron/archive.py
@@ -31,7 +31,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
+from huggingface_hub import (
+    CommitOperationAdd,
+    CommitOperationDelete,
+    HfApi,
+    hf_hub_download,
+)
 from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
 
 from every_eval_ever.helpers import raw_capture
@@ -114,6 +119,8 @@ def ledger_rows(
                 ),
                 # Set when a payload was fetched but deliberately not stored.
                 'skipped': entry.get('skipped'),
+                # Set when the capture itself failed; the bytes never existed.
+                'error': entry.get('error'),
             }
         )
     return rows
@@ -129,12 +136,13 @@ def archive(
     raw_fingerprint: str | None = None,
     output_fingerprint: str | None = None,
     gating_fingerprint: str | None = None,
+    reports: list[Path] | None = None,
     repo_id: str = DEFAULT_RAW_REPO_ID,
     token: str | None = None,
     api: HfApi | None = None,
     create_if_missing: bool = True,
 ) -> ArchiveResult:
-    """Store a run's raw payloads and its ledger row permanently.
+    """Store a run's raw payloads, failure reports and ledger permanently.
 
     A payload already present under its content hash is not re-uploaded, so a
     source that has not changed costs one small ledger file per run.
@@ -157,8 +165,9 @@ def archive(
         output_fingerprint=output_fingerprint,
         gating_fingerprint=gating_fingerprint,
     )
-    if not rows:
-        raise ArchiveError(f'no raw payloads to archive under {raw_dir}')
+    reports = list(reports or [])
+    if not rows and not reports:
+        raise ArchiveError(f'nothing to archive under {raw_dir}')
 
     if create_if_missing:
         try:
@@ -208,12 +217,27 @@ def archive(
         result.uploaded += 1
         result.uploaded_bytes += row['bytes'] or 0
 
-    body = '\n'.join(json.dumps(row, ensure_ascii=False) for row in rows) + '\n'
-    operations.append(
-        CommitOperationAdd(
-            path_in_repo=destination, path_or_fileobj=body.encode('utf-8')
+    if rows:
+        body = (
+            '\n'.join(json.dumps(row, ensure_ascii=False) for row in rows)
+            + '\n'
         )
-    )
+        operations.append(
+            CommitOperationAdd(
+                path_in_repo=destination, path_or_fileobj=body.encode('utf-8')
+            )
+        )
+    for report in reports:
+        # Failure reports embed raw source rows, so they belong here — in the
+        # private dataset — not in a public workflow artifact.
+        operations.append(
+            CommitOperationAdd(
+                path_in_repo=(
+                    f'reports/{adapter}/{run_date}-{run_id}/{report.name}'
+                ),
+                path_or_fileobj=str(report),
+            )
+        )
 
     try:
         api.create_commit(
@@ -280,6 +304,89 @@ def state_path(adapter: str) -> str:
     return f'{STATE_PREFIX}/{adapter}.json'
 
 
+def attempt_path(adapter: str) -> str:
+    """Return the per-adapter in-flight publish attempt record path."""
+    return f'{STATE_PREFIX}/{adapter}.attempt.json'
+
+
+def write_attempt(
+    adapter: str,
+    attempt: dict[str, Any],
+    *,
+    repo_id: str = DEFAULT_RAW_REPO_ID,
+    token: str | None = None,
+    api: HfApi | None = None,
+) -> None:
+    """Record the datastore paths a publish is about to commit.
+
+    Written *before* the first batch, so a publish that dies between batches
+    leaves a durable list of exactly the paths its incomplete attempt added.
+    The next run deletes those from the pull request before republishing —
+    without this, every retry of a multi-batch publish stacks a fresh copy of
+    the full set under new UUID filenames.
+
+    Raises:
+        ArchiveError: if the record cannot be written; publishing without it
+            would make a mid-publish failure unrecoverable without duplicates.
+    """
+    api = api or HfApi(token=token)
+    body = json.dumps(attempt, indent=2, sort_keys=True) + '\n'
+    try:
+        api.create_commit(
+            repo_id=repo_id,
+            repo_type='dataset',
+            operations=[
+                CommitOperationAdd(
+                    path_in_repo=attempt_path(adapter),
+                    path_or_fileobj=body.encode('utf-8'),
+                )
+            ],
+            commit_message=f'{adapter}: record publish attempt',
+        )
+    except Exception as error:
+        raise ArchiveError(
+            f'could not record the publish attempt for {adapter} in '
+            f'{repo_id}: {error}'
+        ) from error
+
+
+def read_attempt(
+    adapter: str,
+    *,
+    repo_id: str = DEFAULT_RAW_REPO_ID,
+    token: str | None = None,
+    api: HfApi | None = None,
+) -> dict[str, Any] | None:
+    """Return the in-flight attempt a previous run left behind, if any.
+
+    ``None`` means no unfinished attempt (confirmed absent). Like
+    :func:`read_state`, any other failure raises: guessing here risks either
+    duplicating a set or deleting the wrong files.
+    """
+    del api
+    try:
+        local = hf_hub_download(
+            repo_id=repo_id,
+            filename=attempt_path(adapter),
+            repo_type='dataset',
+            token=token,
+            force_download=True,
+        )
+    except (RepositoryNotFoundError, EntryNotFoundError):
+        return None
+    except Exception as error:
+        raise ArchiveError(
+            f'could not read {attempt_path(adapter)} from {repo_id}: {error}'
+        ) from error
+    try:
+        attempt = json.loads(Path(local).read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ArchiveError(
+            f'{attempt_path(adapter)} in {repo_id} is unreadable: {error}'
+        ) from error
+    return attempt if isinstance(attempt, dict) else None
+
+
 def read_state(
     adapter: str,
     *,
@@ -338,6 +445,7 @@ def write_state(
     repo_id: str = DEFAULT_RAW_REPO_ID,
     token: str | None = None,
     api: HfApi | None = None,
+    clear_attempt: bool = False,
 ) -> None:
     """Record a successful publish, for the next run to compare against.
 
@@ -352,16 +460,23 @@ def write_state(
     """
     api = api or HfApi(token=token)
     body = json.dumps(state, indent=2, sort_keys=True) + '\n'
+    operations: list[Any] = [
+        CommitOperationAdd(
+            path_in_repo=state_path(adapter),
+            path_or_fileobj=body.encode('utf-8'),
+        )
+    ]
+    if clear_attempt:
+        # Same repository, same commit: the attempt record and the state can
+        # never disagree about whether the publish completed.
+        operations.append(
+            CommitOperationDelete(path_in_repo=attempt_path(adapter))
+        )
     try:
         api.create_commit(
             repo_id=repo_id,
             repo_type='dataset',
-            operations=[
-                CommitOperationAdd(
-                    path_in_repo=state_path(adapter),
-                    path_or_fileobj=body.encode('utf-8'),
-                )
-            ],
+            operations=operations,
             commit_message=f'{adapter}: record publish state',
         )
     except Exception as error:

--- a/every_eval_ever/cron/fingerprint.py
+++ b/every_eval_ever/cron/fingerprint.py
@@ -32,13 +32,8 @@ from every_eval_ever.cron.stamp import (
     UNKNOWN_FIELDS_KEY,
     aggregate_records,
 )
-
-#: Record fields that differ on every run without the data differing.
-VOLATILE_RECORD_FIELDS = (
-    # Regenerated per run.
-    'retrieved_timestamp',
-    # Convention embeds retrieved_timestamp in the id.
-    'evaluation_id',
+from every_eval_ever.validator.check_duplicate_entries import (
+    strip_ignored_keys,
 )
 
 #: Stamp keys the cron itself adds; they must not make a run look changed.
@@ -52,10 +47,16 @@ VOLATILE_STAMP_KEYS = (
 
 
 def canonical_record(payload: dict[str, Any]) -> dict[str, Any]:
-    """Return ``payload`` without the values that change on every run."""
-    canonical = json.loads(json.dumps(payload))
-    for name in VOLATILE_RECORD_FIELDS:
-        canonical.pop(name, None)
+    """Return ``payload`` without the values that change on every run.
+
+    What counts as scrape noise (``retrieved_timestamp``, ``evaluation_id``) is
+    the *validator's* definition — ``check_duplicate_entries.IGNORE_KEYS``, the
+    same rule the datastore's duplicate checker applies — so the cron's
+    unchanged-source gate and the datastore's duplicate detection can never
+    disagree about what makes two records the same. This module adds only what
+    is cron-specific: the stamp keys, and the regenerated companion path.
+    """
+    canonical = strip_ignored_keys(payload)
 
     details = canonical.get('source_metadata', {}).get('additional_details')
     if isinstance(details, dict):

--- a/every_eval_ever/cron/fingerprint.py
+++ b/every_eval_ever/cron/fingerprint.py
@@ -1,0 +1,116 @@
+"""Deciding whether a refresh actually found anything new.
+
+A daily refresh that republishes identical records is how a datastore
+accumulates thousands of near-duplicate files. The cron avoids that at the
+level of a whole run rather than per record: if a run's inputs and outputs are
+unchanged from the previous run, it publishes nothing.
+
+Two fingerprints support that, in order of preference:
+
+- the **raw** fingerprint, over the archived source payloads
+  (:mod:`every_eval_ever.helpers.raw_capture`). Closest to the source: equality
+  means the upstream data itself has not moved.
+- the **output** fingerprint, over the generated records with per-run values
+  removed. The fallback for adapters whose raw payloads are not archived.
+
+Neither is record-level de-duplication: a run either publishes everything it
+produced or nothing at all, so no individual record is ever dropped.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from every_eval_ever.cron.stamp import (
+    ADAPTER_KEY,
+    RUN_DATE_KEY,
+    RUN_URL_KEY,
+    TYPE_OF_ADDITION_KEY,
+    UNKNOWN_FIELDS_KEY,
+    aggregate_records,
+)
+
+#: Record fields that differ on every run without the data differing.
+VOLATILE_RECORD_FIELDS = (
+    # Regenerated per run.
+    'retrieved_timestamp',
+    # Convention embeds retrieved_timestamp in the id.
+    'evaluation_id',
+)
+
+#: Stamp keys the cron itself adds; they must not make a run look changed.
+VOLATILE_STAMP_KEYS = (
+    TYPE_OF_ADDITION_KEY,
+    RUN_DATE_KEY,
+    ADAPTER_KEY,
+    RUN_URL_KEY,
+    UNKNOWN_FIELDS_KEY,
+)
+
+
+def canonical_record(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return ``payload`` without the values that change on every run."""
+    canonical = json.loads(json.dumps(payload))
+    for name in VOLATILE_RECORD_FIELDS:
+        canonical.pop(name, None)
+
+    details = canonical.get('source_metadata', {}).get('additional_details')
+    if isinstance(details, dict):
+        for key in VOLATILE_STAMP_KEYS:
+            details.pop(key, None)
+        if not details:
+            canonical['source_metadata'].pop('additional_details', None)
+
+    detailed = canonical.get('detailed_evaluation_results')
+    if isinstance(detailed, dict):
+        # Contains the freshly generated companion UUID; the checksum beside it
+        # is content-derived and stays.
+        detailed.pop('file_path', None)
+
+    return canonical
+
+
+def record_digest(payload: dict[str, Any], location: str) -> str:
+    """Digest one record's content together with where it will be stored."""
+    canonical = canonical_record(payload)
+    body = json.dumps(canonical, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(f'{location}\n{body}'.encode('utf-8')).hexdigest()
+
+
+def output_fingerprint(data_root: str | Path) -> str | None:
+    """Digest every generated record under ``data_root``, or ``None`` if empty.
+
+    The record's UUID filename is excluded and its datastore directory is
+    included, so a re-run that only regenerated UUIDs matches while a record
+    that moved collection does not.
+    """
+    root = Path(data_root)
+    digests = []
+    for path in aggregate_records(root):
+        payload = json.loads(path.read_text(encoding='utf-8'))
+        location = path.parent.relative_to(root).as_posix()
+        digests.append(record_digest(payload, location))
+    if not digests:
+        return None
+    return hashlib.sha256(
+        '\n'.join(sorted(digests)).encode('utf-8')
+    ).hexdigest()
+
+
+def read_fingerprint(path: str | Path) -> str | None:
+    """Read a previously stored fingerprint, tolerating a missing file."""
+    fingerprint_path = Path(path)
+    if not fingerprint_path.is_file():
+        return None
+    value = fingerprint_path.read_text(encoding='utf-8').strip()
+    return value or None
+
+
+def write_fingerprint(path: str | Path, value: str) -> None:
+    """Store ``value`` for the next run to compare against."""
+    fingerprint_path = Path(path)
+    fingerprint_path.parent.mkdir(parents=True, exist_ok=True)
+    fingerprint_path.write_text(f'{value}\n', encoding='utf-8')

--- a/every_eval_ever/cron/preflight.py
+++ b/every_eval_ever/cron/preflight.py
@@ -13,10 +13,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from huggingface_hub import HfApi
+from huggingface_hub.errors import RepositoryNotFoundError
 
 from every_eval_ever.cron.archive import DEFAULT_RAW_REPO_ID
 from every_eval_ever.cron.publish import DEFAULT_REPO_ID
-from every_eval_ever.cron.schedule import scheduled_adapters
+from every_eval_ever.cron.schedule import CRON_ADAPTERS
 
 
 @dataclass
@@ -35,7 +36,13 @@ class Check:
 
 
 def check_token(api: HfApi) -> Check:
-    """Confirm the Hugging Face token resolves to an identity."""
+    """Confirm the Hugging Face token resolves to an identity that can write.
+
+    A read-only token would sail through planning and fail every adapter at
+    its publish step, so a token whose role is definitively read-only fails
+    here. A fine-grained token whose scopes cannot be interpreted passes with
+    its role reported — only the datastore commit itself can prove those.
+    """
     try:
         identity = api.whoami()
     except Exception as error:
@@ -46,6 +53,13 @@ def check_token(api: HfApi) -> Check:
         )
     name = identity.get('name') or identity.get('fullname') or 'unknown'
     role = (identity.get('auth') or {}).get('accessToken', {}).get('role')
+    if role == 'read':
+        return Check(
+            'hugging face token',
+            False,
+            f'authenticated as {name}, but the token is read-only; publishing '
+            'and raw archiving both need write access',
+        )
     return Check(
         'hugging face token',
         True,
@@ -69,25 +83,38 @@ def check_datastore(api: HfApi, repo_id: str) -> Check:
 def check_raw_dataset(
     api: HfApi, repo_id: str, *, create: bool = True
 ) -> Check:
-    """Confirm the private raw dataset exists, creating it if it does not.
+    """Confirm the private raw dataset exists and is private.
 
     Creating it here rather than mid-refresh means a token that cannot create
-    repositories is reported before any adapter has run.
+    repositories is reported before any adapter has run. A dataset that exists
+    but is *public* is a hard failure: raw source payloads are archived there
+    on the promise of privacy, and visibility is a deliberate human decision —
+    the cron reports it rather than flipping it. (The archive itself re-checks
+    privacy before every commit, so this failing closed is defence in depth,
+    not the only line.)
     """
     try:
         info = api.repo_info(repo_id=repo_id, repo_type='dataset')
-    except Exception:
+    except RepositoryNotFoundError:
         info = None
+    except Exception as error:
+        # A transient error is not evidence the repo is missing; creating (or
+        # blessing) anything on that basis could mask a public dataset.
+        return Check(
+            'raw dataset',
+            False,
+            f'could not read {repo_id}: {error}',
+        )
 
     if info is not None:
-        visibility = 'private' if getattr(info, 'private', False) else 'public'
-        if visibility == 'public':
+        if not getattr(info, 'private', False):
             return Check(
                 'raw dataset',
-                True,
-                f'{repo_id} exists but is public; raw source data is meant to '
-                'be private. Not changing it automatically.',
-                required=False,
+                False,
+                f'{repo_id} exists but is PUBLIC; raw source data must stay '
+                'private. Make it private (or point at another repo) — the '
+                'cron will not change visibility itself, and archiving '
+                'refuses to write to a public dataset.',
             )
         return Check('raw dataset', True, f'{repo_id} exists and is private')
 
@@ -101,6 +128,7 @@ def check_raw_dataset(
             private=True,
             exist_ok=True,
         )
+        created = api.repo_info(repo_id=repo_id, repo_type='dataset')
     except Exception as error:
         return Check(
             'raw dataset',
@@ -109,31 +137,49 @@ def check_raw_dataset(
             'Create it by hand as a private dataset, or point '
             '--raw-repo-id at one that exists.',
         )
+    if not getattr(created, 'private', False):
+        return Check(
+            'raw dataset',
+            False,
+            f'{repo_id} was created but reads back as PUBLIC; refusing to '
+            'treat it as a raw-data destination.',
+        )
     return Check('raw dataset', True, f'created {repo_id} as a private dataset')
 
 
 def check_adapter_credentials(environment: dict[str, str]) -> list[Check]:
-    """Report which adapters are held back by a missing credential."""
-    runnable, skipped = scheduled_adapters(environment)
-    checks = [
+    """Report which adapters are held back by a missing credential.
+
+    Asks each adapter directly (``missing_env``) instead of parsing the prose
+    reason ``scheduled_adapters`` formats — rewording a message must never make
+    a credential problem invisible.
+    """
+    runnable = []
+    held_back: list[Check] = []
+    for adapter in CRON_ADAPTERS:
+        if not adapter.enabled:
+            continue
+        missing = adapter.missing_env(environment)
+        if missing:
+            held_back.append(
+                Check(
+                    f'credential for {adapter.name}',
+                    False,
+                    f'missing environment: {", ".join(missing)}',
+                    required=False,
+                )
+            )
+        else:
+            runnable.append(adapter)
+    return [
         Check(
             'scheduled adapters',
             bool(runnable),
             f'{len(runnable)} will run: '
             + ', '.join(adapter.name for adapter in runnable),
-        )
+        ),
+        *held_back,
     ]
-    for adapter, reason in skipped:
-        if reason.startswith('missing environment'):
-            checks.append(
-                Check(
-                    f'credential for {adapter.name}',
-                    False,
-                    reason,
-                    required=False,
-                )
-            )
-    return checks
 
 
 def run_preflight(

--- a/every_eval_ever/cron/preflight.py
+++ b/every_eval_ever/cron/preflight.py
@@ -1,0 +1,174 @@
+"""Check a refresh's credentials before it does any work.
+
+The cron fails closed: if raw payloads cannot be stored, nothing is published.
+That is the right order, but it means a token without the access it needs turns
+into every adapter failing at the last step. These checks run first, on every
+scheduled run, so a credential problem is reported once and up front rather than
+fifteen jobs deep.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from huggingface_hub import HfApi
+
+from every_eval_ever.cron.archive import DEFAULT_RAW_REPO_ID
+from every_eval_ever.cron.publish import DEFAULT_REPO_ID
+from every_eval_ever.cron.schedule import scheduled_adapters
+
+
+@dataclass
+class Check:
+    """One thing that has to be true before a refresh can work."""
+
+    name: str
+    ok: bool
+    detail: str
+    #: False when the refresh can still run usefully without it.
+    required: bool = True
+
+    def render(self) -> str:
+        mark = 'PASS' if self.ok else ('FAIL' if self.required else 'WARN')
+        return f'{mark}  {self.name}: {self.detail}'
+
+
+def check_token(api: HfApi) -> Check:
+    """Confirm the Hugging Face token resolves to an identity."""
+    try:
+        identity = api.whoami()
+    except Exception as error:
+        return Check(
+            'hugging face token',
+            False,
+            f'no usable token: {error}. Set HF_TOKEN.',
+        )
+    name = identity.get('name') or identity.get('fullname') or 'unknown'
+    role = (identity.get('auth') or {}).get('accessToken', {}).get('role')
+    return Check(
+        'hugging face token',
+        True,
+        f'authenticated as {name}' + (f' (role: {role})' if role else ''),
+    )
+
+
+def check_datastore(api: HfApi, repo_id: str) -> Check:
+    """Confirm the datastore is reachable.
+
+    Reachable is not the same as writable — only a commit proves that — so this
+    catches a wrong repo id or an unauthorised token, not a read-only one.
+    """
+    try:
+        api.repo_info(repo_id=repo_id, repo_type='dataset')
+    except Exception as error:
+        return Check('datastore', False, f'cannot read {repo_id}: {error}')
+    return Check('datastore', True, f'{repo_id} is reachable')
+
+
+def check_raw_dataset(
+    api: HfApi, repo_id: str, *, create: bool = True
+) -> Check:
+    """Confirm the private raw dataset exists, creating it if it does not.
+
+    Creating it here rather than mid-refresh means a token that cannot create
+    repositories is reported before any adapter has run.
+    """
+    try:
+        info = api.repo_info(repo_id=repo_id, repo_type='dataset')
+    except Exception:
+        info = None
+
+    if info is not None:
+        visibility = 'private' if getattr(info, 'private', False) else 'public'
+        if visibility == 'public':
+            return Check(
+                'raw dataset',
+                True,
+                f'{repo_id} exists but is public; raw source data is meant to '
+                'be private. Not changing it automatically.',
+                required=False,
+            )
+        return Check('raw dataset', True, f'{repo_id} exists and is private')
+
+    if not create:
+        return Check('raw dataset', False, f'{repo_id} does not exist')
+
+    try:
+        api.create_repo(
+            repo_id=repo_id,
+            repo_type='dataset',
+            private=True,
+            exist_ok=True,
+        )
+    except Exception as error:
+        return Check(
+            'raw dataset',
+            False,
+            f'{repo_id} does not exist and could not be created: {error}. '
+            'Create it by hand as a private dataset, or point '
+            '--raw-repo-id at one that exists.',
+        )
+    return Check('raw dataset', True, f'created {repo_id} as a private dataset')
+
+
+def check_adapter_credentials(environment: dict[str, str]) -> list[Check]:
+    """Report which adapters are held back by a missing credential."""
+    runnable, skipped = scheduled_adapters(environment)
+    checks = [
+        Check(
+            'scheduled adapters',
+            bool(runnable),
+            f'{len(runnable)} will run: '
+            + ', '.join(adapter.name for adapter in runnable),
+        )
+    ]
+    for adapter, reason in skipped:
+        if reason.startswith('missing environment'):
+            checks.append(
+                Check(
+                    f'credential for {adapter.name}',
+                    False,
+                    reason,
+                    required=False,
+                )
+            )
+    return checks
+
+
+def run_preflight(
+    *,
+    environment: dict[str, str],
+    repo_id: str = DEFAULT_REPO_ID,
+    raw_repo_id: str = DEFAULT_RAW_REPO_ID,
+    create_raw: bool = True,
+    api: HfApi | None = None,
+) -> list[Check]:
+    """Run every pre-refresh check and return the results in order."""
+    api = api or HfApi(token=environment.get('HF_TOKEN'))
+    token_check = check_token(api)
+    checks = [token_check]
+    if token_check.ok:
+        checks.append(check_datastore(api, repo_id))
+        checks.append(check_raw_dataset(api, raw_repo_id, create=create_raw))
+    checks.extend(check_adapter_credentials(environment))
+    return checks
+
+
+def render(checks: list[Check]) -> str:
+    """Render the checks as lines, in the order they ran."""
+    return '\n'.join(check.render() for check in checks)
+
+
+def failed(checks: list[Check]) -> list[Check]:
+    """Return the checks that must pass and did not."""
+    return [check for check in checks if check.required and not check.ok]
+
+
+def write_markdown(checks: list[Check], path: str | Path) -> None:
+    """Append a checklist to a file, for a workflow step summary."""
+    lines = ['## Preflight', '']
+    for check in checks:
+        icon = '✅' if check.ok else ('❌' if check.required else '⚠️')
+        lines.append(f'- {icon} **{check.name}** — {check.detail}')
+    Path(path).open('a', encoding='utf-8').write('\n'.join(lines) + '\n')

--- a/every_eval_ever/cron/publish.py
+++ b/every_eval_ever/cron/publish.py
@@ -1,0 +1,195 @@
+"""Send a refresh to the datastore as one pull request per adapter.
+
+Each adapter owns one open pull request, identified by its title. A refresh
+commits onto that request when it is open and opens it when it is not, because
+opening a fresh request per round is the largest documented source of review
+churn in this datastore's history — see the conversion skill's
+``reference/datastore-submission.md``.
+
+Commits are batched: a single commit carrying thousands of files can time out
+server-side while the client sees an error, leaving a half-submitted request.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from huggingface_hub import CommitOperationAdd, HfApi
+
+DEFAULT_REPO_ID = 'evaleval/EEE_datastore'
+DEFAULT_FILES_PER_COMMIT = 300
+
+#: Marks the pull request a given adapter's cron output belongs to.
+PR_TITLE_TEMPLATE = '[Submission] Daily cron refresh: {adapter}'
+
+_logger = logging.getLogger(__name__)
+
+
+class PublishError(Exception):
+    """Raised when a refresh cannot be published."""
+
+
+@dataclass
+class PublishPlan:
+    """The files a refresh would send, and where."""
+
+    repo_id: str
+    adapter: str
+    files: list[Path] = field(default_factory=list)
+    existing_pr: int | None = None
+
+    @property
+    def title(self) -> str:
+        return PR_TITLE_TEMPLATE.format(adapter=self.adapter)
+
+
+@dataclass
+class PublishResult:
+    """What publishing did."""
+
+    pr_url: str | None
+    pr_number: int | None
+    files: int
+    commits: int
+    reused_existing_pr: bool
+
+
+def pr_title(adapter: str) -> str:
+    """Return the pull request title that identifies an adapter's cron output."""
+    return PR_TITLE_TEMPLATE.format(adapter=adapter)
+
+
+def collect_files(data_root: str | Path) -> list[Path]:
+    """Return every record file to upload, aggregates and sample companions."""
+    root = Path(data_root)
+    if not root.is_dir():
+        return []
+    return sorted(
+        path
+        for path in root.glob('*/*/*/*')
+        if path.is_file() and path.suffix in {'.json', '.jsonl'}
+    )
+
+
+def find_open_pr(
+    api: HfApi,
+    repo_id: str,
+    adapter: str,
+) -> int | None:
+    """Return the number of this adapter's open cron pull request, if any."""
+    title = pr_title(adapter)
+    for discussion in api.get_repo_discussions(
+        repo_id=repo_id,
+        repo_type='dataset',
+        discussion_type='pull_request',
+        discussion_status='open',
+    ):
+        if discussion.title.strip() == title:
+            return discussion.num
+    return None
+
+
+def _pr_number_from_url(pr_url: str | None) -> int | None:
+    if not pr_url:
+        return None
+    tail = pr_url.rstrip('/').rsplit('/', 1)[-1]
+    return int(tail) if tail.isdigit() else None
+
+
+def _batched(items: list[Path], size: int) -> list[list[Path]]:
+    return [items[index : index + size] for index in range(0, len(items), size)]
+
+
+def publish(
+    data_root: str | Path,
+    *,
+    adapter: str,
+    repo_id: str = DEFAULT_REPO_ID,
+    token: str | None = None,
+    commit_description: str = '',
+    files_per_commit: int = DEFAULT_FILES_PER_COMMIT,
+    api: HfApi | None = None,
+) -> PublishResult:
+    """Commit every record under ``data_root`` to this adapter's pull request."""
+    files = collect_files(data_root)
+    if not files:
+        raise PublishError(f'no record files found under {data_root}')
+
+    root = Path(data_root)
+    api = api or HfApi(token=token)
+    existing = find_open_pr(api, repo_id, adapter)
+    batches = _batched(files, max(1, files_per_commit))
+    total = len(batches)
+
+    pr_number = existing
+    pr_url = None
+    for index, batch in enumerate(batches, start=1):
+        operations = [
+            CommitOperationAdd(
+                path_in_repo=f'data/{path.relative_to(root).as_posix()}',
+                path_or_fileobj=str(path),
+            )
+            for path in batch
+        ]
+        suffix = f' ({index}/{total})' if total > 1 else ''
+        if pr_number is None:
+            info = api.create_commit(
+                repo_id=repo_id,
+                repo_type='dataset',
+                operations=operations,
+                commit_message=f'{pr_title(adapter)}{suffix}',
+                commit_description=commit_description,
+                create_pr=True,
+            )
+            pr_url = info.pr_url
+            pr_number = _pr_number_from_url(pr_url)
+            if pr_number is None:
+                raise PublishError(
+                    'Hugging Face did not return a pull request URL for the '
+                    f'first commit; {len(batches) - 1} batches were not sent'
+                )
+        else:
+            info = api.create_commit(
+                repo_id=repo_id,
+                repo_type='dataset',
+                operations=operations,
+                commit_message=f'{pr_title(adapter)}{suffix}',
+                commit_description=commit_description,
+                revision=f'refs/pr/{pr_number}',
+            )
+            pr_url = pr_url or getattr(info, 'pr_url', None)
+        _logger.info('committed batch %d/%d to PR %s', index, total, pr_number)
+
+    if pr_url is None and pr_number is not None:
+        pr_url = (
+            f'https://huggingface.co/datasets/{repo_id}/discussions/{pr_number}'
+        )
+
+    return PublishResult(
+        pr_url=pr_url,
+        pr_number=pr_number,
+        files=len(files),
+        commits=total,
+        reused_existing_pr=existing is not None,
+    )
+
+
+def plan(
+    data_root: str | Path,
+    *,
+    adapter: str,
+    repo_id: str = DEFAULT_REPO_ID,
+    api: HfApi | None = None,
+) -> PublishPlan:
+    """Describe what :func:`publish` would send, without sending it."""
+    existing = None
+    if api is not None:
+        existing = find_open_pr(api, repo_id, adapter)
+    return PublishPlan(
+        repo_id=repo_id,
+        adapter=adapter,
+        files=collect_files(data_root),
+        existing_pr=existing,
+    )

--- a/every_eval_ever/cron/publish.py
+++ b/every_eval_ever/cron/publish.py
@@ -78,13 +78,21 @@ def find_open_pr(
     repo_id: str,
     adapter: str,
 ) -> int | None:
-    """Return the number of this adapter's open cron pull request, if any."""
+    """Return the number of this adapter's open cron pull request, if any.
+
+    Matched by title *and* author: the datastore is public, so anyone can open
+    a pull request with any title, and committing onto a stranger's PR would
+    hand them control of where the cron's records land. Only PRs opened by the
+    account the cron authenticates as are candidates.
+    """
     title = pr_title(adapter)
+    author = api.whoami().get('name')
     for discussion in api.get_repo_discussions(
         repo_id=repo_id,
         repo_type='dataset',
         discussion_type='pull_request',
         discussion_status='open',
+        author=author,
     ):
         if discussion.title.strip() == title:
             return discussion.num
@@ -135,12 +143,23 @@ def publish(
         ]
         suffix = f' ({index}/{total})' if total > 1 else ''
         if pr_number is None:
+            # The Hub titles a created PR from this commit's message, and
+            # find_open_pr matches that title exactly tomorrow — so the
+            # PR-creating commit must carry the bare title, never the batch
+            # suffix. The suffix still marks the follow-up commits, which are
+            # ordinary commits on the PR ref.
+            description = commit_description
+            if total > 1:
+                description = (
+                    f'Batch 1/{total}; the set is incomplete until the last '
+                    f'batch lands.\n\n{commit_description}'
+                )
             info = api.create_commit(
                 repo_id=repo_id,
                 repo_type='dataset',
                 operations=operations,
-                commit_message=f'{pr_title(adapter)}{suffix}',
-                commit_description=commit_description,
+                commit_message=pr_title(adapter),
+                commit_description=description,
                 create_pr=True,
             )
             pr_url = info.pr_url

--- a/every_eval_ever/cron/publish.py
+++ b/every_eval_ever/cron/publish.py
@@ -16,7 +16,7 @@ import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from huggingface_hub import CommitOperationAdd, HfApi
+from huggingface_hub import CommitOperationAdd, CommitOperationDelete, HfApi
 
 DEFAULT_REPO_ID = 'evaleval/EEE_datastore'
 DEFAULT_FILES_PER_COMMIT = 300
@@ -59,6 +59,15 @@ class PublishResult:
 def pr_title(adapter: str) -> str:
     """Return the pull request title that identifies an adapter's cron output."""
     return PR_TITLE_TEMPLATE.format(adapter=adapter)
+
+
+def repo_paths(data_root: str | Path) -> list[str]:
+    """Return the datastore paths a publish of ``data_root`` would add."""
+    root = Path(data_root)
+    return [
+        f'data/{path.relative_to(root).as_posix()}'
+        for path in collect_files(root)
+    ]
 
 
 def collect_files(data_root: str | Path) -> list[Path]:
@@ -106,6 +115,29 @@ def _pr_number_from_url(pr_url: str | None) -> int | None:
     return int(tail) if tail.isdigit() else None
 
 
+def _paths_on_revision(
+    api: HfApi, repo_id: str, revision: str, paths: list[str]
+) -> list[str]:
+    """Return which of ``paths`` exist at ``revision``, in one call.
+
+    Deleting a path that does not exist fails the whole commit, so stale paths
+    are filtered against the pull request's actual tree first.
+    """
+    try:
+        found = api.get_paths_info(
+            repo_id=repo_id,
+            paths=paths,
+            repo_type='dataset',
+            revision=revision,
+        )
+    except Exception as error:
+        raise PublishError(
+            f'could not inspect {revision} of {repo_id} to reconcile an '
+            f'incomplete attempt: {error}'
+        ) from error
+    return [entry.path for entry in found]
+
+
 def _batched(items: list[Path], size: int) -> list[list[Path]]:
     return [items[index : index + size] for index in range(0, len(items), size)]
 
@@ -118,9 +150,16 @@ def publish(
     token: str | None = None,
     commit_description: str = '',
     files_per_commit: int = DEFAULT_FILES_PER_COMMIT,
+    stale_paths: list[str] | None = None,
     api: HfApi | None = None,
 ) -> PublishResult:
-    """Commit every record under ``data_root`` to this adapter's pull request."""
+    """Commit every record under ``data_root`` to this adapter's pull request.
+
+    ``stale_paths`` names datastore paths a previous *incomplete* attempt
+    committed before failing; whichever of them exist on the adopted pull
+    request are deleted in the first commit, so a retry replaces the broken
+    attempt instead of stacking a second copy of the set beside it.
+    """
     files = collect_files(data_root)
     if not files:
         raise PublishError(f'no record files found under {data_root}')
@@ -131,16 +170,34 @@ def publish(
     batches = _batched(files, max(1, files_per_commit))
     total = len(batches)
 
+    removals: list[CommitOperationDelete] = []
+    if stale_paths and existing is not None:
+        removals = [
+            CommitOperationDelete(path_in_repo=path)
+            for path in _paths_on_revision(
+                api, repo_id, f'refs/pr/{existing}', stale_paths
+            )
+        ]
+        if removals:
+            _logger.info(
+                'removing %d file(s) left by an incomplete attempt from '
+                'PR %d before republishing',
+                len(removals),
+                existing,
+            )
+
     pr_number = existing
     pr_url = None
     for index, batch in enumerate(batches, start=1):
-        operations = [
+        operations: list[CommitOperationAdd | CommitOperationDelete] = [
             CommitOperationAdd(
                 path_in_repo=f'data/{path.relative_to(root).as_posix()}',
                 path_or_fileobj=str(path),
             )
             for path in batch
         ]
+        if index == 1 and removals:
+            operations = [*removals, *operations]
         suffix = f' ({index}/{total})' if total > 1 else ''
         if pr_number is None:
             # The Hub titles a created PR from this commit's message, and

--- a/every_eval_ever/cron/runner.py
+++ b/every_eval_ever/cron/runner.py
@@ -1,0 +1,533 @@
+"""Run one adapter end to end for the daily refresh.
+
+    uv run python -m every_eval_ever.cron run vals_ai --dry-run
+
+One invocation handles one adapter, which is what makes the schedule one
+workflow job and one datastore pull request per adapter. The stages are:
+
+1. run the adapter into a scratch tree, archiving raw payloads it fetched;
+2. compare this run's fingerprint against the previous run's and stop if the
+   source has not moved;
+3. stamp every record as cron-produced;
+4. validate through the same CLI the datastore's pull request bot runs;
+5. commit the records to the adapter's pull request.
+
+Exit codes: ``0`` published, ``2`` nothing new to publish, ``1`` failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from every_eval_ever.cron import publish as publish_module
+from every_eval_ever.cron.fingerprint import (
+    output_fingerprint,
+    read_fingerprint,
+    write_fingerprint,
+)
+from every_eval_ever.cron.schedule import (
+    CronAdapter,
+    RawPolicy,
+    get_adapter,
+    scheduled_adapters,
+)
+from every_eval_ever.cron.stamp import stamp_tree
+from every_eval_ever.helpers import raw_capture
+
+EXIT_PUBLISHED = 0
+EXIT_FAILED = 1
+EXIT_NOTHING_NEW = 2
+
+_logger = logging.getLogger('every_eval_ever.cron')
+
+
+@dataclass
+class RunSummary:
+    """The record of one adapter refresh, written to disk for the artifact."""
+
+    adapter: str
+    run_date: str
+    status: str = 'pending'
+    detail: str = ''
+    invocations: int = 0
+    #: Invocations that exited non-zero. Their valid records are still kept and
+    #: published; the reason each failed is in the run's adapter_reports/.
+    failed_invocations: list[dict[str, object]] = field(default_factory=list)
+    records: int = 0
+    raw_payloads: int = 0
+    raw_bytes: int = 0
+    raw_policy: str = ''
+    raw_fingerprint: str | None = None
+    output_fingerprint: str | None = None
+    previous_fingerprint: str | None = None
+    fingerprint_source: str | None = None
+    unknown_inferred_fields: dict[str, int] = field(default_factory=dict)
+    collections: list[str] = field(default_factory=list)
+    validation: dict[str, int] = field(default_factory=dict)
+    pr_url: str | None = None
+    pr_reused: bool | None = None
+
+    def write(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(asdict(self), indent=2, sort_keys=True) + '\n',
+            encoding='utf-8',
+        )
+
+
+def utc_run_date() -> str:
+    """Return today's UTC date, the value stamped onto every record."""
+    return datetime.now(timezone.utc).strftime('%Y-%m-%d')
+
+
+@dataclass
+class Invocation:
+    """One adapter invocation and how it ended."""
+
+    arguments: list[str]
+    returncode: int
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+@dataclass
+class AdapterOutcome:
+    """Every invocation this refresh made for one adapter."""
+
+    invocations: list[Invocation] = field(default_factory=list)
+
+    @property
+    def failed(self) -> list[Invocation]:
+        return [item for item in self.invocations if not item.ok]
+
+    @property
+    def all_failed(self) -> bool:
+        return bool(self.invocations) and not any(
+            item.ok for item in self.invocations
+        )
+
+
+def run_adapter(
+    adapter: CronAdapter,
+    *,
+    work_dir: Path,
+    raw_dir: Path,
+    environment: dict[str, str],
+) -> AdapterOutcome:
+    """Invoke the adapter once per configured run, and keep going on failure.
+
+    Adapters default their output to a relative ``data/`` path, so the scratch
+    tree is the working directory rather than a flag: the ones that do accept
+    ``--output-dir`` disagree about whether it means the base or the collection
+    directory.
+
+    A non-zero exit is not treated as fatal here. An adapter that hits a source
+    row it cannot represent writes every valid record, writes a report under
+    ``adapter_reports/``, and *then* exits non-zero — so a run is reported,
+    never discarded, and one bad leaderboard does not cost the others their
+    records.
+    """
+    work_dir.mkdir(parents=True, exist_ok=True)
+    child_environment = {
+        **environment,
+        raw_capture.RAW_CAPTURE_DIR_ENV: str(raw_dir),
+        'PYTHONUNBUFFERED': '1',
+    }
+    outcome = AdapterOutcome()
+    for run in adapter.runs:
+        argv = [sys.executable, *adapter.argv_for(run, raw_dir)]
+        _logger.info('running %s', ' '.join(argv[1:]))
+        completed = subprocess.run(
+            argv,
+            cwd=work_dir,
+            env=child_environment,
+            check=False,
+        )
+        outcome.invocations.append(
+            Invocation(arguments=list(run), returncode=completed.returncode)
+        )
+        if completed.returncode != 0:
+            _logger.warning(
+                '%s exited %d for %s; continuing with the remaining runs',
+                adapter.name,
+                completed.returncode,
+                list(run) or '[no arguments]',
+            )
+    return outcome
+
+
+def validate_records(data_root: Path) -> dict[str, int]:
+    """Validate generated records with the CLI the datastore's bot uses.
+
+    Raises:
+        RuntimeError: if any record fails, or if warnings would block a merge.
+    """
+    pattern = str(data_root / '*' / '*' / '*' / '*.json*')
+    completed = subprocess.run(
+        [
+            sys.executable,
+            '-m',
+            'every_eval_ever',
+            'validate',
+            '--format',
+            'json',
+            pattern,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(
+            'could not read validator output '
+            f'(exit {completed.returncode}): {completed.stderr.strip()}'
+        ) from error
+
+    # The package CLI reports a bare list of file reports.
+    reports = (
+        payload if isinstance(payload, list) else payload.get('reports', [])
+    )
+    errors = sum(len(report.get('errors', [])) for report in reports)
+    warnings = sum(len(report.get('warnings', [])) for report in reports)
+    counts = {'files': len(reports), 'errors': errors, 'warnings': warnings}
+    if completed.returncode != 0:
+        # Exit 2 is warning-only, which does not make a record invalid but does
+        # block a merge, so it is not something to publish and walk away from.
+        raise RuntimeError(
+            f'validation failed with {errors} error(s) and {warnings} '
+            'warning(s); records were not published'
+        )
+    return counts
+
+
+def collections_in(data_root: Path) -> list[str]:
+    """Return the datastore collections a run wrote to."""
+    if not data_root.is_dir():
+        return []
+    return sorted(entry.name for entry in data_root.iterdir() if entry.is_dir())
+
+
+def refresh(
+    name: str,
+    *,
+    work_dir: Path,
+    fingerprint_path: Path | None,
+    summary_path: Path,
+    repo_id: str,
+    run_url: str | None,
+    dry_run: bool,
+    force: bool,
+    environment: dict[str, str] | None = None,
+) -> tuple[int, RunSummary]:
+    """Refresh one adapter. Returns its exit code and summary."""
+    environment = dict(os.environ if environment is None else environment)
+    adapter = get_adapter(name)
+    run_date = utc_run_date()
+    summary = RunSummary(
+        adapter=adapter.name,
+        run_date=run_date,
+        raw_policy=adapter.raw_policy.value,
+    )
+
+    missing = adapter.missing_env(environment)
+    if missing:
+        summary.status = 'skipped'
+        summary.detail = f'missing environment: {", ".join(missing)}'
+        summary.write(summary_path)
+        _logger.warning('%s: %s', adapter.name, summary.detail)
+        return EXIT_NOTHING_NEW, summary
+
+    data_root = work_dir / 'data'
+    raw_dir = work_dir / 'raw'
+
+    outcome = run_adapter(
+        adapter,
+        work_dir=work_dir,
+        raw_dir=raw_dir,
+        environment=environment,
+    )
+    summary.invocations = len(outcome.invocations)
+    summary.failed_invocations = [
+        {
+            'arguments': ' '.join(item.arguments) or '(no arguments)',
+            'returncode': item.returncode,
+        }
+        for item in outcome.failed
+    ]
+
+    raw_capture.index_unlisted_payloads(raw_dir)
+    manifest = raw_capture.read_manifest(raw_dir)
+    summary.raw_payloads = sum(1 for entry in manifest if entry.get('file'))
+    summary.raw_bytes = sum(entry.get('bytes') or 0 for entry in manifest)
+    # Only verbatim wire captures can say whether the source moved; a dump an
+    # adapter wrote itself is archived but may carry its own fetch timestamp.
+    summary.raw_fingerprint = raw_capture.fingerprint(
+        raw_dir, verbatim_only=True
+    )
+
+    if (
+        adapter.raw_policy
+        in {RawPolicy.VIA_FETCH_HELPERS, RawPolicy.VIA_ADAPTER_FLAG}
+        and not summary.raw_payloads
+    ):
+        # Declared as archived but nothing landed: report it rather than let the
+        # run look like it saved raw data.
+        _logger.warning(
+            '%s declares raw policy %s but archived no payloads',
+            adapter.name,
+            adapter.raw_policy.value,
+        )
+
+    summary.records = len(list(data_root.glob('*/*/*/*.json')))
+    summary.collections = collections_in(data_root)
+    if not summary.records:
+        # No records and a failing adapter is a broken source; no records and a
+        # clean exit just means the source had nothing to give today.
+        if outcome.failed:
+            summary.status = 'failed'
+            summary.detail = (
+                'the adapter produced no records and '
+                f'{len(outcome.failed)} of {summary.invocations} invocation(s) '
+                'failed'
+            )
+            summary.write(summary_path)
+            _logger.error('%s: %s', adapter.name, summary.detail)
+            return EXIT_FAILED, summary
+        summary.status = 'nothing_produced'
+        summary.detail = 'the adapter produced no records'
+        summary.write(summary_path)
+        return EXIT_NOTHING_NEW, summary
+
+    stamped = stamp_tree(
+        data_root,
+        adapter=adapter.name,
+        run_date=run_date,
+        run_url=run_url,
+    )
+    summary.unknown_inferred_fields = stamped.unknown_inferred
+
+    summary.output_fingerprint = output_fingerprint(data_root)
+    summary.fingerprint_source = 'raw' if summary.raw_fingerprint else 'output'
+    current = summary.raw_fingerprint or summary.output_fingerprint
+    previous = read_fingerprint(fingerprint_path) if fingerprint_path else None
+    summary.previous_fingerprint = previous
+
+    if previous and current == previous and not force:
+        summary.status = 'unchanged'
+        summary.detail = (
+            f'{summary.fingerprint_source} fingerprint matches the previous '
+            'run; nothing published'
+        )
+        summary.write(summary_path)
+        _logger.info('%s: %s', adapter.name, summary.detail)
+        return EXIT_NOTHING_NEW, summary
+
+    summary.validation = validate_records(data_root)
+
+    if dry_run:
+        preview = publish_module.plan(
+            data_root, adapter=adapter.name, repo_id=repo_id
+        )
+        summary.status = 'dry_run'
+        summary.detail = (
+            f'would send {len(preview.files)} file(s) to {repo_id} as '
+            f'{preview.title!r}'
+        )
+        summary.write(summary_path)
+        _logger.info('%s: %s', adapter.name, summary.detail)
+        return EXIT_PUBLISHED, summary
+
+    if summary.failed_invocations:
+        _logger.warning(
+            '%s: publishing %d record(s) from a partial refresh; %d '
+            'invocation(s) failed',
+            adapter.name,
+            summary.records,
+            len(summary.failed_invocations),
+        )
+
+    result = publish_module.publish(
+        data_root,
+        adapter=adapter.name,
+        repo_id=repo_id,
+        token=environment.get('HF_TOKEN'),
+        commit_description=_commit_description(summary, run_url),
+    )
+    summary.status = (
+        'published_partial' if summary.failed_invocations else 'published'
+    )
+    summary.pr_url = result.pr_url
+    summary.pr_reused = result.reused_existing_pr
+    summary.detail = (
+        f'{result.files} file(s) in {result.commits} commit(s) to '
+        f'{result.pr_url}'
+    )
+    if fingerprint_path and current:
+        write_fingerprint(fingerprint_path, current)
+    summary.write(summary_path)
+    _logger.info('%s: %s', adapter.name, summary.detail)
+    return EXIT_PUBLISHED, summary
+
+
+def _partial_refresh_lines(summary: RunSummary) -> list[str]:
+    """Say up front that a refresh was partial, and which part is missing."""
+    if not summary.failed_invocations:
+        return []
+    failures = '; '.join(
+        f'`{item["arguments"]}` exited {item["returncode"]}'
+        for item in summary.failed_invocations
+    )
+    return [
+        f'- **Partial refresh**: {len(summary.failed_invocations)} of '
+        f'{summary.invocations} invocation(s) failed ({failures}). The records '
+        'here are the ones that converted; the rest of this source is not in '
+        'this update. Reasons are in the run artifact under '
+        '`adapter_reports/`.'
+    ]
+
+
+def _commit_description(summary: RunSummary, run_url: str | None) -> str:
+    """Describe the run in the commit, so a reviewer can trace it."""
+    lines = [
+        f'Automated refresh of the `{summary.adapter}` adapter.',
+        '',
+        f'- Run date (UTC): {summary.run_date}',
+        f'- Records: {summary.records} across {len(summary.collections)} '
+        f'collection(s): {", ".join(summary.collections)}',
+        f'- Adapter invocations: {summary.invocations}',
+        f'- Raw payloads archived: {summary.raw_payloads} '
+        f'({summary.raw_policy})',
+        *_partial_refresh_lines(summary),
+        f'- Every record carries `type_of_addition: cron` and '
+        f'`cron_run_date: {summary.run_date}` in '
+        '`source_metadata.additional_details`.',
+    ]
+    if summary.unknown_inferred_fields:
+        unknown = ', '.join(
+            f'{name} ({count})'
+            for name, count in sorted(summary.unknown_inferred_fields.items())
+        )
+        lines.append(
+            f'- Inferred axes still `unknown`: {unknown}. The source does not '
+            'state these; each affected record names them in '
+            '`cron_unknown_inferred_fields`.'
+        )
+    if run_url:
+        lines.append(f'- Workflow run (raw data artifact): {run_url}')
+    return '\n'.join(lines)
+
+
+def _add_run_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument('adapter', help='Adapter to refresh')
+    parser.add_argument(
+        '--work-dir',
+        type=Path,
+        required=True,
+        help='Scratch directory for generated records and raw payloads',
+    )
+    parser.add_argument(
+        '--fingerprint',
+        type=Path,
+        help=(
+            'File holding the previous run fingerprint. Updated on a '
+            'successful publish; a missing file means the run always publishes.'
+        ),
+    )
+    parser.add_argument(
+        '--summary',
+        type=Path,
+        help='Where to write the run summary JSON (default: <work-dir>/summary.json)',
+    )
+    parser.add_argument(
+        '--repo-id',
+        default=publish_module.DEFAULT_REPO_ID,
+        help=f'Datastore repo (default: {publish_module.DEFAULT_REPO_ID})',
+    )
+    parser.add_argument(
+        '--run-url',
+        default=os.environ.get('EEE_CRON_RUN_URL'),
+        help='Workflow run URL recorded on each record and in the commit',
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Do everything except commit to the datastore',
+    )
+    parser.add_argument(
+        '--force',
+        action='store_true',
+        help='Publish even when the fingerprint matches the previous run',
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog='every_eval_ever.cron',
+        description='Daily adapter refresh for the EEE datastore.',
+    )
+    subcommands = parser.add_subparsers(dest='command', required=True)
+    run_parser = subcommands.add_parser('run', help='Refresh one adapter')
+    _add_run_arguments(run_parser)
+    subcommands.add_parser(
+        'list', help='Print the adapters the schedule would run, as JSON'
+    )
+
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s %(name)s: %(message)s',
+    )
+
+    if args.command == 'list':
+        runnable, skipped = scheduled_adapters(dict(os.environ))
+        print(
+            json.dumps(
+                {
+                    'adapters': [adapter.name for adapter in runnable],
+                    'skipped': {
+                        adapter.name: reason for adapter, reason in skipped
+                    },
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    summary_path = args.summary or (args.work_dir / 'summary.json')
+    try:
+        code, _ = refresh(
+            args.adapter,
+            work_dir=args.work_dir,
+            fingerprint_path=args.fingerprint,
+            summary_path=summary_path,
+            repo_id=args.repo_id,
+            run_url=args.run_url,
+            dry_run=args.dry_run,
+            force=args.force,
+        )
+        return code
+    except Exception as error:
+        _logger.error('%s failed: %s', args.adapter, error)
+        RunSummary(
+            adapter=args.adapter,
+            run_date=utc_run_date(),
+            status='failed',
+            detail=str(error),
+        ).write(summary_path)
+        return EXIT_FAILED
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/every_eval_ever/cron/runner.py
+++ b/every_eval_ever/cron/runner.py
@@ -56,6 +56,12 @@ EXIT_FAILED = 1
 # code as success.
 EXIT_NOTHING_NEW = 3
 
+#: The cron's write-capable Hugging Face credentials, in every spelling the
+#: hub client reads. Never forwarded to adapter subprocesses.
+WRITE_TOKEN_ENV_NAMES = ('HF_TOKEN', 'HUGGING_FACE_HUB_TOKEN', 'HF_HUB_TOKEN')
+#: A separate read-only token for sources that need authenticated HF access.
+SOURCE_HF_TOKEN_ENV = 'EEE_SOURCE_HF_TOKEN'
+
 _logger = logging.getLogger('every_eval_ever.cron')
 
 
@@ -149,10 +155,33 @@ def run_adapter(
     """
     work_dir.mkdir(parents=True, exist_ok=True)
     child_environment = {
-        **environment,
-        raw_capture.RAW_CAPTURE_DIR_ENV: str(raw_dir),
-        'PYTHONUNBUFFERED': '1',
+        name: value
+        for name, value in environment.items()
+        # The cron's Hugging Face token can write to the datastore and the
+        # private raw dataset. Adapter code and its dependencies have no
+        # business holding that authority: it stays in the parent, which does
+        # all archiving, state and publication itself.
+        if name not in WRITE_TOKEN_ENV_NAMES
     }
+    child_environment.update(
+        {
+            raw_capture.RAW_CAPTURE_DIR_ENV: str(raw_dir),
+            'PYTHONUNBUFFERED': '1',
+        }
+    )
+    if adapter.source_hf_token:
+        # A source that needs authenticated Hugging Face *read* access gets a
+        # separate least-privilege token, never the cron's own.
+        source_token = (environment.get(SOURCE_HF_TOKEN_ENV) or '').strip()
+        if source_token:
+            child_environment['HF_TOKEN'] = source_token
+        else:
+            _logger.warning(
+                '%s declares source_hf_token but %s is not set; the source '
+                'fetch will run unauthenticated',
+                adapter.name,
+                SOURCE_HF_TOKEN_ENV,
+            )
     outcome = AdapterOutcome()
     for run in adapter.runs:
         argv = [sys.executable, *adapter.argv_for(run, raw_dir)]
@@ -295,11 +324,24 @@ def _unchanged_since(
     )
 
 
+def _failure_reports(work_dir: Path) -> list[Path]:
+    """Return the failure reports the adapter left under ``adapter_reports/``.
+
+    These embed raw source rows, so they are archived into the private raw
+    dataset — never uploaded as a public workflow artifact.
+    """
+    reports_dir = work_dir / 'adapter_reports'
+    if not reports_dir.is_dir():
+        return []
+    return sorted(path for path in reports_dir.iterdir() if path.is_file())
+
+
 def _archive_raw(
     raw_dir: Path,
     *,
     summary: RunSummary,
     captured: int,
+    reports: list[Path],
     run_id: str,
     run_url: str | None,
     gating_fingerprint: str | None,
@@ -308,13 +350,13 @@ def _archive_raw(
     dry_run: bool,
     token: str | None,
 ) -> dict[str, object]:
-    """Store this run's raw payloads permanently, or say why it did not.
+    """Store this run's raw payloads and reports permanently, or say why not.
 
     ``captured`` counts every manifest entry, not just the ones that landed on
-    disk: a payload too large to store still gets a ledger row, so a run that
-    only fetched an oversized payload must still be archived.
+    disk: a payload too large to store still gets a ledger row, and a capture
+    *failure* row is precisely the evidence worth keeping.
     """
-    if not captured:
+    if not captured and not reports:
         return {
             'status': 'nothing_captured',
             'reason': (
@@ -346,6 +388,7 @@ def _archive_raw(
         raw_fingerprint=summary.raw_fingerprint,
         output_fingerprint=summary.output_fingerprint,
         gating_fingerprint=gating_fingerprint,
+        reports=reports,
         repo_id=raw_repo_id,
         token=token,
     )
@@ -357,6 +400,7 @@ def _archive_raw(
         'reused': result.reused,
         'uploaded_bytes': result.uploaded_bytes,
         'ledger_rows': len(result.rows),
+        'reports': len(reports),
     }
 
 
@@ -393,11 +437,14 @@ def refresh(
 
     missing = adapter.missing_env(environment)
     if missing:
-        summary.status = 'skipped'
+        # An enabled adapter without its credential is a broken configuration,
+        # not a quiet day: the job must fail visibly, in isolation, while the
+        # other adapters' jobs proceed.
+        summary.status = 'missing_credentials'
         summary.detail = f'missing environment: {", ".join(missing)}'
         summary.write(summary_path)
-        _logger.warning('%s: %s', adapter.name, summary.detail)
-        return EXIT_NOTHING_NEW, summary
+        _logger.error('%s: %s', adapter.name, summary.detail)
+        return EXIT_FAILED, summary
 
     data_root = work_dir / 'data'
     raw_dir = work_dir / 'raw'
@@ -448,31 +495,6 @@ def refresh(
     summary.records = len(list(data_root.glob('*/*/*/*.json')))
     summary.collections = collections_in(data_root)
 
-    if summary.records and declares_capture:
-        # Records without their source bytes archived must not be published:
-        # a swallowed capture exception, or an adapter that fetched without
-        # its declared capture route, would otherwise erode provenance one
-        # quiet day at a time. Deliberate ceiling skips are not errors.
-        problems = []
-        if summary.capture_errors:
-            problems.append(
-                f'{len(summary.capture_errors)} capture failure(s): '
-                + ', '.join(summary.capture_errors[:5])
-            )
-        if not manifest:
-            problems.append(
-                f'raw policy {adapter.raw_policy.value} captured nothing'
-            )
-        if problems:
-            summary.status = 'failed'
-            summary.detail = (
-                'records were produced but their raw source was not '
-                'archived (' + '; '.join(problems) + '); nothing published'
-            )
-            summary.write(summary_path)
-            _logger.error('%s: %s', adapter.name, summary.detail)
-            return EXIT_FAILED, summary
-
     # Computed before stamping deliberately: the digest strips the cron stamp,
     # so the value is the same either side of it, and archiving it here means
     # the ledger row carries the fingerprint even for a run that fails later.
@@ -489,6 +511,7 @@ def refresh(
         raw_dir,
         summary=summary,
         captured=len(manifest),
+        reports=_failure_reports(work_dir),
         run_id=run_id,
         run_url=run_url,
         gating_fingerprint=current,
@@ -497,6 +520,34 @@ def refresh(
         dry_run=dry_run,
         token=environment.get('HF_TOKEN'),
     )
+
+    if summary.records and declares_capture:
+        # Records without their source bytes archived must not be published: a
+        # swallowed capture exception, or an adapter that fetched without its
+        # declared capture route, would erode provenance one quiet day at a
+        # time. Checked *after* archiving, so the successful sibling captures
+        # and the error rows themselves are already stored permanently.
+        # Deliberate ceiling skips are not errors.
+        problems = []
+        if summary.capture_errors:
+            problems.append(
+                f'{len(summary.capture_errors)} capture failure(s): '
+                + ', '.join(summary.capture_errors[:5])
+            )
+        if not manifest:
+            problems.append(
+                f'raw policy {adapter.raw_policy.value} captured nothing'
+            )
+        if problems:
+            summary.status = 'failed'
+            summary.detail = (
+                'records were produced but their raw source was not fully '
+                'captured (' + '; '.join(problems) + '); nothing published. '
+                'What was captured, and the error rows, are archived.'
+            )
+            summary.write(summary_path)
+            _logger.error('%s: %s', adapter.name, summary.detail)
+            return EXIT_FAILED, summary
 
     if not summary.records:
         # No records and a failing adapter is a broken source; no records and a
@@ -536,8 +587,34 @@ def refresh(
     )
     current_failures = failure_identity(summary.failed_invocations)
 
-    if not force and _unchanged_since(
-        previous, current=current, current_failures=current_failures
+    # A dangling attempt record means a previous publish died between batches:
+    # its partial file set is sitting on the pull request. That forces a
+    # publish (never a skip, even on a matching fingerprint), and hands the
+    # attempt's paths to publish() so the broken half-set is removed first.
+    dangling = (
+        archive_module.read_attempt(
+            adapter.name,
+            repo_id=raw_repo_id,
+            token=environment.get('HF_TOKEN'),
+        )
+        if archive_raw and not dry_run
+        else None
+    )
+    if dangling:
+        _logger.warning(
+            '%s: a previous publish left an incomplete attempt (%d file(s), '
+            'run %s); reconciling it instead of gating on the fingerprint',
+            adapter.name,
+            len(dangling.get('paths') or []),
+            dangling.get('run_id'),
+        )
+
+    if (
+        not force
+        and not dangling
+        and _unchanged_since(
+            previous, current=current, current_failures=current_failures
+        )
     ):
         summary.status = 'unchanged'
         summary.detail = (
@@ -578,12 +655,29 @@ def refresh(
             len(summary.failed_invocations),
         )
 
+    # Recorded before the first batch: a publish that dies between batches
+    # leaves this durable list of exactly what its incomplete attempt added,
+    # which is what lets the next run replace it instead of stacking a copy.
+    if archive_raw:
+        archive_module.write_attempt(
+            adapter.name,
+            {
+                'run_id': run_id,
+                'run_date': run_date,
+                'gating_fingerprint': current,
+                'paths': publish_module.repo_paths(data_root),
+            },
+            repo_id=raw_repo_id,
+            token=environment.get('HF_TOKEN'),
+        )
+
     result = publish_module.publish(
         data_root,
         adapter=adapter.name,
         repo_id=repo_id,
         token=environment.get('HF_TOKEN'),
         commit_description=_commit_description(summary, run_url),
+        stale_paths=(dangling or {}).get('paths'),
     )
     summary.status = (
         'published_partial' if summary.failed_invocations else 'published'
@@ -596,37 +690,72 @@ def refresh(
     )
     # Only now, after the datastore has the records, is the fingerprint safe to
     # persist: recording it any earlier would make a failed publish look
-    # 'unchanged' tomorrow and silently withhold the records forever.
+    # 'unchanged' tomorrow and silently withhold the records forever. The same
+    # commit clears the attempt record, so the two can never disagree.
     if fingerprint_path and current:
         write_fingerprint(fingerprint_path, current)
     if archive_raw and current:
-        try:
-            archive_module.write_state(
-                adapter.name,
-                {
-                    'gating_fingerprint': current,
-                    'fingerprint_source': summary.fingerprint_source,
-                    'run_date': run_date,
-                    'run_id': run_id,
-                    'run_url': run_url,
-                    'partial': bool(summary.failed_invocations),
-                    'failure_identity': current_failures,
-                    'pr_number': result.pr_number,
-                    'pr_url': result.pr_url,
-                },
-                repo_id=raw_repo_id,
-                token=environment.get('HF_TOKEN'),
+        state = {
+            'gating_fingerprint': current,
+            'fingerprint_source': summary.fingerprint_source,
+            'run_date': run_date,
+            'run_id': run_id,
+            'run_url': run_url,
+            'partial': bool(summary.failed_invocations),
+            'failure_identity': current_failures,
+            'pr_number': result.pr_number,
+            'pr_url': result.pr_url,
+        }
+        error = _write_state_with_retry(
+            adapter.name,
+            state,
+            raw_repo_id=raw_repo_id,
+            token=environment.get('HF_TOKEN'),
+        )
+        if error is not None:
+            # The records ARE on the pull request; only the gate is stale. A
+            # green exit here would hide that tomorrow will republish the set
+            # (and, with the attempt record still standing, first delete and
+            # re-add these very files). Fail, keeping the PR URL in view.
+            summary.status = 'published_state_unrecorded'
+            summary.detail = (
+                f'published {result.files} file(s) to {result.pr_url}, but '
+                f'the publish state could not be recorded after retrying: '
+                f'{error}. The next run will reconcile this attempt.'
             )
-        except archive_module.ArchiveError as error:
-            # The publish itself succeeded; stale state can only cause a
-            # duplicate publish tomorrow, never a loss. Say so loudly.
-            summary.detail += f' (WARNING: publish state not recorded: {error})'
-            _logger.error(
-                '%s: %s; tomorrow may republish this set', adapter.name, error
-            )
+            summary.write(summary_path)
+            _logger.error('%s: %s', adapter.name, summary.detail)
+            return EXIT_FAILED, summary
     summary.write(summary_path)
     _logger.info('%s: %s', adapter.name, summary.detail)
     return EXIT_PUBLISHED, summary
+
+
+def _write_state_with_retry(
+    adapter: str,
+    state: dict[str, object],
+    *,
+    raw_repo_id: str,
+    token: str | None,
+) -> archive_module.ArchiveError | None:
+    """Record the publish state, retrying once. Returns the final error."""
+    error: archive_module.ArchiveError | None = None
+    for _ in range(2):
+        try:
+            archive_module.write_state(
+                adapter,
+                state,
+                repo_id=raw_repo_id,
+                token=token,
+                clear_attempt=True,
+            )
+            return None
+        except archive_module.ArchiveError as exc:
+            error = exc
+            _logger.warning(
+                '%s: state write failed, retrying: %s', adapter, exc
+            )
+    return error
 
 
 def _raw_archive_lines(summary: RunSummary) -> list[str]:
@@ -668,7 +797,14 @@ def _commit_description(summary: RunSummary, run_url: str | None) -> str:
         f'collection(s): {", ".join(summary.collections)}',
         f'- Adapter invocations: {summary.invocations}',
         f'- Raw payloads archived: {summary.raw_payloads} '
-        f'({summary.raw_policy})',
+        f'({summary.raw_policy}'
+        + (
+            f'; {summary.raw_skipped} fetched but over the capture ceiling, '
+            'recorded in the ledger only'
+            if summary.raw_skipped
+            else ''
+        )
+        + ')',
         *_raw_archive_lines(summary),
         *_partial_refresh_lines(summary),
         f'- Every record carries `type_of_addition: cron` and '

--- a/every_eval_ever/cron/runner.py
+++ b/every_eval_ever/cron/runner.py
@@ -5,12 +5,12 @@
 One invocation handles one adapter, which is what makes the schedule one
 workflow job and one datastore pull request per adapter. The stages are:
 
-1. run the adapter into a scratch tree, archiving raw payloads it fetched;
-2. compare this run's fingerprint against the previous run's and stop if the
-   source has not moved;
-3. stamp every record as cron-produced;
-4. validate through the same CLI the datastore's pull request bot runs;
-5. commit the records to the adapter's pull request.
+1. run the adapter into a scratch tree;
+2. store what it fetched permanently, in the private raw dataset;
+3. stop if the source has not moved since the fingerprint the ledger recorded;
+4. stamp every record as cron-produced;
+5. validate through the same CLI the datastore's pull request bot runs;
+6. commit the records to the adapter's pull request.
 
 Exit codes: ``0`` published, ``2`` nothing new to publish, ``1`` failed.
 """
@@ -27,6 +27,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+from every_eval_ever.cron import archive as archive_module
 from every_eval_ever.cron import publish as publish_module
 from every_eval_ever.cron.fingerprint import (
     output_fingerprint,
@@ -65,6 +66,7 @@ class RunSummary:
     raw_payloads: int = 0
     raw_bytes: int = 0
     raw_policy: str = ''
+    raw_archive: dict[str, object] = field(default_factory=dict)
     raw_fingerprint: str | None = None
     output_fingerprint: str | None = None
     previous_fingerprint: str | None = None
@@ -219,6 +221,84 @@ def collections_in(data_root: Path) -> list[str]:
     return sorted(entry.name for entry in data_root.iterdir() if entry.is_dir())
 
 
+def _previous_fingerprint(
+    adapter: str,
+    *,
+    fingerprint_path: Path | None,
+    raw_repo_id: str,
+    consult_ledger: bool,
+    token: str | None,
+) -> str | None:
+    """Return the fingerprint to compare this run against.
+
+    A local ``--fingerprint`` file wins when it has a value, which is what makes
+    a local run reproducible. Otherwise the raw dataset's ledger is the durable
+    memory: it survives the build cache, so an adapter cannot forget last night's
+    state and republish its whole set.
+    """
+    stored = read_fingerprint(fingerprint_path) if fingerprint_path else None
+    if stored:
+        return stored
+    if not consult_ledger:
+        return None
+    return archive_module.last_gating_fingerprint(
+        adapter, repo_id=raw_repo_id, token=token
+    )
+
+
+def _archive_raw(
+    raw_dir: Path,
+    *,
+    summary: RunSummary,
+    run_id: str,
+    run_url: str | None,
+    gating_fingerprint: str | None,
+    raw_repo_id: str,
+    archive_raw: bool,
+    dry_run: bool,
+    token: str | None,
+) -> dict[str, object]:
+    """Store this run's raw payloads permanently, or say why it did not."""
+    if not summary.raw_payloads:
+        return {
+            'status': 'nothing_captured',
+            'reason': (
+                'the adapter archives no raw data; see its raw policy'
+                if summary.raw_policy
+                else ''
+            ),
+        }
+    if not archive_raw:
+        return {'status': 'disabled', 'payloads': summary.raw_payloads}
+    if dry_run:
+        return {
+            'status': 'skipped_dry_run',
+            'repo_id': raw_repo_id,
+            'payloads': summary.raw_payloads,
+        }
+
+    result = archive_module.archive(
+        raw_dir,
+        adapter=summary.adapter,
+        run_date=summary.run_date,
+        run_id=run_id,
+        run_url=run_url,
+        raw_fingerprint=summary.raw_fingerprint,
+        output_fingerprint=summary.output_fingerprint,
+        gating_fingerprint=gating_fingerprint,
+        repo_id=raw_repo_id,
+        token=token,
+    )
+    return {
+        'status': 'archived',
+        'repo_id': result.repo_id,
+        'ledger_path': result.ledger_path,
+        'uploaded': result.uploaded,
+        'reused': result.reused,
+        'uploaded_bytes': result.uploaded_bytes,
+    }
+
+
 def refresh(
     name: str,
     *,
@@ -229,6 +309,9 @@ def refresh(
     run_url: str | None,
     dry_run: bool,
     force: bool,
+    run_id: str = 'local',
+    raw_repo_id: str = archive_module.DEFAULT_RAW_REPO_ID,
+    archive_raw: bool = True,
     environment: dict[str, str] | None = None,
 ) -> tuple[int, RunSummary]:
     """Refresh one adapter. Returns its exit code and summary."""
@@ -292,6 +375,31 @@ def refresh(
 
     summary.records = len(list(data_root.glob('*/*/*/*.json')))
     summary.collections = collections_in(data_root)
+
+    # Computed before stamping deliberately: the digest strips the cron stamp,
+    # so the value is the same either side of it, and archiving it here means
+    # the ledger row carries the fingerprint even for a run that fails later.
+    summary.output_fingerprint = output_fingerprint(data_root)
+    summary.fingerprint_source = 'raw' if summary.raw_fingerprint else 'output'
+    current = summary.raw_fingerprint or summary.output_fingerprint
+
+    # Archive before anything is published, and on every path that captured
+    # something — including a run that produced no records, whose payload is
+    # often the evidence for why. Records must never reach the datastore without
+    # their raw provenance stored somewhere permanent, so a failure here is
+    # fatal rather than a warning.
+    summary.raw_archive = _archive_raw(
+        raw_dir,
+        summary=summary,
+        run_id=run_id,
+        run_url=run_url,
+        gating_fingerprint=current,
+        raw_repo_id=raw_repo_id,
+        archive_raw=archive_raw,
+        dry_run=dry_run,
+        token=environment.get('HF_TOKEN'),
+    )
+
     if not summary.records:
         # No records and a failing adapter is a broken source; no records and a
         # clean exit just means the source had nothing to give today.
@@ -318,10 +426,13 @@ def refresh(
     )
     summary.unknown_inferred_fields = stamped.unknown_inferred
 
-    summary.output_fingerprint = output_fingerprint(data_root)
-    summary.fingerprint_source = 'raw' if summary.raw_fingerprint else 'output'
-    current = summary.raw_fingerprint or summary.output_fingerprint
-    previous = read_fingerprint(fingerprint_path) if fingerprint_path else None
+    previous = _previous_fingerprint(
+        adapter.name,
+        fingerprint_path=fingerprint_path,
+        raw_repo_id=raw_repo_id,
+        consult_ledger=archive_raw and not dry_run,
+        token=environment.get('HF_TOKEN'),
+    )
     summary.previous_fingerprint = previous
 
     if previous and current == previous and not force:
@@ -381,6 +492,18 @@ def refresh(
     return EXIT_PUBLISHED, summary
 
 
+def _raw_archive_lines(summary: RunSummary) -> list[str]:
+    """Point a reviewer at the permanently stored raw data for this run."""
+    archive = summary.raw_archive
+    if archive.get('status') != 'archived':
+        return []
+    return [
+        f'- Raw data kept in `{archive["repo_id"]}` (private): '
+        f'{archive["uploaded"]} new payload(s), {archive["reused"]} already '
+        f'stored. Ledger row: `{archive["ledger_path"]}`.'
+    ]
+
+
 def _partial_refresh_lines(summary: RunSummary) -> list[str]:
     """Say up front that a refresh was partial, and which part is missing."""
     if not summary.failed_invocations:
@@ -409,6 +532,7 @@ def _commit_description(summary: RunSummary, run_url: str | None) -> str:
         f'- Adapter invocations: {summary.invocations}',
         f'- Raw payloads archived: {summary.raw_payloads} '
         f'({summary.raw_policy})',
+        *_raw_archive_lines(summary),
         *_partial_refresh_lines(summary),
         f'- Every record carries `type_of_addition: cron` and '
         f'`cron_run_date: {summary.run_date}` in '
@@ -454,6 +578,28 @@ def _add_run_arguments(parser: argparse.ArgumentParser) -> None:
         '--repo-id',
         default=publish_module.DEFAULT_REPO_ID,
         help=f'Datastore repo (default: {publish_module.DEFAULT_REPO_ID})',
+    )
+    parser.add_argument(
+        '--raw-repo-id',
+        default=archive_module.DEFAULT_RAW_REPO_ID,
+        help=(
+            'Private dataset that permanently holds raw payloads and the '
+            f'ledger (default: {archive_module.DEFAULT_RAW_REPO_ID})'
+        ),
+    )
+    parser.add_argument(
+        '--no-archive-raw',
+        dest='archive_raw',
+        action='store_false',
+        help=(
+            'Do not store raw payloads permanently. They stay in --work-dir '
+            'only, so use this for local runs, not for the schedule.'
+        ),
+    )
+    parser.add_argument(
+        '--run-id',
+        default='local',
+        help='Identifier for this run, used in the ledger path',
     )
     parser.add_argument(
         '--run-url',
@@ -516,6 +662,9 @@ def main(argv: list[str] | None = None) -> int:
             run_url=args.run_url,
             dry_run=args.dry_run,
             force=args.force,
+            run_id=args.run_id,
+            raw_repo_id=args.raw_repo_id,
+            archive_raw=args.archive_raw,
         )
         return code
     except Exception as error:

--- a/every_eval_ever/cron/runner.py
+++ b/every_eval_ever/cron/runner.py
@@ -57,8 +57,14 @@ EXIT_FAILED = 1
 EXIT_NOTHING_NEW = 3
 
 #: The cron's write-capable Hugging Face credentials, in every spelling the
-#: hub client reads. Never forwarded to adapter subprocesses.
-WRITE_TOKEN_ENV_NAMES = ('HF_TOKEN', 'HUGGING_FACE_HUB_TOKEN', 'HF_HUB_TOKEN')
+#: hub client or the wider ecosystem (e.g. LangChain) reads. Never forwarded
+#: to adapter subprocesses.
+WRITE_TOKEN_ENV_NAMES = (
+    'HF_TOKEN',
+    'HUGGING_FACE_HUB_TOKEN',
+    'HF_HUB_TOKEN',
+    'HUGGINGFACEHUB_API_TOKEN',
+)
 #: A separate read-only token for sources that need authenticated HF access.
 SOURCE_HF_TOKEN_ENV = 'EEE_SOURCE_HF_TOKEN'
 

--- a/every_eval_ever/cron/runner.py
+++ b/every_eval_ever/cron/runner.py
@@ -1,18 +1,23 @@
 """Run one adapter end to end for the daily refresh.
 
-    uv run python -m every_eval_ever.cron run vals_ai --dry-run
+    uv run python -m every_eval_ever.cron run vals_ai \\
+        --work-dir /tmp/cron-vals-ai --dry-run
 
 One invocation handles one adapter, which is what makes the schedule one
 workflow job and one datastore pull request per adapter. The stages are:
 
 1. run the adapter into a scratch tree;
 2. store what it fetched permanently, in the private raw dataset;
-3. stop if the source has not moved since the fingerprint the ledger recorded;
+3. stop if the source has not moved since the last successful publish (the
+   per-adapter state file in the raw dataset, written only after a publish);
 4. stamp every record as cron-produced;
 5. validate through the same CLI the datastore's pull request bot runs;
 6. commit the records to the adapter's pull request.
 
-Exit codes: ``0`` published, ``2`` nothing new to publish, ``1`` failed.
+Exit codes: ``0`` published, ``3`` nothing new to publish, ``1`` failed.
+(``2`` is argparse's usage-error exit and must keep meaning *failure*: the
+workflow treats the nothing-new code as success, and a flag typo that exited
+``2`` would silently disable the whole cron while every job stayed green.)
 """
 
 from __future__ import annotations
@@ -46,7 +51,9 @@ from every_eval_ever.helpers import raw_capture
 
 EXIT_PUBLISHED = 0
 EXIT_FAILED = 1
-EXIT_NOTHING_NEW = 2
+# Not 2: that is argparse's usage-error exit, and the workflow treats this
+# code as success.
+EXIT_NOTHING_NEW = 3
 
 _logger = logging.getLogger('every_eval_ever.cron')
 
@@ -115,12 +122,6 @@ class AdapterOutcome:
     @property
     def failed(self) -> list[Invocation]:
         return [item for item in self.invocations if not item.ok]
-
-    @property
-    def all_failed(self) -> bool:
-        return bool(self.invocations) and not any(
-            item.ok for item in self.invocations
-        )
 
 
 def run_adapter(
@@ -230,24 +231,37 @@ def _previous_fingerprint(
     *,
     fingerprint_path: Path | None,
     raw_repo_id: str,
-    consult_ledger: bool,
+    consult_state: bool,
     token: str | None,
 ) -> str | None:
     """Return the fingerprint to compare this run against.
 
     A local ``--fingerprint`` file wins when it has a value, which is what makes
-    a local run reproducible. Otherwise the raw dataset's ledger is the durable
-    memory: it survives the build cache, so an adapter cannot forget last night's
-    state and republish its whole set.
+    a local run reproducible. Otherwise the raw dataset's per-adapter state file
+    is the durable memory of the last *successful publish* — deliberately not
+    the ledger, which this run has already written and would only hand back its
+    own fingerprint.
+
+    A previous run recorded as partial returns ``None``: some of the source
+    failed to convert that day, so the next run must publish even if the source
+    has not moved, or the records that failed would never reach the datastore.
     """
     stored = read_fingerprint(fingerprint_path) if fingerprint_path else None
     if stored:
         return stored
-    if not consult_ledger:
+    if not consult_state:
         return None
-    return archive_module.last_gating_fingerprint(
-        adapter, repo_id=raw_repo_id, token=token
-    )
+    state = archive_module.read_state(adapter, repo_id=raw_repo_id, token=token)
+    if not state:
+        return None
+    if state.get('partial'):
+        _logger.info(
+            '%s: previous publish was partial; publishing regardless of the '
+            'fingerprint so the missing records get another attempt',
+            adapter,
+        )
+        return None
+    return state.get('gating_fingerprint')
 
 
 def _archive_raw(
@@ -325,7 +339,7 @@ def refresh(
     run_url: str | None,
     dry_run: bool,
     force: bool,
-    run_id: str = 'local',
+    run_id: str | None = None,
     raw_repo_id: str = archive_module.DEFAULT_RAW_REPO_ID,
     archive_raw: bool = True,
     environment: dict[str, str] | None = None,
@@ -333,6 +347,12 @@ def refresh(
     """Refresh one adapter. Returns its exit code and summary."""
     environment = dict(os.environ if environment is None else environment)
     adapter = get_adapter(name)
+    if run_id is None:
+        run_id = datetime.now(timezone.utc).strftime('local-%H%M%S')
+    # The adapter runs with the scratch tree as its cwd, so every path handed
+    # to it must already be absolute — a relative raw_dir would resolve inside
+    # the scratch tree and the runner would read an empty manifest.
+    work_dir = work_dir.resolve()
     run_date = utc_run_date()
     summary = RunSummary(
         adapter=adapter.name,
@@ -458,7 +478,7 @@ def refresh(
         adapter.name,
         fingerprint_path=fingerprint_path,
         raw_repo_id=raw_repo_id,
-        consult_ledger=archive_raw and not dry_run,
+        consult_state=archive_raw and not dry_run,
         token=environment.get('HF_TOKEN'),
     )
     summary.previous_fingerprint = previous
@@ -513,8 +533,35 @@ def refresh(
         f'{result.files} file(s) in {result.commits} commit(s) to '
         f'{result.pr_url}'
     )
+    # Only now, after the datastore has the records, is the fingerprint safe to
+    # persist: recording it any earlier would make a failed publish look
+    # 'unchanged' tomorrow and silently withhold the records forever.
     if fingerprint_path and current:
         write_fingerprint(fingerprint_path, current)
+    if archive_raw and current:
+        try:
+            archive_module.write_state(
+                adapter.name,
+                {
+                    'gating_fingerprint': current,
+                    'fingerprint_source': summary.fingerprint_source,
+                    'run_date': run_date,
+                    'run_id': run_id,
+                    'run_url': run_url,
+                    'partial': bool(summary.failed_invocations),
+                    'pr_number': result.pr_number,
+                    'pr_url': result.pr_url,
+                },
+                repo_id=raw_repo_id,
+                token=environment.get('HF_TOKEN'),
+            )
+        except archive_module.ArchiveError as error:
+            # The publish itself succeeded; stale state can only cause a
+            # duplicate publish tomorrow, never a loss. Say so loudly.
+            summary.detail += f' (WARNING: publish state not recorded: {error})'
+            _logger.error(
+                '%s: %s; tomorrow may republish this set', adapter.name, error
+            )
     summary.write(summary_path)
     _logger.info('%s: %s', adapter.name, summary.detail)
     return EXIT_PUBLISHED, summary
@@ -626,12 +673,15 @@ def _add_run_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         '--run-id',
-        default='local',
-        help='Identifier for this run, used in the ledger path',
+        default=None,
+        help=(
+            'Identifier for this run, used in the ledger path. Defaults to '
+            'local-<UTC time>, so two local runs on the same day do not share '
+            'a ledger file.'
+        ),
     )
     parser.add_argument(
         '--run-url',
-        default=os.environ.get('EEE_CRON_RUN_URL'),
         help='Workflow run URL recorded on each record and in the commit',
     )
     parser.add_argument(

--- a/every_eval_ever/cron/runner.py
+++ b/every_eval_ever/cron/runner.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from every_eval_ever.cron import archive as archive_module
+from every_eval_ever.cron import preflight as preflight_module
 from every_eval_ever.cron import publish as publish_module
 from every_eval_ever.cron.fingerprint import (
     output_fingerprint,
@@ -629,6 +630,27 @@ def main(argv: list[str] | None = None) -> int:
     subcommands.add_parser(
         'list', help='Print the adapters the schedule would run, as JSON'
     )
+    preflight_parser = subcommands.add_parser(
+        'preflight',
+        help='Check credentials and destinations before refreshing anything',
+    )
+    preflight_parser.add_argument(
+        '--repo-id', default=publish_module.DEFAULT_REPO_ID
+    )
+    preflight_parser.add_argument(
+        '--raw-repo-id', default=archive_module.DEFAULT_RAW_REPO_ID
+    )
+    preflight_parser.add_argument(
+        '--no-create-raw',
+        dest='create_raw',
+        action='store_false',
+        help='Report a missing raw dataset instead of creating it',
+    )
+    preflight_parser.add_argument(
+        '--markdown',
+        type=Path,
+        help='Append a checklist here as well (e.g. $GITHUB_STEP_SUMMARY)',
+    )
 
     args = parser.parse_args(argv)
     logging.basicConfig(
@@ -650,6 +672,18 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
         return 0
+
+    if args.command == 'preflight':
+        checks = preflight_module.run_preflight(
+            environment=dict(os.environ),
+            repo_id=args.repo_id,
+            raw_repo_id=args.raw_repo_id,
+            create_raw=args.create_raw,
+        )
+        print(preflight_module.render(checks))
+        if args.markdown:
+            preflight_module.write_markdown(checks, args.markdown)
+        return EXIT_FAILED if preflight_module.failed(checks) else 0
 
     summary_path = args.summary or (args.work_dir / 'summary.json')
     try:

--- a/every_eval_ever/cron/runner.py
+++ b/every_eval_ever/cron/runner.py
@@ -23,6 +23,7 @@ workflow treats the nothing-new code as success, and a flag typo that exited
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
 import os
@@ -76,6 +77,8 @@ class RunSummary:
     #: Payloads fetched but not stored, e.g. over the capture ceiling. They are
     #: still recorded in the ledger so the gap is visible rather than silent.
     raw_skipped: int = 0
+    #: Source URLs whose capture failed; fatal for a declared-capture adapter.
+    capture_errors: list[str] = field(default_factory=list)
     raw_policy: str = ''
     raw_archive: dict[str, object] = field(default_factory=dict)
     raw_fingerprint: str | None = None
@@ -226,42 +229,70 @@ def collections_in(data_root: Path) -> list[str]:
     return sorted(entry.name for entry in data_root.iterdir() if entry.is_dir())
 
 
-def _previous_fingerprint(
+def failure_identity(failed_invocations: list[dict[str, object]]) -> str | None:
+    """Digest which invocations failed and how, order-independently.
+
+    Lets a *persistently* partial run be recognised: identical output plus an
+    identical failure set means republishing would only duplicate the records
+    that already made it in, while the failed ones would fail again.
+    """
+    if not failed_invocations:
+        return None
+    lines = sorted(
+        f'{item["arguments"]} {item["returncode"]}'
+        for item in failed_invocations
+    )
+    return hashlib.sha256('\n'.join(lines).encode('utf-8')).hexdigest()
+
+
+def _previous_state(
     adapter: str,
     *,
     fingerprint_path: Path | None,
     raw_repo_id: str,
     consult_state: bool,
     token: str | None,
-) -> str | None:
-    """Return the fingerprint to compare this run against.
+) -> dict[str, object] | None:
+    """Return what the last successful publish recorded, or ``None``.
 
     A local ``--fingerprint`` file wins when it has a value, which is what makes
     a local run reproducible. Otherwise the raw dataset's per-adapter state file
     is the durable memory of the last *successful publish* — deliberately not
     the ledger, which this run has already written and would only hand back its
     own fingerprint.
-
-    A previous run recorded as partial returns ``None``: some of the source
-    failed to convert that day, so the next run must publish even if the source
-    has not moved, or the records that failed would never reach the datastore.
     """
     stored = read_fingerprint(fingerprint_path) if fingerprint_path else None
     if stored:
-        return stored
+        return {'gating_fingerprint': stored, 'partial': False}
     if not consult_state:
         return None
-    state = archive_module.read_state(adapter, repo_id=raw_repo_id, token=token)
-    if not state:
-        return None
-    if state.get('partial'):
-        _logger.info(
-            '%s: previous publish was partial; publishing regardless of the '
-            'fingerprint so the missing records get another attempt',
-            adapter,
-        )
-        return None
-    return state.get('gating_fingerprint')
+    return archive_module.read_state(adapter, repo_id=raw_repo_id, token=token)
+
+
+def _unchanged_since(
+    previous: dict[str, object] | None,
+    *,
+    current: str | None,
+    current_failures: str | None,
+) -> bool:
+    """Decide whether this run repeats what the last publish already sent.
+
+    A non-partial previous publish is repeated when the fingerprint matches. A
+    *partial* one is repeated only when the failure identity also matches: the
+    same records converted and the same invocations failed the same way, so
+    republishing would duplicate the successes without recovering anything.
+    Any change on either side — the source moved, a failure recovered, a new
+    failure appeared — publishes.
+    """
+    if not previous or not current:
+        return False
+    if current != previous.get('gating_fingerprint'):
+        return False
+    if not previous.get('partial'):
+        return True
+    return current_failures is not None and current_failures == previous.get(
+        'failure_identity'
+    )
 
 
 def _archive_raw(
@@ -388,30 +419,24 @@ def refresh(
 
     raw_capture.index_unlisted_payloads(raw_dir)
     manifest = raw_capture.read_manifest(raw_dir)
+    errors = raw_capture.capture_errors(raw_dir)
     stored = [entry for entry in manifest if entry.get('file')]
     summary.raw_payloads = len(stored)
     summary.raw_bytes = sum(entry.get('bytes') or 0 for entry in stored)
     # Fetched but deliberately not stored, e.g. over the capture ceiling. These
     # still belong in the ledger, so they must not read as "nothing captured".
-    summary.raw_skipped = len(manifest) - len(stored)
+    summary.raw_skipped = len(manifest) - len(stored) - len(errors)
+    summary.capture_errors = [entry.get('url') or '?' for entry in errors]
     # Only verbatim wire captures can say whether the source moved; a dump an
     # adapter wrote itself is archived but may carry its own fetch timestamp.
     summary.raw_fingerprint = raw_capture.fingerprint(
         raw_dir, verbatim_only=True
     )
 
-    if (
-        adapter.raw_policy
-        in {RawPolicy.VIA_FETCH_HELPERS, RawPolicy.VIA_ADAPTER_FLAG}
-        and not manifest
-    ):
-        # Declared as archived but nothing was captured at all: report it rather
-        # than let the run look like it saved raw data.
-        _logger.warning(
-            '%s declares raw policy %s but captured no payloads',
-            adapter.name,
-            adapter.raw_policy.value,
-        )
+    declares_capture = adapter.raw_policy in {
+        RawPolicy.VIA_FETCH_HELPERS,
+        RawPolicy.VIA_ADAPTER_FLAG,
+    }
     if summary.raw_skipped:
         _logger.warning(
             '%s fetched %d payload(s) that were not stored; the ledger records '
@@ -422,6 +447,31 @@ def refresh(
 
     summary.records = len(list(data_root.glob('*/*/*/*.json')))
     summary.collections = collections_in(data_root)
+
+    if summary.records and declares_capture:
+        # Records without their source bytes archived must not be published:
+        # a swallowed capture exception, or an adapter that fetched without
+        # its declared capture route, would otherwise erode provenance one
+        # quiet day at a time. Deliberate ceiling skips are not errors.
+        problems = []
+        if summary.capture_errors:
+            problems.append(
+                f'{len(summary.capture_errors)} capture failure(s): '
+                + ', '.join(summary.capture_errors[:5])
+            )
+        if not manifest:
+            problems.append(
+                f'raw policy {adapter.raw_policy.value} captured nothing'
+            )
+        if problems:
+            summary.status = 'failed'
+            summary.detail = (
+                'records were produced but their raw source was not '
+                'archived (' + '; '.join(problems) + '); nothing published'
+            )
+            summary.write(summary_path)
+            _logger.error('%s: %s', adapter.name, summary.detail)
+            return EXIT_FAILED, summary
 
     # Computed before stamping deliberately: the digest strips the cron stamp,
     # so the value is the same either side of it, and archiving it here means
@@ -474,20 +524,31 @@ def refresh(
     )
     summary.unknown_inferred_fields = stamped.unknown_inferred
 
-    previous = _previous_fingerprint(
+    previous = _previous_state(
         adapter.name,
         fingerprint_path=fingerprint_path,
         raw_repo_id=raw_repo_id,
         consult_state=archive_raw and not dry_run,
         token=environment.get('HF_TOKEN'),
     )
-    summary.previous_fingerprint = previous
+    summary.previous_fingerprint = (
+        previous.get('gating_fingerprint') if previous else None
+    )
+    current_failures = failure_identity(summary.failed_invocations)
 
-    if previous and current == previous and not force:
+    if not force and _unchanged_since(
+        previous, current=current, current_failures=current_failures
+    ):
         summary.status = 'unchanged'
         summary.detail = (
             f'{summary.fingerprint_source} fingerprint matches the previous '
-            'run; nothing published'
+            'publish'
+            + (
+                ' (including its failure set)'
+                if previous.get('partial')
+                else ''
+            )
+            + '; nothing published'
         )
         summary.write(summary_path)
         _logger.info('%s: %s', adapter.name, summary.detail)
@@ -549,6 +610,7 @@ def refresh(
                     'run_id': run_id,
                     'run_url': run_url,
                     'partial': bool(summary.failed_invocations),
+                    'failure_identity': current_failures,
                     'pr_number': result.pr_number,
                     'pr_url': result.pr_url,
                 },

--- a/every_eval_ever/cron/runner.py
+++ b/every_eval_ever/cron/runner.py
@@ -66,6 +66,9 @@ class RunSummary:
     records: int = 0
     raw_payloads: int = 0
     raw_bytes: int = 0
+    #: Payloads fetched but not stored, e.g. over the capture ceiling. They are
+    #: still recorded in the ledger so the gap is visible rather than silent.
+    raw_skipped: int = 0
     raw_policy: str = ''
     raw_archive: dict[str, object] = field(default_factory=dict)
     raw_fingerprint: str | None = None
@@ -251,6 +254,7 @@ def _archive_raw(
     raw_dir: Path,
     *,
     summary: RunSummary,
+    captured: int,
     run_id: str,
     run_url: str | None,
     gating_fingerprint: str | None,
@@ -259,8 +263,13 @@ def _archive_raw(
     dry_run: bool,
     token: str | None,
 ) -> dict[str, object]:
-    """Store this run's raw payloads permanently, or say why it did not."""
-    if not summary.raw_payloads:
+    """Store this run's raw payloads permanently, or say why it did not.
+
+    ``captured`` counts every manifest entry, not just the ones that landed on
+    disk: a payload too large to store still gets a ledger row, so a run that
+    only fetched an oversized payload must still be archived.
+    """
+    if not captured:
         return {
             'status': 'nothing_captured',
             'reason': (
@@ -270,12 +279,17 @@ def _archive_raw(
             ),
         }
     if not archive_raw:
-        return {'status': 'disabled', 'payloads': summary.raw_payloads}
+        return {
+            'status': 'disabled',
+            'payloads': summary.raw_payloads,
+            'skipped_payloads': summary.raw_skipped,
+        }
     if dry_run:
         return {
             'status': 'skipped_dry_run',
             'repo_id': raw_repo_id,
             'payloads': summary.raw_payloads,
+            'skipped_payloads': summary.raw_skipped,
         }
 
     result = archive_module.archive(
@@ -297,6 +311,7 @@ def _archive_raw(
         'uploaded': result.uploaded,
         'reused': result.reused,
         'uploaded_bytes': result.uploaded_bytes,
+        'ledger_rows': len(result.rows),
     }
 
 
@@ -353,8 +368,12 @@ def refresh(
 
     raw_capture.index_unlisted_payloads(raw_dir)
     manifest = raw_capture.read_manifest(raw_dir)
-    summary.raw_payloads = sum(1 for entry in manifest if entry.get('file'))
-    summary.raw_bytes = sum(entry.get('bytes') or 0 for entry in manifest)
+    stored = [entry for entry in manifest if entry.get('file')]
+    summary.raw_payloads = len(stored)
+    summary.raw_bytes = sum(entry.get('bytes') or 0 for entry in stored)
+    # Fetched but deliberately not stored, e.g. over the capture ceiling. These
+    # still belong in the ledger, so they must not read as "nothing captured".
+    summary.raw_skipped = len(manifest) - len(stored)
     # Only verbatim wire captures can say whether the source moved; a dump an
     # adapter wrote itself is archived but may carry its own fetch timestamp.
     summary.raw_fingerprint = raw_capture.fingerprint(
@@ -364,14 +383,21 @@ def refresh(
     if (
         adapter.raw_policy
         in {RawPolicy.VIA_FETCH_HELPERS, RawPolicy.VIA_ADAPTER_FLAG}
-        and not summary.raw_payloads
+        and not manifest
     ):
-        # Declared as archived but nothing landed: report it rather than let the
-        # run look like it saved raw data.
+        # Declared as archived but nothing was captured at all: report it rather
+        # than let the run look like it saved raw data.
         _logger.warning(
-            '%s declares raw policy %s but archived no payloads',
+            '%s declares raw policy %s but captured no payloads',
             adapter.name,
             adapter.raw_policy.value,
+        )
+    if summary.raw_skipped:
+        _logger.warning(
+            '%s fetched %d payload(s) that were not stored; the ledger records '
+            'them but the bytes are gone',
+            adapter.name,
+            summary.raw_skipped,
         )
 
     summary.records = len(list(data_root.glob('*/*/*/*.json')))
@@ -392,6 +418,7 @@ def refresh(
     summary.raw_archive = _archive_raw(
         raw_dir,
         summary=summary,
+        captured=len(manifest),
         run_id=run_id,
         run_url=run_url,
         gating_fingerprint=current,

--- a/every_eval_ever/cron/schedule.py
+++ b/every_eval_ever/cron/schedule.py
@@ -226,11 +226,6 @@ EXCLUDED_ADAPTERS: dict[str, str] = {
 _BY_NAME = {adapter.name: adapter for adapter in CRON_ADAPTERS}
 
 
-def all_adapters() -> tuple[CronAdapter, ...]:
-    """Return every registered adapter, enabled or not."""
-    return CRON_ADAPTERS
-
-
 def get_adapter(name: str) -> CronAdapter:
     """Return the registry entry for ``name``."""
     try:

--- a/every_eval_ever/cron/schedule.py
+++ b/every_eval_ever/cron/schedule.py
@@ -1,0 +1,283 @@
+"""Which adapters the daily refresh may run, and how to run each one.
+
+Adapter CLIs are not uniform: some need a hand-supplied input file, some are
+pinned to a source commit, some fetch several leaderboards one invocation at a
+time. This module records those differences once so the runner and the workflow
+do not each re-derive them, and so adding an adapter to the cron is a data
+change rather than a code change.
+
+Every adapter directory must appear either in :data:`CRON_ADAPTERS` or in
+:data:`EXCLUDED_ADAPTERS` with a reason. ``tests/test_cron_schedule.py``
+enforces that, so a newly added adapter cannot quietly sit outside the cron.
+
+This is the cron's own schedule. It is unrelated to the canonical entity ids in
+the `eval-card-registry <https://github.com/evaleval/eval-card-registry>`_.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+ADAPTERS_PACKAGE = 'every_eval_ever.adapters'
+
+# Placeholder the runner substitutes with the run's raw-capture directory.
+RAW_DIR_PLACEHOLDER = '{raw_dir}'
+
+
+class RawPolicy(str, Enum):
+    """Where a run's raw source data comes from.
+
+    The cron archives payloads it scrapes and deliberately does not re-archive
+    data that upstream already stores immutably.
+    """
+
+    #: Fetched through ``helpers.fetch``, so the shared capture hook archives it.
+    VIA_FETCH_HELPERS = 'via_fetch_helpers'
+    #: Archived by the adapter's own ``--save-raw-*`` flag.
+    VIA_ADAPTER_FLAG = 'via_adapter_flag'
+    #: Already immutable upstream (a HF dataset revision, a git commit).
+    UPSTREAM_VERSIONED = 'upstream_versioned'
+    #: Not archived: the adapter calls an HTTP client directly and has no flag.
+    NOT_CAPTURED = 'not_captured'
+
+
+@dataclass(frozen=True)
+class CronAdapter:
+    """One unit of cron work: one adapter, one datastore pull request."""
+
+    name: str
+    raw_policy: RawPolicy
+    #: One argv tuple per invocation. An adapter that exposes a leaderboard as
+    #: a required choice needs one entry per leaderboard; their records share a
+    #: single pull request because they share an adapter.
+    runs: tuple[tuple[str, ...], ...] = ((),)
+    #: Extra argv appended to every run, with RAW_DIR_PLACEHOLDER substituted.
+    raw_args: tuple[str, ...] = ()
+    #: Environment variables the source requires. A run is skipped, not failed,
+    #: when one is missing, so an unconfigured credential does not read as a
+    #: broken adapter.
+    requires_env: tuple[str, ...] = ()
+    enabled: bool = True
+    notes: str = ''
+
+    @property
+    def module(self) -> str:
+        return f'{ADAPTERS_PACKAGE}.{self.name}.adapter'
+
+    def argv_for(self, run: tuple[str, ...], raw_dir: Path | str) -> list[str]:
+        """Return the full argv for one invocation."""
+        raw_args = [
+            argument.replace(RAW_DIR_PLACEHOLDER, str(raw_dir))
+            for argument in self.raw_args
+        ]
+        return ['-m', self.module, *run, *raw_args]
+
+    def missing_env(self, environment: dict[str, str]) -> list[str]:
+        """Return the required environment variables that are not set."""
+        return [
+            name
+            for name in self.requires_env
+            if not (environment.get(name) or '').strip()
+        ]
+
+
+CRON_ADAPTERS: tuple[CronAdapter, ...] = (
+    CronAdapter(
+        name='artificial_analysis',
+        raw_policy=RawPolicy.VIA_ADAPTER_FLAG,
+        raw_args=(
+            '--save-raw-json',
+            f'{RAW_DIR_PLACEHOLDER}/artificial-analysis.json',
+        ),
+        requires_env=('ARTIFICIAL_ANALYSIS_API_KEY',),
+    ),
+    CronAdapter(
+        name='exgentic',
+        raw_policy=RawPolicy.UPSTREAM_VERSIONED,
+        runs=(('--from-hf',),),
+        notes='Reads a HuggingFace dataset; upstream keeps the revisions.',
+    ),
+    CronAdapter(
+        name='global_mmlu_lite',
+        raw_policy=RawPolicy.VIA_FETCH_HELPERS,
+    ),
+    CronAdapter(
+        name='hal',
+        raw_policy=RawPolicy.NOT_CAPTURED,
+        notes=(
+            'Calls requests directly and exposes no raw-dump flag, so this '
+            'run is gated on its output fingerprint rather than raw data.'
+        ),
+    ),
+    CronAdapter(
+        name='helm',
+        raw_policy=RawPolicy.VIA_FETCH_HELPERS,
+        runs=(
+            ('--leaderboard_name', 'HELM_Capabilities'),
+            ('--leaderboard_name', 'HELM_Lite'),
+            ('--leaderboard_name', 'HELM_Classic'),
+            ('--leaderboard_name', 'HELM_Instruct'),
+            ('--leaderboard_name', 'HELM_MMLU'),
+        ),
+        notes='One invocation per leaderboard; all five share one PR.',
+    ),
+    CronAdapter(
+        name='hfopenllm_v2',
+        raw_policy=RawPolicy.VIA_FETCH_HELPERS,
+        enabled=False,
+        notes=(
+            'Emits one record per leaderboard model (>4500 per run). Until '
+            'record-level de-duplication exists, a daily refresh would add '
+            'thousands of near-duplicate files to its PR every time the '
+            'leaderboard moves. Enable this entry once de-duplication lands.'
+        ),
+    ),
+    CronAdapter(
+        name='hle',
+        raw_policy=RawPolicy.VIA_ADAPTER_FLAG,
+        raw_args=('--save-raw-json', f'{RAW_DIR_PLACEHOLDER}/hle.json'),
+    ),
+    CronAdapter(
+        name='lexam',
+        raw_policy=RawPolicy.NOT_CAPTURED,
+        notes=(
+            'Scrapes HTML with requests directly and exposes --input-html but '
+            'no --save-raw-html, so nothing is archived for it yet.'
+        ),
+    ),
+    CronAdapter(
+        name='llm_stats',
+        raw_policy=RawPolicy.VIA_ADAPTER_FLAG,
+        raw_args=('--save-raw-json', f'{RAW_DIR_PLACEHOLDER}/llm-stats.json'),
+        requires_env=('LLM_STATS_API_KEY',),
+    ),
+    CronAdapter(
+        name='mmlu_pro',
+        raw_policy=RawPolicy.VIA_ADAPTER_FLAG,
+        raw_args=('--save-raw-csv', f'{RAW_DIR_PLACEHOLDER}/mmlu-pro.csv'),
+    ),
+    CronAdapter(
+        name='mt_bench',
+        raw_policy=RawPolicy.NOT_CAPTURED,
+        notes=(
+            'Streams the judgment JSONL with requests directly and has no '
+            'raw-dump flag. The source is a finished artifact, so the output '
+            'fingerprint should hold steady and skip most days.'
+        ),
+    ),
+    CronAdapter(
+        name='multi_swe_bench',
+        raw_policy=RawPolicy.UPSTREAM_VERSIONED,
+        notes='Clones the upstream experiments repo; git holds the history.',
+    ),
+    CronAdapter(
+        name='openeval',
+        raw_policy=RawPolicy.UPSTREAM_VERSIONED,
+        notes='Downloads from a HuggingFace dataset revision.',
+    ),
+    CronAdapter(
+        name='rewardbench',
+        raw_policy=RawPolicy.VIA_FETCH_HELPERS,
+    ),
+    CronAdapter(
+        name='swe_bench_verified',
+        raw_policy=RawPolicy.UPSTREAM_VERSIONED,
+        notes='Reads the upstream experiments repo and a HF dataset.',
+    ),
+    CronAdapter(
+        name='swe_polybench',
+        raw_policy=RawPolicy.UPSTREAM_VERSIONED,
+        notes='Reads the upstream experiments repo and a HF dataset.',
+    ),
+    CronAdapter(
+        name='terminal_bench_2',
+        raw_policy=RawPolicy.VIA_ADAPTER_FLAG,
+        raw_args=(
+            '--save-raw-html',
+            f'{RAW_DIR_PLACEHOLDER}/terminal-bench-2.html',
+        ),
+    ),
+    CronAdapter(
+        name='vals_ai',
+        raw_policy=RawPolicy.VIA_ADAPTER_FLAG,
+        raw_args=('--save-raw-json', f'{RAW_DIR_PLACEHOLDER}/vals-ai.json'),
+        notes='Saves the normalized payload rather than the raw HTML.',
+    ),
+)
+
+
+#: Adapter directories the cron must not run, and why.
+EXCLUDED_ADAPTERS: dict[str, str] = {
+    'arc_agi': 'Legacy: upstream source is no longer usable for a refresh.',
+    'bfcl': 'Needs a hand-supplied --input-csv; no live fetch.',
+    'cocoabench': 'Needs a hand-supplied --csv; no live fetch.',
+    'livecodebenchpro': 'Legacy: upstream source is no longer usable.',
+    'mercor_eval': 'Legacy: the API currently returns an empty response.',
+    'sciarena': 'Needs a hand-supplied --input-json; no live fetch.',
+    'vectara_hallucination_leaderboard': (
+        'Pinned to SOURCE_COMMIT in code, so a refresh is a code change and a '
+        'daily run could only re-emit identical records.'
+    ),
+}
+
+
+_BY_NAME = {adapter.name: adapter for adapter in CRON_ADAPTERS}
+
+
+def all_adapters() -> tuple[CronAdapter, ...]:
+    """Return every registered adapter, enabled or not."""
+    return CRON_ADAPTERS
+
+
+def get_adapter(name: str) -> CronAdapter:
+    """Return the registry entry for ``name``."""
+    try:
+        return _BY_NAME[name]
+    except KeyError:
+        excluded = EXCLUDED_ADAPTERS.get(name)
+        if excluded:
+            raise KeyError(
+                f'{name!r} is excluded from the cron: {excluded}'
+            ) from None
+        known = ', '.join(sorted(_BY_NAME))
+        raise KeyError(
+            f'unknown cron adapter {name!r}; registered adapters: {known}'
+        ) from None
+
+
+def scheduled_adapters(
+    environment: dict[str, str],
+) -> tuple[list[CronAdapter], list[tuple[CronAdapter, str]]]:
+    """Split the enabled adapters into runnable ones and skipped ones.
+
+    Returns ``(runnable, skipped)`` where each skipped entry carries the reason
+    it was left out, so a caller can report it instead of failing silently.
+    """
+    runnable: list[CronAdapter] = []
+    skipped: list[tuple[CronAdapter, str]] = []
+    for adapter in CRON_ADAPTERS:
+        if not adapter.enabled:
+            skipped.append((adapter, adapter.notes or 'disabled'))
+            continue
+        missing = adapter.missing_env(environment)
+        if missing:
+            skipped.append(
+                (adapter, f'missing environment: {", ".join(missing)}')
+            )
+            continue
+        runnable.append(adapter)
+    return runnable, skipped
+
+
+def adapter_directories() -> set[str]:
+    """Return the adapter package directories present in the checkout."""
+    package_root = Path(__file__).resolve().parent.parent / 'adapters'
+    return {
+        entry.name
+        for entry in package_root.iterdir()
+        if entry.is_dir()
+        and not entry.name.startswith('_')
+        and (entry / 'adapter.py').is_file()
+    }

--- a/every_eval_ever/cron/schedule.py
+++ b/every_eval_ever/cron/schedule.py
@@ -55,10 +55,14 @@ class CronAdapter:
     runs: tuple[tuple[str, ...], ...] = ((),)
     #: Extra argv appended to every run, with RAW_DIR_PLACEHOLDER substituted.
     raw_args: tuple[str, ...] = ()
-    #: Environment variables the source requires. A run is skipped, not failed,
-    #: when one is missing, so an unconfigured credential does not read as a
-    #: broken adapter.
+    #: Environment variables the source requires. An enabled adapter missing
+    #: one fails its run visibly rather than being quietly dropped.
     requires_env: tuple[str, ...] = ()
+    #: True only when the source itself needs an authenticated Hugging Face
+    #: read. The child then receives EEE_SOURCE_HF_TOKEN — a separate,
+    #: least-privilege read token — as HF_TOKEN. The cron's own write-capable
+    #: token is never forwarded to adapter code.
+    source_hf_token: bool = False
     enabled: bool = True
     notes: str = ''
 
@@ -245,24 +249,20 @@ def get_adapter(name: str) -> CronAdapter:
 def scheduled_adapters(
     environment: dict[str, str],
 ) -> tuple[list[CronAdapter], list[tuple[CronAdapter, str]]]:
-    """Split the enabled adapters into runnable ones and skipped ones.
+    """Split the adapters into scheduled ones and quietly skipped ones.
 
-    Returns ``(runnable, skipped)`` where each skipped entry carries the reason
-    it was left out, so a caller can report it instead of failing silently.
+    Every *enabled* adapter is scheduled, credentialed or not: an enabled
+    adapter with a missing credential must fail its own job visibly, not
+    vanish from the matrix behind a green run. Only adapters deliberately
+    declared disabled are skipped quietly, with their reason.
     """
-    runnable: list[CronAdapter] = []
-    skipped: list[tuple[CronAdapter, str]] = []
-    for adapter in CRON_ADAPTERS:
-        if not adapter.enabled:
-            skipped.append((adapter, adapter.notes or 'disabled'))
-            continue
-        missing = adapter.missing_env(environment)
-        if missing:
-            skipped.append(
-                (adapter, f'missing environment: {", ".join(missing)}')
-            )
-            continue
-        runnable.append(adapter)
+    del environment  # Credentials are checked (and failed) per run.
+    runnable = [adapter for adapter in CRON_ADAPTERS if adapter.enabled]
+    skipped = [
+        (adapter, adapter.notes or 'disabled')
+        for adapter in CRON_ADAPTERS
+        if not adapter.enabled
+    ]
     return runnable, skipped
 
 

--- a/every_eval_ever/cron/stamp.py
+++ b/every_eval_ever/cron/stamp.py
@@ -1,0 +1,197 @@
+"""Mark generated records as cron-produced, before they are published.
+
+The cron stamps records after the adapter wrote them rather than asking each
+adapter to do it, so an adapter behaves identically whether a person or the
+schedule invoked it. Both facts a later fix needs — that a record arrived
+automatically, and when — live in ``source_metadata.additional_details``, which
+the schema defines as a string map.
+
+The stamp never overwrites what an adapter reported.
+
+``model_info.additional_details.deployment_type`` and ``model_availability``
+are inferred axes a leaderboard almost never states. ``ModelInfo`` already
+defaults both to ``unknown`` (see ``every_eval_ever.post_codegen``), so the
+cron does not need to fill them — it names the ones that came out ``unknown``
+under :data:`UNKNOWN_FIELDS_KEY`, which is what lets a later pass find the
+records still needing a real value.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from every_eval_ever.eval_types import EvaluationLog
+
+TYPE_OF_ADDITION_KEY = 'type_of_addition'
+CRON_ADDITION_TYPE = 'cron'
+RUN_DATE_KEY = 'cron_run_date'
+ADAPTER_KEY = 'cron_adapter'
+RUN_URL_KEY = 'cron_run_url'
+UNKNOWN_FIELDS_KEY = 'cron_unknown_inferred_fields'
+
+UNKNOWN = 'unknown'
+#: Axes that are almost never available to an adapter directly. Both are
+#: required by the schema and both admit 'unknown'.
+INFERRED_MODEL_FIELDS = ('deployment_type', 'model_availability')
+
+
+class StampError(Exception):
+    """Raised when a record cannot be stamped."""
+
+
+class StampConflict(StampError):
+    """Raised when a record already carries a different addition type."""
+
+
+@dataclass
+class StampSummary:
+    """What stamping did across a set of files."""
+
+    stamped: int = 0
+    #: How many records came out ``unknown`` on each inferred axis.
+    unknown_inferred: dict[str, int] = field(default_factory=dict)
+    paths: list[Path] = field(default_factory=list)
+
+    def record(self, path: Path, unknown: list[str]) -> None:
+        self.stamped += 1
+        self.paths.append(path)
+        for name in unknown:
+            self.unknown_inferred[name] = self.unknown_inferred.get(name, 0) + 1
+
+
+def stamp_payload(
+    payload: dict[str, Any],
+    *,
+    adapter: str,
+    run_date: str,
+    run_url: str | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Return ``payload`` stamped, plus the inferred axes that are ``unknown``.
+
+    Raises:
+        StampConflict: if the record already declares a different
+            ``type_of_addition``, which would mean the adapter has its own
+            meaning for the key.
+    """
+    stamped = json.loads(json.dumps(payload))
+    source_metadata = stamped.setdefault('source_metadata', {})
+    details = source_metadata.setdefault('additional_details', {})
+
+    existing = details.get(TYPE_OF_ADDITION_KEY)
+    if existing is not None and existing != CRON_ADDITION_TYPE:
+        raise StampConflict(
+            f'record declares {TYPE_OF_ADDITION_KEY}={existing!r}; refusing to '
+            f'relabel it as {CRON_ADDITION_TYPE!r}'
+        )
+
+    details[TYPE_OF_ADDITION_KEY] = CRON_ADDITION_TYPE
+    details[RUN_DATE_KEY] = run_date
+    details[ADAPTER_KEY] = adapter
+    if run_url:
+        details[RUN_URL_KEY] = run_url
+
+    unknown = _note_unknown_inferred_fields(stamped)
+    if unknown:
+        details[UNKNOWN_FIELDS_KEY] = ','.join(unknown)
+
+    return stamped, unknown
+
+
+def _note_unknown_inferred_fields(payload: dict[str, Any]) -> list[str]:
+    """Return the inferred axes that are ``unknown``, filling any that are absent.
+
+    ``ModelInfo`` normally fills these before a record is ever written; the
+    ``setdefault`` here only matters for a record that reached the cron without
+    passing through the model.
+    """
+    model_info = payload.setdefault('model_info', {})
+    details = model_info.setdefault('additional_details', {})
+    unknown = []
+    for name in INFERRED_MODEL_FIELDS:
+        if not details.get(name):
+            details[name] = UNKNOWN
+        if details[name] == UNKNOWN:
+            unknown.append(name)
+    return unknown
+
+
+def _serialize(payload: dict[str, Any]) -> str:
+    """Serialize exactly as ``helpers.io`` does, so the stamp is the only diff."""
+    validated = EvaluationLog.model_validate(payload)
+    return (
+        json.dumps(
+            validated.model_dump(mode='json', exclude_none=True),
+            indent=2,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+        + '\n'
+    )
+
+
+def stamp_file(
+    path: str | Path,
+    *,
+    adapter: str,
+    run_date: str,
+    run_url: str | None = None,
+) -> list[str]:
+    """Stamp one aggregate record in place, returning its ``unknown`` axes."""
+    path = Path(path)
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    stamped, unknown = stamp_payload(
+        payload,
+        adapter=adapter,
+        run_date=run_date,
+        run_url=run_url,
+    )
+    try:
+        text = _serialize(stamped)
+    except ValidationError as error:
+        # Name the file: the useful fact is which record the adapter got wrong.
+        raise StampError(
+            f'{path} is not a valid EvaluationLog, so it cannot be stamped or '
+            f'published: {error}'
+        ) from error
+    path.write_text(text, encoding='utf-8')
+    return unknown
+
+
+def aggregate_records(root: str | Path) -> list[Path]:
+    """Return the aggregate records under a ``data/`` tree, sample files aside.
+
+    Instance-level ``*_samples.jsonl`` companions carry no ``source_metadata``;
+    they are reachable from the aggregate that references them, which is what
+    the stamp goes on.
+    """
+    data_root = Path(root)
+    return sorted(
+        path
+        for path in data_root.glob('*/*/*/*.json')
+        if not path.name.endswith('_samples.json')
+    )
+
+
+def stamp_tree(
+    root: str | Path,
+    *,
+    adapter: str,
+    run_date: str,
+    run_url: str | None = None,
+) -> StampSummary:
+    """Stamp every aggregate record under a ``data/`` tree."""
+    summary = StampSummary()
+    for path in aggregate_records(root):
+        unknown = stamp_file(
+            path,
+            adapter=adapter,
+            run_date=run_date,
+            run_url=run_url,
+        )
+        summary.record(path, unknown)
+    return summary

--- a/every_eval_ever/cron/stamp.py
+++ b/every_eval_ever/cron/stamp.py
@@ -34,6 +34,9 @@ ADAPTER_KEY = 'cron_adapter'
 RUN_URL_KEY = 'cron_run_url'
 UNKNOWN_FIELDS_KEY = 'cron_unknown_inferred_fields'
 
+#: Stem suffix that marks an instance-level companion, e.g. `<uuid>_samples`.
+SAMPLES_SUFFIX = '_samples'
+
 UNKNOWN = 'unknown'
 #: Axes that are almost never available to an adapter directly. Both are
 #: required by the schema and both admit 'unknown'.
@@ -168,12 +171,16 @@ def aggregate_records(root: str | Path) -> list[Path]:
     Instance-level ``*_samples.jsonl`` companions carry no ``source_metadata``;
     they are reachable from the aggregate that references them, which is what
     the stamp goes on.
+
+    A companion is recognised by its ``_samples`` stem rather than its full
+    filename, so widening the glob to ``*.json*`` — the pattern the validator
+    uses, and an easy edit to make here — cannot start pulling companions in.
     """
     data_root = Path(root)
     return sorted(
         path
         for path in data_root.glob('*/*/*/*.json')
-        if not path.name.endswith('_samples.json')
+        if path.suffix == '.json' and not path.stem.endswith(SAMPLES_SUFFIX)
     )
 
 

--- a/every_eval_ever/cron/stamp.py
+++ b/every_eval_ever/cron/stamp.py
@@ -26,6 +26,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from every_eval_ever.eval_types import EvaluationLog
+from every_eval_ever.helpers.io import serialize_evaluation_log
 
 TYPE_OF_ADDITION_KEY = 'type_of_addition'
 CRON_ADDITION_TYPE = 'cron'
@@ -124,17 +125,8 @@ def _note_unknown_inferred_fields(payload: dict[str, Any]) -> list[str]:
 
 
 def _serialize(payload: dict[str, Any]) -> str:
-    """Serialize exactly as ``helpers.io`` does, so the stamp is the only diff."""
-    validated = EvaluationLog.model_validate(payload)
-    return (
-        json.dumps(
-            validated.model_dump(mode='json', exclude_none=True),
-            indent=2,
-            ensure_ascii=False,
-            allow_nan=False,
-        )
-        + '\n'
-    )
+    """Serialize through the datastore's one serializer; the stamp is the only diff."""
+    return serialize_evaluation_log(EvaluationLog.model_validate(payload))
 
 
 def stamp_file(

--- a/every_eval_ever/helpers/fetch.py
+++ b/every_eval_ever/helpers/fetch.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from every_eval_ever.helpers.raw_capture import capture_response
+
 DEFAULT_TIMEOUT = 60  # seconds
 
 
@@ -37,6 +39,12 @@ def fetch_json(
     try:
         response = requests.get(url, timeout=timeout, headers=headers)
         response.raise_for_status()
+        # Capture before parsing, so a malformed body is still archived.
+        capture_response(
+            url,
+            response.content,
+            content_type=response.headers.get('Content-Type'),
+        )
         return response.json()
     except requests.exceptions.RequestException as e:
         raise FetchError(f'Failed to fetch {url}: {e}') from e
@@ -68,6 +76,11 @@ def fetch_csv(
             url, timeout=timeout, headers=headers, allow_redirects=True
         )
         response.raise_for_status()
+        capture_response(
+            url,
+            response.content,
+            content_type=response.headers.get('Content-Type'),
+        )
         reader = csv.DictReader(io.StringIO(response.text))
         return list(reader)
     except requests.exceptions.RequestException as e:

--- a/every_eval_ever/helpers/io.py
+++ b/every_eval_ever/helpers/io.py
@@ -523,6 +523,25 @@ def save_evaluation_log(
     )[0]
 
 
+def serialize_evaluation_log(log: 'EvaluationLog') -> str:
+    """Serialize a validated log exactly as the datastore stores it.
+
+    The one definition of the on-disk record format. Anything that rewrites a
+    record in place (the cron's provenance stamp, for example) must use this
+    same serializer, or its rewrite touches every byte of the file instead of
+    only the fields it changed.
+    """
+    return (
+        json.dumps(
+            log.model_dump(mode='json', exclude_none=True),
+            indent=2,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+        + '\n'
+    )
+
+
 def _prepare_evaluation_logs(
     outputs: Iterable[EvaluationLogOutput],
 ) -> list[_PreparedEvaluationLog]:
@@ -557,14 +576,10 @@ def _prepare_evaluation_logs(
             raise FileExistsError(f'refusing to overwrite output file {path}')
         paths.add(path)
 
-        json_text = json.dumps(
-            validated.model_dump(mode='json', exclude_none=True),
-            indent=2,
-            ensure_ascii=False,
-            allow_nan=False,
-        )
         prepared.append(
-            _PreparedEvaluationLog(path=path, json_text=json_text + '\n')
+            _PreparedEvaluationLog(
+                path=path, json_text=serialize_evaluation_log(validated)
+            )
         )
     return prepared
 

--- a/every_eval_ever/helpers/raw_capture.py
+++ b/every_eval_ever/helpers/raw_capture.py
@@ -48,10 +48,6 @@ _EXTENSION_BY_CONTENT_TYPE = {
 
 _logger = logging.getLogger(__name__)
 _lock = threading.Lock()
-# (capture directory, filename) -> sha256 already recorded by this process.
-# Keyed by directory too: one process may capture into more than one directory,
-# and the same payload name in a different directory is a different payload.
-_recorded: dict[tuple[str, str], str] = {}
 
 
 def capture_dir() -> Path | None:
@@ -77,14 +73,22 @@ def max_capture_bytes() -> int:
     return parsed if parsed > 0 else DEFAULT_MAX_BYTES
 
 
-def payload_filename(url: str, content_type: str | None = None) -> str:
-    """Return a stable, filesystem-safe capture filename for ``url``.
+def payload_filename(
+    url: str,
+    content_type: str | None = None,
+    checksum: str | None = None,
+) -> str:
+    """Return a stable, filesystem-safe capture filename for a payload.
 
-    The name is a function of the URL alone, so re-fetching the same URL
-    overwrites its own payload instead of accumulating copies. The leading
-    digest keeps two URLs that share a last path segment apart.
+    The name is a function of the URL *and* the body: re-fetching identical
+    bytes maps to the same file (idempotent), while the same URL serving
+    different bytes gets a second file rather than overwriting the first —
+    each manifest row must keep pointing at exactly the bytes it hashed, or
+    the content-addressed archive would store one body under another's hash.
     """
     digest = hashlib.sha256(url.encode('utf-8')).hexdigest()[:12]
+    if checksum:
+        digest = f'{digest}-{checksum[:12]}'
     parsed = urlparse(url)
     stem, suffix = _split_last_segment(parsed.path)
     label = _UNSAFE_NAME.sub('-', stem or parsed.netloc).strip('-')
@@ -135,8 +139,8 @@ def _capture(
     body: bytes,
     content_type: str | None,
 ) -> Path | None:
-    filename = payload_filename(url, content_type)
     checksum = hashlib.sha256(body).hexdigest()
+    filename = payload_filename(url, content_type, checksum)
     ceiling = max_capture_bytes()
     entry: dict[str, Any] = {
         'url': url,
@@ -178,12 +182,19 @@ def _record(
     checksum: str,
     entry: dict[str, Any],
 ) -> None:
-    """Append ``entry`` to the manifest unless it is already recorded."""
-    key = (str(directory), filename)
+    """Append ``entry`` to the manifest unless it is already recorded.
+
+    Deduplication reads the manifest itself rather than any in-process memo, so
+    the record always agrees with the directory it describes — a cleared and
+    reused capture directory starts from a genuinely empty manifest.
+    """
     with _lock:
-        if _recorded.get(key) == checksum:
+        already = any(
+            item.get('file') == filename and item.get('sha256') == checksum
+            for item in read_manifest(directory)
+        )
+        if already:
             return
-        _recorded[key] = checksum
         directory.mkdir(parents=True, exist_ok=True)
         with (directory / MANIFEST_NAME).open('a', encoding='utf-8') as handle:
             handle.write(json.dumps(entry, ensure_ascii=False) + '\n')
@@ -224,16 +235,17 @@ def index_unlisted_payloads(directory: str | Path) -> list[str]:
             continue
         if path.name.endswith('.partial'):
             continue
-        body = path.read_bytes()
+        with path.open('rb') as handle:
+            checksum = hashlib.file_digest(handle, 'sha256').hexdigest()
         _record(
             root,
             path.name,
-            hashlib.sha256(body).hexdigest(),
+            checksum,
             {
                 'url': None,
                 'file': path.name,
-                'bytes': len(body),
-                'sha256': hashlib.sha256(body).hexdigest(),
+                'bytes': path.stat().st_size,
+                'sha256': checksum,
                 'source': ADAPTER_FLAG_SOURCE,
             },
         )
@@ -270,9 +282,3 @@ def fingerprint(
     if not lines:
         return None
     return hashlib.sha256('\n'.join(lines).encode('utf-8')).hexdigest()
-
-
-def reset_recorded_state() -> None:
-    """Forget which payloads this process already recorded (tests only)."""
-    with _lock:
-        _recorded.clear()

--- a/every_eval_ever/helpers/raw_capture.py
+++ b/every_eval_ever/helpers/raw_capture.py
@@ -128,8 +128,27 @@ def capture_response(
         return None
     try:
         return _capture(directory, url, body, content_type)
-    except Exception as error:  # pragma: no cover - defensive
+    except Exception as error:
+        # The fetch still returns, but the failure must not evaporate with the
+        # subprocess: a manifest error row is the durable signal the runner
+        # uses to refuse publication without archived source bytes.
         _logger.warning('could not capture raw payload for %s: %s', url, error)
+        try:
+            _record(
+                directory,
+                f'error:{url}',
+                'capture-failed',
+                {
+                    'url': url,
+                    'file': None,
+                    'sha256': None,
+                    'content_type': content_type,
+                    'source': VERBATIM_SOURCE,
+                    'error': f'{type(error).__name__}: {error}',
+                },
+            )
+        except Exception:  # pragma: no cover - the log line above remains
+            pass
         return None
 
 
@@ -198,6 +217,11 @@ def _record(
         directory.mkdir(parents=True, exist_ok=True)
         with (directory / MANIFEST_NAME).open('a', encoding='utf-8') as handle:
             handle.write(json.dumps(entry, ensure_ascii=False) + '\n')
+
+
+def capture_errors(directory: str | Path) -> list[dict[str, Any]]:
+    """Return the manifest rows recording a failed capture."""
+    return [entry for entry in read_manifest(directory) if entry.get('error')]
 
 
 def read_manifest(directory: str | Path) -> list[dict[str, Any]]:

--- a/every_eval_ever/helpers/raw_capture.py
+++ b/every_eval_ever/helpers/raw_capture.py
@@ -1,0 +1,278 @@
+"""Opt-in on-disk capture of raw source payloads.
+
+Adapters fetch through :mod:`every_eval_ever.helpers.fetch`. When
+``EEE_RAW_CAPTURE_DIR`` names a directory, every response body those helpers
+receive is also written there verbatim, next to a ``manifest.jsonl`` recording
+the URL, byte count, and SHA-256 of each payload. Nothing is captured when the
+variable is unset, so interactive adapter runs are unaffected.
+
+Capture is best-effort: a capture failure is logged and the fetch still
+returns. The caller decides whether missing raw data matters —
+:func:`fingerprint` and :func:`read_manifest` describe what was actually
+written.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+RAW_CAPTURE_DIR_ENV = 'EEE_RAW_CAPTURE_DIR'
+RAW_CAPTURE_MAX_BYTES_ENV = 'EEE_RAW_CAPTURE_MAX_BYTES'
+MANIFEST_NAME = 'manifest.jsonl'
+
+#: A response body stored exactly as the server sent it.
+VERBATIM_SOURCE = 'fetch_helpers'
+#: A file an adapter's own --save-raw-* flag wrote. Archived, but derived: it
+#: may wrap the payload or stamp it with a retrieval time, so it cannot be
+#: compared across runs to decide whether the source moved.
+ADAPTER_FLAG_SOURCE = 'adapter_flag'
+
+DEFAULT_MAX_BYTES = 64 * 1024 * 1024
+
+_UNSAFE_NAME = re.compile(r'[^A-Za-z0-9._-]+')
+_EXTENSION_BY_CONTENT_TYPE = {
+    'application/json': '.json',
+    'text/csv': '.csv',
+    'text/html': '.html',
+    'text/plain': '.txt',
+}
+
+_logger = logging.getLogger(__name__)
+_lock = threading.Lock()
+# (capture directory, filename) -> sha256 already recorded by this process.
+# Keyed by directory too: one process may capture into more than one directory,
+# and the same payload name in a different directory is a different payload.
+_recorded: dict[tuple[str, str], str] = {}
+
+
+def capture_dir() -> Path | None:
+    """Return the configured capture directory, or ``None`` when disabled."""
+    value = os.environ.get(RAW_CAPTURE_DIR_ENV, '').strip()
+    return Path(value) if value else None
+
+
+def max_capture_bytes() -> int:
+    """Return the per-payload capture ceiling in bytes."""
+    value = os.environ.get(RAW_CAPTURE_MAX_BYTES_ENV, '').strip()
+    if not value:
+        return DEFAULT_MAX_BYTES
+    try:
+        parsed = int(value)
+    except ValueError:
+        _logger.warning(
+            '%s is not an integer (%r); using the default ceiling',
+            RAW_CAPTURE_MAX_BYTES_ENV,
+            value,
+        )
+        return DEFAULT_MAX_BYTES
+    return parsed if parsed > 0 else DEFAULT_MAX_BYTES
+
+
+def payload_filename(url: str, content_type: str | None = None) -> str:
+    """Return a stable, filesystem-safe capture filename for ``url``.
+
+    The name is a function of the URL alone, so re-fetching the same URL
+    overwrites its own payload instead of accumulating copies. The leading
+    digest keeps two URLs that share a last path segment apart.
+    """
+    digest = hashlib.sha256(url.encode('utf-8')).hexdigest()[:12]
+    parsed = urlparse(url)
+    stem, suffix = _split_last_segment(parsed.path)
+    label = _UNSAFE_NAME.sub('-', stem or parsed.netloc).strip('-')
+    extension = suffix or _extension_for(content_type)
+    return f'{digest}-{label[:60] or "payload"}{extension}'
+
+
+def _split_last_segment(path: str) -> tuple[str, str]:
+    """Split a URL path's last segment into a stem and a file extension."""
+    segment = path.rstrip('/').rsplit('/', 1)[-1]
+    stem, dot, suffix = segment.rpartition('.')
+    if dot and 1 <= len(suffix) <= 5 and suffix.isalnum():
+        return stem, f'.{suffix.lower()}'
+    return segment, ''
+
+
+def _extension_for(content_type: str | None) -> str:
+    if not content_type:
+        return '.bin'
+    base = content_type.split(';', 1)[0].strip().lower()
+    return _EXTENSION_BY_CONTENT_TYPE.get(base, '.bin')
+
+
+def capture_response(
+    url: str,
+    body: bytes,
+    *,
+    content_type: str | None = None,
+) -> Path | None:
+    """Write ``body`` to the capture directory and record it in the manifest.
+
+    Returns the payload path, or ``None`` when capture is disabled, skipped, or
+    failed. Never raises: a fetch must not fail because archiving did.
+    """
+    directory = capture_dir()
+    if directory is None:
+        return None
+    try:
+        return _capture(directory, url, body, content_type)
+    except Exception as error:  # pragma: no cover - defensive
+        _logger.warning('could not capture raw payload for %s: %s', url, error)
+        return None
+
+
+def _capture(
+    directory: Path,
+    url: str,
+    body: bytes,
+    content_type: str | None,
+) -> Path | None:
+    filename = payload_filename(url, content_type)
+    checksum = hashlib.sha256(body).hexdigest()
+    ceiling = max_capture_bytes()
+    entry: dict[str, Any] = {
+        'url': url,
+        'file': filename,
+        'bytes': len(body),
+        'sha256': checksum,
+        'content_type': content_type,
+        'source': VERBATIM_SOURCE,
+        'retrieved_at': datetime.now(timezone.utc).isoformat(
+            timespec='seconds'
+        ),
+    }
+
+    if len(body) > ceiling:
+        # Record the gap rather than dropping the payload silently.
+        entry['file'] = None
+        entry['skipped'] = f'payload exceeds {ceiling} byte capture ceiling'
+        _logger.warning(
+            'not capturing %s: %d bytes exceeds the %d byte ceiling',
+            url,
+            len(body),
+            ceiling,
+        )
+        _record(directory, filename, checksum, entry)
+        return None
+
+    directory.mkdir(parents=True, exist_ok=True)
+    payload_path = directory / filename
+    temporary_path = payload_path.with_name(f'{filename}.partial')
+    temporary_path.write_bytes(body)
+    temporary_path.replace(payload_path)
+    _record(directory, filename, checksum, entry)
+    return payload_path
+
+
+def _record(
+    directory: Path,
+    filename: str,
+    checksum: str,
+    entry: dict[str, Any],
+) -> None:
+    """Append ``entry`` to the manifest unless it is already recorded."""
+    key = (str(directory), filename)
+    with _lock:
+        if _recorded.get(key) == checksum:
+            return
+        _recorded[key] = checksum
+        directory.mkdir(parents=True, exist_ok=True)
+        with (directory / MANIFEST_NAME).open('a', encoding='utf-8') as handle:
+            handle.write(json.dumps(entry, ensure_ascii=False) + '\n')
+
+
+def read_manifest(directory: str | Path) -> list[dict[str, Any]]:
+    """Return the manifest entries written under ``directory``."""
+    manifest_path = Path(directory) / MANIFEST_NAME
+    if not manifest_path.is_file():
+        return []
+    entries = []
+    for line in manifest_path.read_text(encoding='utf-8').splitlines():
+        if line.strip():
+            entries.append(json.loads(line))
+    return entries
+
+
+def index_unlisted_payloads(directory: str | Path) -> list[str]:
+    """Add manifest entries for payloads written outside the capture hook.
+
+    An adapter's own ``--save-raw-*`` flag writes into the same directory
+    without going through :func:`capture_response`. Indexing those files brings
+    them under :func:`fingerprint`, so raw archived by either route counts.
+
+    Returns the filenames newly recorded.
+    """
+    root = Path(directory)
+    if not root.is_dir():
+        return []
+    listed = {
+        entry['file'] for entry in read_manifest(root) if entry.get('file')
+    }
+    added = []
+    for path in sorted(root.iterdir()):
+        if not path.is_file():
+            continue
+        if path.name in listed or path.name == MANIFEST_NAME:
+            continue
+        if path.name.endswith('.partial'):
+            continue
+        body = path.read_bytes()
+        _record(
+            root,
+            path.name,
+            hashlib.sha256(body).hexdigest(),
+            {
+                'url': None,
+                'file': path.name,
+                'bytes': len(body),
+                'sha256': hashlib.sha256(body).hexdigest(),
+                'source': ADAPTER_FLAG_SOURCE,
+            },
+        )
+        added.append(path.name)
+    return added
+
+
+def fingerprint(
+    directory: str | Path, *, verbatim_only: bool = False
+) -> str | None:
+    """Return a digest of the captured payloads, or ``None`` if none exist.
+
+    The digest covers each payload's name and content hash and nothing else, so
+    two runs that fetched byte-identical data agree even though their manifests
+    carry different retrieval timestamps. That equality is what lets a caller
+    conclude the upstream source has not moved.
+
+    Pass ``verbatim_only`` when the answer must support that conclusion. Only
+    bodies stored exactly as the server sent them qualify: a file written by an
+    adapter's own ``--save-raw-*`` flag is a derived artifact and may embed its
+    own fetch time, which would make every run look different from the last.
+    """
+    entries = read_manifest(directory)
+    if verbatim_only:
+        entries = [
+            entry
+            for entry in entries
+            if entry.get('source', VERBATIM_SOURCE) == VERBATIM_SOURCE
+        ]
+    lines = sorted(
+        f'{entry.get("file") or entry["url"]} {entry["sha256"]}'
+        for entry in entries
+    )
+    if not lines:
+        return None
+    return hashlib.sha256('\n'.join(lines).encode('utf-8')).hexdigest()
+
+
+def reset_recorded_state() -> None:
+    """Forget which payloads this process already recorded (tests only)."""
+    with _lock:
+        _recorded.clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ every_eval_ever = [
     "adapters/**/*.md",
     "adapters/**/*.sh",
     "adapters/**/registry_snapshot.json",
+    "cron/*.md",
     "tools/*.md",
 ]
 [dependency-groups]

--- a/tests/test_cron_archive.py
+++ b/tests/test_cron_archive.py
@@ -13,32 +13,39 @@ from every_eval_ever.helpers import raw_capture
 REPO = 'evaleval/EEE_raw'
 
 
-@pytest.fixture(autouse=True)
-def _forget_recorded_payloads():
-    raw_capture.reset_recorded_state()
-    yield
-    raw_capture.reset_recorded_state()
+class _Info:
+    def __init__(self, private: bool):
+        self.private = private
 
 
 class _FakeApi:
     """Stands in for the Hub, recording what a run would store."""
 
-    def __init__(self, existing: set[str] | None = None):
+    def __init__(self, existing: set[str] | None = None, private: bool = True):
         self.existing = existing or set()
         self.commits: list[dict] = []
         self.created: list[dict] = []
+        self.private = private
 
     def create_repo(self, **kwargs):
         self.created.append(kwargs)
 
-    def file_exists(self, *, repo_id, filename, repo_type):
-        return filename in self.existing
+    def repo_info(self, *, repo_id, repo_type):
+        return _Info(private=self.private)
+
+    def get_paths_info(self, *, repo_id, paths, repo_type):
+        return [_PathInfo(path) for path in paths if path in self.existing]
 
     def create_commit(self, **kwargs):
         self.commits.append(kwargs)
         for operation in kwargs['operations']:
             self.existing.add(operation.path_in_repo)
         return object()
+
+
+class _PathInfo:
+    def __init__(self, path: str):
+        self.path = path
 
 
 def _capture(monkeypatch, raw_dir: Path, url: str, body: bytes) -> None:
@@ -260,83 +267,96 @@ def test_adapter_written_dumps_are_archived_too(tmp_path: Path):
     assert result.rows[0]['capture_source'] == raw_capture.ADAPTER_FLAG_SOURCE
 
 
-def test_the_ledger_remembers_the_fingerprint_for_the_next_run(
-    monkeypatch, tmp_path: Path
-):
-    _capture(monkeypatch, tmp_path, 'https://x.invalid/a.json', b'{"a": 1}')
-    api = _FakeApi()
-    _archive(tmp_path, api, gating_fingerprint='today')
+def test_publish_state_round_trips(monkeypatch, tmp_path: Path):
+    written = {}
 
-    class _ReadBack(_FakeApi):
-        def list_repo_files(self, *, repo_id, repo_type):
-            return sorted(self.existing)
+    class _StateApi(_FakeApi):
+        def create_commit(self, **kwargs):
+            super().create_commit(**kwargs)
+            operation = kwargs['operations'][0]
+            written[operation.path_in_repo] = bytes(operation.path_or_fileobj)
+            return object()
 
-    read_back = _ReadBack(existing=api.existing)
-    ledger = next(
-        operation
-        for operation in api.commits[0]['operations']
-        if operation.path_in_repo.startswith('ledger/')
+    api = _StateApi()
+    archive.write_state(
+        'hle',
+        {'gating_fingerprint': 'abc', 'pr_number': 7, 'partial': False},
+        repo_id=REPO,
+        api=api,
     )
-    stored = tmp_path / 'stored.jsonl'
-    stored.write_bytes(bytes(ledger.path_or_fileobj))
+
+    stored = tmp_path / 'state.json'
+    stored.write_bytes(written[archive.state_path('hle')])
     monkeypatch.setattr(
         archive, 'hf_hub_download', lambda **kwargs: str(stored)
     )
 
-    assert (
-        archive.last_gating_fingerprint('hle', repo_id=REPO, api=read_back)
-        == 'today'
-    )
+    state = archive.read_state('hle', repo_id=REPO)
+    assert state == {
+        'gating_fingerprint': 'abc',
+        'pr_number': 7,
+        'partial': False,
+    }
 
 
-def test_the_most_recent_ledger_wins(monkeypatch, tmp_path: Path):
-    class _Api(_FakeApi):
-        def list_repo_files(self, *, repo_id, repo_type):
-            return [
-                'ledger/hle/2026-08-09-1-1.jsonl',
-                'ledger/hle/2026-08-11-9-1.jsonl',
-                'ledger/hle/2026-08-10-5-1.jsonl',
-                'ledger/vals_ai/2026-08-12-1-1.jsonl',
-            ]
+def test_missing_state_reads_as_none(monkeypatch):
+    from huggingface_hub.errors import EntryNotFoundError
 
-    requested = []
+    def missing(**kwargs):
+        raise EntryNotFoundError('no state yet')
 
-    def fake_download(**kwargs):
-        requested.append(kwargs['filename'])
-        path = tmp_path / 'row.jsonl'
-        path.write_text(
-            json.dumps({'gating_fingerprint': 'latest'}) + '\n',
-            encoding='utf-8',
-        )
-        return str(path)
+    monkeypatch.setattr(archive, 'hf_hub_download', missing)
 
-    monkeypatch.setattr(archive, 'hf_hub_download', fake_download)
-
-    result = archive.last_gating_fingerprint('hle', repo_id=REPO, api=_Api())
-
-    assert result == 'latest'
-    assert requested == ['ledger/hle/2026-08-11-9-1.jsonl']
+    assert archive.read_state('hle', repo_id=REPO) is None
 
 
-def test_no_ledger_yet_means_no_previous_fingerprint(tmp_path: Path):
-    class _Empty(_FakeApi):
-        def list_repo_files(self, *, repo_id, repo_type):
-            return []
-
-    assert (
-        archive.last_gating_fingerprint('hle', repo_id=REPO, api=_Empty())
-        is None
-    )
-
-
-def test_an_unreadable_ledger_does_not_stop_a_run(tmp_path: Path):
+def test_unreadable_state_reads_as_none(monkeypatch):
     # Failing closed here would mean never publishing; failing open can only
     # add a duplicate.
-    class _Broken(_FakeApi):
-        def list_repo_files(self, *, repo_id, repo_type):
-            raise RuntimeError('404 not found')
+    def broken(**kwargs):
+        raise RuntimeError('504 gateway timeout')
 
-    assert (
-        archive.last_gating_fingerprint('hle', repo_id=REPO, api=_Broken())
-        is None
-    )
+    monkeypatch.setattr(archive, 'hf_hub_download', broken)
+
+    assert archive.read_state('hle', repo_id=REPO) is None
+
+
+def test_a_public_raw_dataset_is_refused(monkeypatch, tmp_path: Path):
+    # Raw source payloads are stored on the promise of privacy; visibility is
+    # re-checked before every commit, not only at preflight.
+    _capture(monkeypatch, tmp_path, 'https://x.invalid/a.json', b'{}')
+    api = _FakeApi(private=False)
+
+    with pytest.raises(archive.ArchiveError, match='PUBLIC'):
+        _archive(tmp_path, api)
+
+    assert api.commits == []
+
+
+def test_one_url_serving_two_bodies_archives_both_correctly(
+    monkeypatch, tmp_path: Path
+):
+    # Regression: a URL-keyed capture filename let the second body overwrite
+    # the first while both manifest rows survived, so the archive stored one
+    # body under the other's hash.
+    import hashlib
+
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+    raw_capture.capture_response('https://x.invalid/a.json', b'{"a": 1}')
+    raw_capture.capture_response('https://x.invalid/a.json', b'{"a": 2}')
+    api = _FakeApi()
+
+    result = _archive(tmp_path, api)
+
+    assert result.uploaded == 2
+    blobs = {
+        operation.path_in_repo: operation
+        for operation in api.commits[0]['operations']
+        if operation.path_in_repo.startswith('blobs/')
+    }
+    assert len(blobs) == 2
+    for path_in_repo, operation in blobs.items():
+        body = Path(operation.path_or_fileobj).read_bytes()
+        digest = hashlib.sha256(body).hexdigest()
+        # The blob really contains the bytes its address promises.
+        assert Path(path_in_repo).stem == digest

--- a/tests/test_cron_archive.py
+++ b/tests/test_cron_archive.py
@@ -1,0 +1,342 @@
+"""Raw payloads are kept permanently, cheaply, and with a queryable ledger."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from every_eval_ever.cron import archive
+from every_eval_ever.helpers import raw_capture
+
+REPO = 'evaleval/EEE_raw'
+
+
+@pytest.fixture(autouse=True)
+def _forget_recorded_payloads():
+    raw_capture.reset_recorded_state()
+    yield
+    raw_capture.reset_recorded_state()
+
+
+class _FakeApi:
+    """Stands in for the Hub, recording what a run would store."""
+
+    def __init__(self, existing: set[str] | None = None):
+        self.existing = existing or set()
+        self.commits: list[dict] = []
+        self.created: list[dict] = []
+
+    def create_repo(self, **kwargs):
+        self.created.append(kwargs)
+
+    def file_exists(self, *, repo_id, filename, repo_type):
+        return filename in self.existing
+
+    def create_commit(self, **kwargs):
+        self.commits.append(kwargs)
+        for operation in kwargs['operations']:
+            self.existing.add(operation.path_in_repo)
+        return object()
+
+
+def _capture(monkeypatch, raw_dir: Path, url: str, body: bytes) -> None:
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(raw_dir))
+    raw_capture.capture_response(url, body, content_type='application/json')
+
+
+def _archive(raw_dir: Path, api: _FakeApi, **overrides):
+    arguments = {
+        'adapter': 'hle',
+        'run_date': '2026-08-11',
+        'run_id': '1234-1',
+        'run_url': 'https://github.invalid/run/1234',
+        'gating_fingerprint': 'abc123',
+        'raw_fingerprint': 'raw123',
+        'repo_id': REPO,
+        'api': api,
+    }
+    arguments.update(overrides)
+    return archive.archive(raw_dir, **arguments)
+
+
+def _operations(api: _FakeApi, index: int = 0) -> dict[str, object]:
+    return {
+        operation.path_in_repo: operation
+        for operation in api.commits[index]['operations']
+    }
+
+
+def test_payloads_are_stored_under_their_content_hash(
+    monkeypatch, tmp_path: Path
+):
+    _capture(monkeypatch, tmp_path, 'https://x.invalid/a.json', b'{"a": 1}')
+    api = _FakeApi()
+
+    result = _archive(tmp_path, api)
+
+    entry = raw_capture.read_manifest(tmp_path)[0]
+    expected = archive.blob_path(entry['sha256'], entry['file'])
+    assert expected.startswith(f'blobs/{entry["sha256"][:2]}/')
+    assert expected.endswith('.json')
+    assert expected in _operations(api)
+    assert result.uploaded == 1
+    assert result.reused == 0
+
+
+def test_the_raw_dataset_is_created_private(monkeypatch, tmp_path: Path):
+    _capture(monkeypatch, tmp_path, 'https://x.invalid/a.json', b'{}')
+    api = _FakeApi()
+
+    _archive(tmp_path, api)
+
+    assert api.created == [
+        {
+            'repo_id': REPO,
+            'repo_type': 'dataset',
+            'private': True,
+            'exist_ok': True,
+        }
+    ]
+
+
+def test_a_payload_already_stored_is_not_uploaded_again(
+    monkeypatch, tmp_path: Path
+):
+    # The point of content addressing: an unchanged source costs one ledger row.
+    first = tmp_path / 'first'
+    second = tmp_path / 'second'
+    api = _FakeApi()
+    for directory in (first, second):
+        _capture(
+            monkeypatch, directory, 'https://x.invalid/a.json', b'{"a": 1}'
+        )
+
+    _archive(first, api)
+    result = _archive(second, api, run_id='5678-1')
+
+    assert result.uploaded == 0
+    assert result.reused == 1
+    assert result.uploaded_bytes == 0
+    # Second commit carries the ledger row and nothing else.
+    assert list(_operations(api, 1)) == [
+        archive.ledger_path('hle', '2026-08-11', '5678-1')
+    ]
+
+
+def test_a_changed_payload_is_stored_beside_the_old_one(
+    monkeypatch, tmp_path: Path
+):
+    api = _FakeApi()
+    for index, body in enumerate((b'{"a": 1}', b'{"a": 2}')):
+        directory = tmp_path / str(index)
+        _capture(monkeypatch, directory, 'https://x.invalid/a.json', body)
+        _archive(directory, api, run_id=f'{index}-1')
+
+    blobs = [path for path in api.existing if path.startswith('blobs/')]
+    assert len(blobs) == 2
+
+
+def test_each_run_writes_its_own_ledger_file(monkeypatch, tmp_path: Path):
+    # Parallel adapter jobs must never contend for the same ledger path.
+    _capture(monkeypatch, tmp_path, 'https://x.invalid/a.json', b'{}')
+    api = _FakeApi()
+
+    result = _archive(tmp_path, api)
+
+    assert result.ledger_path == 'ledger/hle/2026-08-11-1234-1.jsonl'
+    assert result.ledger_path in _operations(api)
+
+
+def test_the_ledger_row_traces_a_payload_back_to_its_source_and_run(
+    monkeypatch, tmp_path: Path
+):
+    _capture(monkeypatch, tmp_path, 'https://x.invalid/board.json', b'{"a": 1}')
+    api = _FakeApi()
+
+    result = _archive(tmp_path, api)
+
+    operation = _operations(api)[result.ledger_path]
+    rows = [
+        json.loads(line)
+        for line in bytes(operation.path_or_fileobj).decode().splitlines()
+    ]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row['adapter'] == 'hle'
+    assert row['run_date'] == '2026-08-11'
+    assert row['run_id'] == '1234-1'
+    assert row['run_url'] == 'https://github.invalid/run/1234'
+    assert row['source_url'] == 'https://x.invalid/board.json'
+    assert row['capture_source'] == raw_capture.VERBATIM_SOURCE
+    assert row['gating_fingerprint'] == 'abc123'
+    assert row['raw_fingerprint'] == 'raw123'
+    assert row['blob_path'] == archive.blob_path(
+        row['sha256'], row['file_name']
+    )
+    assert row['bytes'] == 8
+
+
+def test_the_ledger_is_newline_delimited_json(monkeypatch, tmp_path: Path):
+    # So `load_dataset('json', data_files='ledger/**/*.jsonl')` reads the repo.
+    for index in range(2):
+        _capture(
+            monkeypatch,
+            tmp_path,
+            f'https://x.invalid/{index}.json',
+            f'{{"n": {index}}}'.encode(),
+        )
+    api = _FakeApi()
+
+    result = _archive(tmp_path, api)
+
+    body = bytes(_operations(api)[result.ledger_path].path_or_fileobj).decode()
+    assert body.endswith('\n')
+    assert [json.loads(line)['bytes'] for line in body.splitlines()] == [8, 8]
+
+
+def test_a_payload_too_large_to_store_still_gets_a_ledger_row(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_MAX_BYTES_ENV, '4')
+    _capture(monkeypatch, tmp_path, 'https://x.invalid/big.json', b'123456')
+    api = _FakeApi()
+
+    result = _archive(tmp_path, api)
+
+    row = result.rows[0]
+    assert row['blob_path'] is None
+    assert 'ceiling' in row['skipped']
+    # Only the ledger is committed: there is no payload to store.
+    assert list(_operations(api)) == [result.ledger_path]
+
+
+def test_archiving_nothing_is_an_error(tmp_path: Path):
+    with pytest.raises(archive.ArchiveError, match='no raw payloads'):
+        _archive(tmp_path, _FakeApi())
+
+
+def test_an_unreachable_raw_dataset_is_an_error(monkeypatch, tmp_path: Path):
+    _capture(monkeypatch, tmp_path, 'https://x.invalid/a.json', b'{}')
+
+    class _Broken(_FakeApi):
+        def create_repo(self, **kwargs):
+            raise RuntimeError('403 forbidden')
+
+    with pytest.raises(archive.ArchiveError, match='403 forbidden'):
+        _archive(tmp_path, _Broken())
+
+
+def test_a_failed_commit_is_an_error(monkeypatch, tmp_path: Path):
+    _capture(monkeypatch, tmp_path, 'https://x.invalid/a.json', b'{}')
+
+    class _Broken(_FakeApi):
+        def create_commit(self, **kwargs):
+            raise RuntimeError('504 gateway timeout')
+
+    with pytest.raises(archive.ArchiveError, match='504'):
+        _archive(tmp_path, _Broken())
+
+
+def test_a_missing_local_payload_is_an_error(monkeypatch, tmp_path: Path):
+    _capture(monkeypatch, tmp_path, 'https://x.invalid/a.json', b'{}')
+    entry = raw_capture.read_manifest(tmp_path)[0]
+    (tmp_path / entry['file']).unlink()
+
+    with pytest.raises(archive.ArchiveError, match='named in the manifest'):
+        _archive(tmp_path, _FakeApi())
+
+
+def test_adapter_written_dumps_are_archived_too(tmp_path: Path):
+    # Not usable as a fingerprint, but still raw data worth keeping.
+    (tmp_path / 'hle.json').write_bytes(b'{"fetched_at": "1", "rows": []}')
+    raw_capture.index_unlisted_payloads(tmp_path)
+    api = _FakeApi()
+
+    result = _archive(tmp_path, api)
+
+    assert result.uploaded == 1
+    assert result.rows[0]['capture_source'] == raw_capture.ADAPTER_FLAG_SOURCE
+
+
+def test_the_ledger_remembers_the_fingerprint_for_the_next_run(
+    monkeypatch, tmp_path: Path
+):
+    _capture(monkeypatch, tmp_path, 'https://x.invalid/a.json', b'{"a": 1}')
+    api = _FakeApi()
+    _archive(tmp_path, api, gating_fingerprint='today')
+
+    class _ReadBack(_FakeApi):
+        def list_repo_files(self, *, repo_id, repo_type):
+            return sorted(self.existing)
+
+    read_back = _ReadBack(existing=api.existing)
+    ledger = next(
+        operation
+        for operation in api.commits[0]['operations']
+        if operation.path_in_repo.startswith('ledger/')
+    )
+    stored = tmp_path / 'stored.jsonl'
+    stored.write_bytes(bytes(ledger.path_or_fileobj))
+    monkeypatch.setattr(
+        archive, 'hf_hub_download', lambda **kwargs: str(stored)
+    )
+
+    assert (
+        archive.last_gating_fingerprint('hle', repo_id=REPO, api=read_back)
+        == 'today'
+    )
+
+
+def test_the_most_recent_ledger_wins(monkeypatch, tmp_path: Path):
+    class _Api(_FakeApi):
+        def list_repo_files(self, *, repo_id, repo_type):
+            return [
+                'ledger/hle/2026-08-09-1-1.jsonl',
+                'ledger/hle/2026-08-11-9-1.jsonl',
+                'ledger/hle/2026-08-10-5-1.jsonl',
+                'ledger/vals_ai/2026-08-12-1-1.jsonl',
+            ]
+
+    requested = []
+
+    def fake_download(**kwargs):
+        requested.append(kwargs['filename'])
+        path = tmp_path / 'row.jsonl'
+        path.write_text(
+            json.dumps({'gating_fingerprint': 'latest'}) + '\n',
+            encoding='utf-8',
+        )
+        return str(path)
+
+    monkeypatch.setattr(archive, 'hf_hub_download', fake_download)
+
+    result = archive.last_gating_fingerprint('hle', repo_id=REPO, api=_Api())
+
+    assert result == 'latest'
+    assert requested == ['ledger/hle/2026-08-11-9-1.jsonl']
+
+
+def test_no_ledger_yet_means_no_previous_fingerprint(tmp_path: Path):
+    class _Empty(_FakeApi):
+        def list_repo_files(self, *, repo_id, repo_type):
+            return []
+
+    assert (
+        archive.last_gating_fingerprint('hle', repo_id=REPO, api=_Empty())
+        is None
+    )
+
+
+def test_an_unreadable_ledger_does_not_stop_a_run(tmp_path: Path):
+    # Failing closed here would mean never publishing; failing open can only
+    # add a duplicate.
+    class _Broken(_FakeApi):
+        def list_repo_files(self, *, repo_id, repo_type):
+            raise RuntimeError('404 not found')
+
+    assert (
+        archive.last_gating_fingerprint('hle', repo_id=REPO, api=_Broken())
+        is None
+    )

--- a/tests/test_cron_archive.py
+++ b/tests/test_cron_archive.py
@@ -310,15 +310,27 @@ def test_missing_state_reads_as_none(monkeypatch):
     assert archive.read_state('hle', repo_id=REPO) is None
 
 
-def test_unreadable_state_reads_as_none(monkeypatch):
-    # Failing closed here would mean never publishing; failing open can only
-    # add a duplicate.
+def test_a_transient_state_read_error_raises(monkeypatch):
+    # Guessing "first run" on a 504 would republish an entire unchanged record
+    # set; a failed run just retries tomorrow.
     def broken(**kwargs):
         raise RuntimeError('504 gateway timeout')
 
     monkeypatch.setattr(archive, 'hf_hub_download', broken)
 
-    assert archive.read_state('hle', repo_id=REPO) is None
+    with pytest.raises(archive.ArchiveError, match='504'):
+        archive.read_state('hle', repo_id=REPO)
+
+
+def test_a_malformed_state_file_raises(monkeypatch, tmp_path: Path):
+    stored = tmp_path / 'state.json'
+    stored.write_text('not json', encoding='utf-8')
+    monkeypatch.setattr(
+        archive, 'hf_hub_download', lambda **kwargs: str(stored)
+    )
+
+    with pytest.raises(archive.ArchiveError, match='unreadable'):
+        archive.read_state('hle', repo_id=REPO)
 
 
 def test_a_public_raw_dataset_is_refused(monkeypatch, tmp_path: Path):

--- a/tests/test_cron_archive.py
+++ b/tests/test_cron_archive.py
@@ -220,7 +220,7 @@ def test_a_payload_too_large_to_store_still_gets_a_ledger_row(
 
 
 def test_archiving_nothing_is_an_error(tmp_path: Path):
-    with pytest.raises(archive.ArchiveError, match='no raw payloads'):
+    with pytest.raises(archive.ArchiveError, match='nothing to archive'):
         _archive(tmp_path, _FakeApi())
 
 
@@ -372,3 +372,104 @@ def test_one_url_serving_two_bodies_archives_both_correctly(
         digest = hashlib.sha256(body).hexdigest()
         # The blob really contains the bytes its address promises.
         assert Path(path_in_repo).stem == digest
+
+
+def test_the_attempt_record_round_trips(monkeypatch, tmp_path: Path):
+    written = {}
+
+    class _StateApi(_FakeApi):
+        def create_commit(self, **kwargs):
+            super().create_commit(**kwargs)
+            operation = kwargs['operations'][0]
+            written[operation.path_in_repo] = bytes(operation.path_or_fileobj)
+            return object()
+
+    archive.write_attempt(
+        'hle',
+        {'run_id': '9-1', 'paths': ['data/hle/dev/m/a.json']},
+        repo_id=REPO,
+        api=_StateApi(),
+    )
+    stored = tmp_path / 'attempt.json'
+    stored.write_bytes(written[archive.attempt_path('hle')])
+    monkeypatch.setattr(
+        archive, 'hf_hub_download', lambda **kwargs: str(stored)
+    )
+
+    attempt = archive.read_attempt('hle', repo_id=REPO)
+    assert attempt == {'run_id': '9-1', 'paths': ['data/hle/dev/m/a.json']}
+
+
+def test_a_missing_attempt_reads_as_none(monkeypatch):
+    from huggingface_hub.errors import EntryNotFoundError
+
+    def missing(**kwargs):
+        raise EntryNotFoundError('none')
+
+    monkeypatch.setattr(archive, 'hf_hub_download', missing)
+    assert archive.read_attempt('hle', repo_id=REPO) is None
+
+
+def test_writing_state_clears_the_attempt_in_the_same_commit(tmp_path: Path):
+    from huggingface_hub import CommitOperationDelete
+
+    api = _FakeApi()
+    archive.write_state(
+        'hle',
+        {'gating_fingerprint': 'abc'},
+        repo_id=REPO,
+        api=api,
+        clear_attempt=True,
+    )
+
+    operations = api.commits[0]['operations']
+    assert any(
+        isinstance(op, CommitOperationDelete)
+        and op.path_in_repo == archive.attempt_path('hle')
+        for op in operations
+    ), 'the state and the attempt must change atomically'
+
+
+def test_failure_reports_are_archived_under_the_run(
+    monkeypatch, tmp_path: Path
+):
+    _capture(monkeypatch, tmp_path, 'https://x.invalid/a.json', b'{}')
+    report = tmp_path / 'hle_failures.json'
+    report.write_text('{"failed_records": []}', encoding='utf-8')
+    api = _FakeApi()
+
+    _archive(tmp_path, api, reports=[report])
+
+    assert 'reports/hle/2026-08-11-1234-1/hle_failures.json' in _operations(api)
+
+
+def test_reports_alone_are_enough_to_archive(monkeypatch, tmp_path: Path):
+    # A NOT_CAPTURED adapter has no payloads, but its failure report still
+    # embeds raw source rows and needs the private dataset.
+    report = tmp_path / 'report.json'
+    report.write_text('{}', encoding='utf-8')
+    api = _FakeApi()
+
+    result = _archive(tmp_path, api, reports=[report])
+
+    assert result.uploaded == 0
+    paths = list(_operations(api))
+    assert paths == ['reports/hle/2026-08-11-1234-1/report.json']
+
+
+def test_ledger_rows_carry_capture_errors(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+
+    def broken(directory, url, body, content_type):
+        raise OSError('disk full')
+
+    monkeypatch.setattr(raw_capture, '_capture', broken)
+    raw_capture.capture_response('https://x.invalid/a.json', b'{}')
+
+    rows = archive.ledger_rows(
+        tmp_path, adapter='hle', run_date='2026-08-11', run_id='1'
+    )
+
+    assert len(rows) == 1
+    assert 'disk full' in rows[0]['error']
+    assert rows[0]['blob_path'] is None

--- a/tests/test_cron_preflight.py
+++ b/tests/test_cron_preflight.py
@@ -1,0 +1,217 @@
+"""Credential problems surface before a refresh does any work."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from every_eval_ever.cron import preflight
+
+DATASTORE = 'evaleval/EEE_datastore'
+RAW = 'evaleval/EEE_raw'
+
+
+class _Info:
+    def __init__(self, private: bool = True):
+        self.private = private
+
+
+class _FakeApi:
+    def __init__(
+        self,
+        *,
+        identity: dict | None = None,
+        repos: dict[str, _Info] | None = None,
+        can_create: bool = True,
+    ):
+        self._identity = identity
+        self.repos = repos if repos is not None else {}
+        self.can_create = can_create
+        self.created: list[str] = []
+
+    def whoami(self):
+        if self._identity is None:
+            raise RuntimeError('Token is required')
+        return self._identity
+
+    def repo_info(self, *, repo_id, repo_type):
+        if repo_id not in self.repos:
+            raise RuntimeError(f'404 {repo_id}')
+        return self.repos[repo_id]
+
+    def create_repo(self, *, repo_id, repo_type, private, exist_ok):
+        if not self.can_create:
+            raise RuntimeError('403 you do not have permission')
+        self.created.append(repo_id)
+        self.repos[repo_id] = _Info(private=private)
+
+
+def _named(checks, name):
+    return next(check for check in checks if check.name == name)
+
+
+def _environment(**extra) -> dict[str, str]:
+    return {'HF_TOKEN': 'token', **extra}
+
+
+def test_a_missing_token_fails_before_anything_else():
+    checks = preflight.run_preflight(
+        environment={}, api=_FakeApi(identity=None)
+    )
+
+    token = _named(checks, 'hugging face token')
+    assert not token.ok
+    assert 'HF_TOKEN' in token.detail
+    # No point reporting on destinations we cannot reach.
+    assert not any(check.name == 'datastore' for check in checks)
+    assert preflight.failed(checks)
+
+
+def test_a_working_token_reports_who_it_is():
+    api = _FakeApi(
+        identity={'name': 'eee-bot', 'auth': {'accessToken': {'role': 'write'}}},
+        repos={DATASTORE: _Info(), RAW: _Info()},
+    )
+
+    checks = preflight.run_preflight(environment=_environment(), api=api)
+
+    token = _named(checks, 'hugging face token')
+    assert token.ok
+    assert 'eee-bot' in token.detail
+    assert 'write' in token.detail
+
+
+def test_an_unreachable_datastore_is_a_failure():
+    api = _FakeApi(identity={'name': 'bot'}, repos={RAW: _Info()})
+
+    checks = preflight.run_preflight(environment=_environment(), api=api)
+
+    datastore = _named(checks, 'datastore')
+    assert not datastore.ok
+    assert DATASTORE in datastore.detail
+    assert datastore in preflight.failed(checks)
+
+
+def test_a_missing_raw_dataset_is_created_private():
+    api = _FakeApi(identity={'name': 'bot'}, repos={DATASTORE: _Info()})
+
+    checks = preflight.run_preflight(environment=_environment(), api=api)
+
+    raw = _named(checks, 'raw dataset')
+    assert raw.ok
+    assert api.created == [RAW]
+    assert api.repos[RAW].private is True
+    assert not preflight.failed(checks)
+
+
+def test_a_token_that_cannot_create_the_raw_dataset_fails_early():
+    # Better here than fifteen jobs deep, since the refresh fails closed.
+    api = _FakeApi(
+        identity={'name': 'bot'},
+        repos={DATASTORE: _Info()},
+        can_create=False,
+    )
+
+    checks = preflight.run_preflight(environment=_environment(), api=api)
+
+    raw = _named(checks, 'raw dataset')
+    assert not raw.ok
+    assert 'Create it by hand' in raw.detail
+    assert raw in preflight.failed(checks)
+
+
+def test_a_public_raw_dataset_warns_but_does_not_block():
+    api = _FakeApi(
+        identity={'name': 'bot'},
+        repos={DATASTORE: _Info(), RAW: _Info(private=False)},
+    )
+
+    checks = preflight.run_preflight(environment=_environment(), api=api)
+
+    raw = _named(checks, 'raw dataset')
+    assert raw.ok
+    assert raw.required is False
+    assert 'public' in raw.detail
+    # Not flipped automatically: changing a repo's visibility is not ours to do.
+    assert api.created == []
+    assert not preflight.failed(checks)
+
+
+def test_a_missing_raw_dataset_can_be_reported_without_creating_it():
+    api = _FakeApi(identity={'name': 'bot'}, repos={DATASTORE: _Info()})
+
+    checks = preflight.run_preflight(
+        environment=_environment(), api=api, create_raw=False
+    )
+
+    assert not _named(checks, 'raw dataset').ok
+    assert api.created == []
+
+
+def test_adapters_held_back_by_a_credential_are_named():
+    api = _FakeApi(
+        identity={'name': 'bot'}, repos={DATASTORE: _Info(), RAW: _Info()}
+    )
+
+    checks = preflight.run_preflight(environment=_environment(), api=api)
+
+    warnings = [
+        check for check in checks if check.name.startswith('credential for')
+    ]
+    assert {check.name for check in warnings} == {
+        'credential for artificial_analysis',
+        'credential for llm_stats',
+    }
+    # A missing API key holds back one adapter; it does not stop the refresh.
+    assert not any(check.required for check in warnings)
+    assert not preflight.failed(checks)
+
+
+def test_configured_credentials_leave_no_warning():
+    api = _FakeApi(
+        identity={'name': 'bot'}, repos={DATASTORE: _Info(), RAW: _Info()}
+    )
+    environment = _environment(
+        ARTIFICIAL_ANALYSIS_API_KEY='a', LLM_STATS_API_KEY='b'
+    )
+
+    checks = preflight.run_preflight(environment=environment, api=api)
+
+    assert not [
+        check for check in checks if check.name.startswith('credential for')
+    ]
+    scheduled = _named(checks, 'scheduled adapters')
+    assert 'artificial_analysis' in scheduled.detail
+    assert 'llm_stats' in scheduled.detail
+    assert scheduled.detail.startswith('17 will run')
+
+
+def test_the_checklist_renders_for_a_step_summary(tmp_path: Path):
+    api = _FakeApi(
+        identity={'name': 'bot'}, repos={DATASTORE: _Info(), RAW: _Info()}
+    )
+    checks = preflight.run_preflight(environment=_environment(), api=api)
+    destination = tmp_path / 'summary.md'
+
+    preflight.write_markdown(checks, destination)
+
+    body = destination.read_text(encoding='utf-8')
+    assert body.startswith('## Preflight')
+    assert '✅ **datastore**' in body
+    assert '⚠️ **credential for llm_stats**' in body
+
+
+def test_the_checklist_appends_rather_than_replaces(tmp_path: Path):
+    destination = tmp_path / 'summary.md'
+    destination.write_text('## Planned refresh\n', encoding='utf-8')
+    api = _FakeApi(
+        identity={'name': 'bot'}, repos={DATASTORE: _Info(), RAW: _Info()}
+    )
+
+    preflight.write_markdown(
+        preflight.run_preflight(environment=_environment(), api=api),
+        destination,
+    )
+
+    body = destination.read_text(encoding='utf-8')
+    assert body.startswith('## Planned refresh')
+    assert '## Preflight' in body

--- a/tests/test_cron_preflight.py
+++ b/tests/test_cron_preflight.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from huggingface_hub.errors import RepositoryNotFoundError
+
 from every_eval_ever.cron import preflight
 
 DATASTORE = 'evaleval/EEE_datastore'
@@ -35,7 +37,7 @@ class _FakeApi:
 
     def repo_info(self, *, repo_id, repo_type):
         if repo_id not in self.repos:
-            raise RuntimeError(f'404 {repo_id}')
+            raise RepositoryNotFoundError(f'404 {repo_id}')
         return self.repos[repo_id]
 
     def create_repo(self, *, repo_id, repo_type, private, exist_ok):
@@ -122,7 +124,9 @@ def test_a_token_that_cannot_create_the_raw_dataset_fails_early():
     assert raw in preflight.failed(checks)
 
 
-def test_a_public_raw_dataset_warns_but_does_not_block():
+def test_a_public_raw_dataset_fails_preflight():
+    # Raw source payloads are stored on the promise of privacy; a public
+    # destination blocks the whole refresh rather than warning past it.
     api = _FakeApi(
         identity={'name': 'bot'},
         repos={DATASTORE: _Info(), RAW: _Info(private=False)},
@@ -131,12 +135,48 @@ def test_a_public_raw_dataset_warns_but_does_not_block():
     checks = preflight.run_preflight(environment=_environment(), api=api)
 
     raw = _named(checks, 'raw dataset')
-    assert raw.ok
-    assert raw.required is False
-    assert 'public' in raw.detail
+    assert not raw.ok
+    assert 'PUBLIC' in raw.detail
     # Not flipped automatically: changing a repo's visibility is not ours to do.
     assert api.created == []
-    assert not preflight.failed(checks)
+    assert raw in preflight.failed(checks)
+
+
+def test_a_read_only_token_fails_preflight():
+    api = _FakeApi(
+        identity={
+            'name': 'bot',
+            'auth': {'accessToken': {'role': 'read'}},
+        },
+        repos={DATASTORE: _Info(), RAW: _Info()},
+    )
+
+    checks = preflight.run_preflight(environment=_environment(), api=api)
+
+    token = _named(checks, 'hugging face token')
+    assert not token.ok
+    assert 'read-only' in token.detail
+    assert preflight.failed(checks)
+
+
+def test_a_transient_error_is_not_treated_as_a_missing_raw_dataset():
+    # Creating (or blessing) a repo on the basis of a 500 could mask a public
+    # dataset behind a green check.
+    class _Flaky(_FakeApi):
+        def repo_info(self, *, repo_id, repo_type):
+            if repo_id == RAW:
+                raise RuntimeError('500 internal server error')
+            return super().repo_info(repo_id=repo_id, repo_type=repo_type)
+
+    api = _Flaky(identity={'name': 'bot'}, repos={DATASTORE: _Info()})
+
+    checks = preflight.run_preflight(environment=_environment(), api=api)
+
+    raw = _named(checks, 'raw dataset')
+    assert not raw.ok
+    assert 'could not read' in raw.detail
+    assert api.created == []
+    assert raw in preflight.failed(checks)
 
 
 def test_a_missing_raw_dataset_can_be_reported_without_creating_it():

--- a/tests/test_cron_preflight.py
+++ b/tests/test_cron_preflight.py
@@ -68,7 +68,10 @@ def test_a_missing_token_fails_before_anything_else():
 
 def test_a_working_token_reports_who_it_is():
     api = _FakeApi(
-        identity={'name': 'eee-bot', 'auth': {'accessToken': {'role': 'write'}}},
+        identity={
+            'name': 'eee-bot',
+            'auth': {'accessToken': {'role': 'write'}},
+        },
         repos={DATASTORE: _Info(), RAW: _Info()},
     )
 

--- a/tests/test_cron_publish.py
+++ b/tests/test_cron_publish.py
@@ -1,0 +1,201 @@
+"""Each adapter keeps one datastore pull request, and large sets are batched."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from every_eval_ever.cron import publish
+
+REPO = 'evaleval/EEE_datastore'
+
+
+@dataclass
+class _Discussion:
+    title: str
+    num: int
+
+
+@dataclass
+class _CommitInfo:
+    pr_url: str | None
+
+
+class _FakeApi:
+    """Records the commits a refresh would make."""
+
+    def __init__(self, discussions: list[_Discussion] | None = None):
+        self.discussions = discussions or []
+        self.commits: list[dict] = []
+        self.next_pr = 42
+
+    def get_repo_discussions(self, **kwargs):
+        self.query = kwargs
+        return iter(self.discussions)
+
+    def create_commit(self, **kwargs):
+        self.commits.append(kwargs)
+        if kwargs.get('create_pr'):
+            return _CommitInfo(
+                pr_url=f'https://huggingface.co/datasets/{REPO}/discussions/'
+                f'{self.next_pr}'
+            )
+        return _CommitInfo(pr_url=None)
+
+
+def _records(root: Path, count: int, collection: str = 'vals-ai') -> Path:
+    data_root = root / 'data'
+    for index in range(count):
+        directory = data_root / collection / 'dev' / f'model{index}'
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / f'record{index}.json').write_text('{}', encoding='utf-8')
+    return data_root
+
+
+def test_collect_finds_aggregates_and_sample_companions(tmp_path: Path):
+    data_root = _records(tmp_path, 1)
+    directory = data_root / 'vals-ai' / 'dev' / 'model0'
+    (directory / 'record0_samples.jsonl').write_text('{}\n', encoding='utf-8')
+    (directory / 'notes.txt').write_text('ignored', encoding='utf-8')
+
+    found = publish.collect_files(data_root)
+
+    assert [path.name for path in found] == [
+        'record0.json',
+        'record0_samples.jsonl',
+    ]
+
+
+def test_a_first_refresh_opens_the_adapters_pull_request(tmp_path: Path):
+    data_root = _records(tmp_path, 2)
+    api = _FakeApi()
+
+    result = publish.publish(
+        data_root, adapter='vals_ai', repo_id=REPO, api=api
+    )
+
+    assert result.reused_existing_pr is False
+    assert result.pr_number == 42
+    assert result.files == 2
+    assert result.commits == 1
+    assert api.commits[0]['create_pr'] is True
+    assert api.commits[0]['commit_message'] == publish.pr_title('vals_ai')
+
+
+def test_a_later_refresh_commits_onto_the_same_pull_request(tmp_path: Path):
+    data_root = _records(tmp_path, 1)
+    api = _FakeApi([_Discussion(title=publish.pr_title('vals_ai'), num=7)])
+
+    result = publish.publish(
+        data_root, adapter='vals_ai', repo_id=REPO, api=api
+    )
+
+    assert result.reused_existing_pr is True
+    assert result.pr_number == 7
+    assert api.commits[0]['revision'] == 'refs/pr/7'
+    assert 'create_pr' not in api.commits[0]
+
+
+def test_another_adapters_pull_request_is_not_reused(tmp_path: Path):
+    data_root = _records(tmp_path, 1)
+    api = _FakeApi([_Discussion(title=publish.pr_title('hle'), num=7)])
+
+    result = publish.publish(
+        data_root, adapter='vals_ai', repo_id=REPO, api=api
+    )
+
+    assert result.reused_existing_pr is False
+    assert api.commits[0]['create_pr'] is True
+
+
+def test_only_open_pull_requests_are_searched(tmp_path: Path):
+    data_root = _records(tmp_path, 1)
+    api = _FakeApi()
+
+    publish.publish(data_root, adapter='vals_ai', repo_id=REPO, api=api)
+
+    assert api.query['discussion_status'] == 'open'
+    assert api.query['discussion_type'] == 'pull_request'
+    assert api.query['repo_type'] == 'dataset'
+
+
+def test_large_sets_are_split_across_commits(tmp_path: Path):
+    data_root = _records(tmp_path, 5)
+    api = _FakeApi()
+
+    result = publish.publish(
+        data_root,
+        adapter='vals_ai',
+        repo_id=REPO,
+        api=api,
+        files_per_commit=2,
+    )
+
+    assert result.commits == 3
+    assert [len(commit['operations']) for commit in api.commits] == [2, 2, 1]
+    # Only the first commit opens the PR; the rest land on its ref.
+    assert api.commits[0]['create_pr'] is True
+    assert [commit.get('revision') for commit in api.commits[1:]] == [
+        'refs/pr/42',
+        'refs/pr/42',
+    ]
+
+
+def test_batched_commit_messages_say_the_set_is_incomplete(tmp_path: Path):
+    data_root = _records(tmp_path, 3)
+    api = _FakeApi()
+
+    publish.publish(
+        data_root,
+        adapter='vals_ai',
+        repo_id=REPO,
+        api=api,
+        files_per_commit=2,
+    )
+
+    assert api.commits[0]['commit_message'].endswith('(1/2)')
+    assert api.commits[1]['commit_message'].endswith('(2/2)')
+
+
+def test_records_keep_their_datastore_path(tmp_path: Path):
+    data_root = _records(tmp_path, 1, collection='helm_lite')
+    api = _FakeApi()
+
+    publish.publish(data_root, adapter='helm', repo_id=REPO, api=api)
+
+    operation = api.commits[0]['operations'][0]
+    assert operation.path_in_repo == 'data/helm_lite/dev/model0/record0.json'
+
+
+def test_publishing_nothing_is_an_error(tmp_path: Path):
+    with pytest.raises(publish.PublishError, match='no record files'):
+        publish.publish(
+            tmp_path / 'data', adapter='vals_ai', repo_id=REPO, api=_FakeApi()
+        )
+
+
+def test_a_missing_pull_request_url_stops_before_the_next_batch(
+    tmp_path: Path,
+):
+    data_root = _records(tmp_path, 4)
+
+    class _NoUrlApi(_FakeApi):
+        def create_commit(self, **kwargs):
+            self.commits.append(kwargs)
+            return _CommitInfo(pr_url=None)
+
+    api = _NoUrlApi()
+
+    with pytest.raises(publish.PublishError, match='did not return'):
+        publish.publish(
+            data_root,
+            adapter='vals_ai',
+            repo_id=REPO,
+            api=api,
+            files_per_commit=2,
+        )
+
+    # Stopped rather than sending the rest to the main branch.
+    assert len(api.commits) == 1

--- a/tests/test_cron_publish.py
+++ b/tests/test_cron_publish.py
@@ -16,11 +16,15 @@ REPO = 'evaleval/EEE_datastore'
 class _Discussion:
     title: str
     num: int
+    author: str = 'eee-cron-bot'
 
 
 @dataclass
 class _CommitInfo:
     pr_url: str | None
+
+
+CRON_ACCOUNT = 'eee-cron-bot'
 
 
 class _FakeApi:
@@ -31,9 +35,19 @@ class _FakeApi:
         self.commits: list[dict] = []
         self.next_pr = 42
 
+    def whoami(self):
+        return {'name': CRON_ACCOUNT}
+
     def get_repo_discussions(self, **kwargs):
         self.query = kwargs
-        return iter(self.discussions)
+        author = kwargs.get('author')
+        return iter(
+            [
+                discussion
+                for discussion in self.discussions
+                if author is None or discussion.author == author
+            ]
+        )
 
     def create_commit(self, **kwargs):
         self.commits.append(kwargs)
@@ -143,7 +157,10 @@ def test_large_sets_are_split_across_commits(tmp_path: Path):
     ]
 
 
-def test_batched_commit_messages_say_the_set_is_incomplete(tmp_path: Path):
+def test_the_pr_creating_commit_carries_the_bare_title(tmp_path: Path):
+    # The Hub titles the PR from the first commit's message, and find_open_pr
+    # matches that title exactly tomorrow. A batch suffix here would title the
+    # PR '... (1/2)' and every later day would open a fresh PR.
     data_root = _records(tmp_path, 3)
     api = _FakeApi()
 
@@ -155,8 +172,46 @@ def test_batched_commit_messages_say_the_set_is_incomplete(tmp_path: Path):
         files_per_commit=2,
     )
 
-    assert api.commits[0]['commit_message'].endswith('(1/2)')
+    assert api.commits[0]['commit_message'] == publish.pr_title('vals_ai')
+    assert api.commits[0]['commit_description'].startswith('Batch 1/2')
     assert api.commits[1]['commit_message'].endswith('(2/2)')
+
+
+def test_a_batched_first_publish_is_found_again_the_next_day(tmp_path: Path):
+    data_root = _records(tmp_path, 3)
+    api = _FakeApi()
+    publish.publish(
+        data_root, adapter='vals_ai', repo_id=REPO, api=api, files_per_commit=2
+    )
+    # The Hub would have titled the PR from the first commit's message.
+    api.discussions.append(
+        _Discussion(title=api.commits[0]['commit_message'], num=42)
+    )
+
+    assert publish.find_open_pr(api, REPO, 'vals_ai') == 42
+
+
+def test_a_strangers_pr_with_the_cron_title_is_not_adopted(tmp_path: Path):
+    # The datastore is public: anyone can open a PR with any title. Committing
+    # onto it would hand them control of where the cron's records land.
+    data_root = _records(tmp_path, 1)
+    api = _FakeApi(
+        [
+            _Discussion(
+                title=publish.pr_title('vals_ai'),
+                num=7,
+                author='someone-else',
+            )
+        ]
+    )
+
+    result = publish.publish(
+        data_root, adapter='vals_ai', repo_id=REPO, api=api
+    )
+
+    assert result.reused_existing_pr is False
+    assert api.commits[0]['create_pr'] is True
+    assert api.query['author'] == CRON_ACCOUNT
 
 
 def test_records_keep_their_datastore_path(tmp_path: Path):

--- a/tests/test_cron_publish.py
+++ b/tests/test_cron_publish.py
@@ -254,3 +254,123 @@ def test_a_missing_pull_request_url_stops_before_the_next_batch(
 
     # Stopped rather than sending the rest to the main branch.
     assert len(api.commits) == 1
+
+
+class _PersistentTreeApi(_FakeApi):
+    """A fake Hub keeping one PR file tree across publish attempts."""
+
+    def __init__(self, *, fail_at_commit: int | None = None):
+        super().__init__()
+        self.tree: set[str] = set()
+        self.fail_at_commit = fail_at_commit
+        self._commit_count = 0
+
+    def get_paths_info(self, *, repo_id, paths, repo_type, revision=None):
+        return [
+            type('Info', (), {'path': path})()
+            for path in paths
+            if path in self.tree
+        ]
+
+    def create_commit(self, **kwargs):
+        self._commit_count += 1
+        if self._commit_count == self.fail_at_commit:
+            raise RuntimeError('504 gateway timeout')
+        info = super().create_commit(**kwargs)
+        from huggingface_hub import CommitOperationAdd
+
+        for operation in kwargs['operations']:
+            if isinstance(operation, CommitOperationAdd):
+                self.tree.add(operation.path_in_repo)
+            else:  # CommitOperationDelete
+                self.tree.discard(operation.path_in_repo)
+        return info
+
+
+def test_a_failed_later_batch_retried_leaves_one_copy_of_each_record(
+    tmp_path: Path,
+):
+    # Attempt 1: batch 2 of 3 dies after batch 1 landed on the PR.
+    first_attempt = _records(tmp_path / 'first', 5)
+    api = _PersistentTreeApi(fail_at_commit=2)
+    with pytest.raises(RuntimeError, match='504'):
+        publish.publish(
+            first_attempt,
+            adapter='vals_ai',
+            repo_id=REPO,
+            api=api,
+            files_per_commit=2,
+        )
+    assert len(api.tree) == 2, 'batch 1 landed before the failure'
+    api.discussions.append(
+        _Discussion(title=publish.pr_title('vals_ai'), num=42)
+    )
+
+    # Attempt 2: a fresh work directory (fresh UUID-equivalent names) retries
+    # against the same PR, reconciling the incomplete attempt's paths.
+    second_attempt = tmp_path / 'second' / 'data'
+    for index in range(5):
+        directory = second_attempt / 'vals-ai' / 'dev' / f'model{index}'
+        directory.mkdir(parents=True)
+        (directory / f'retry{index}.json').write_text('{}', encoding='utf-8')
+    api.fail_at_commit = None
+
+    result = publish.publish(
+        second_attempt,
+        adapter='vals_ai',
+        repo_id=REPO,
+        api=api,
+        files_per_commit=2,
+        stale_paths=publish.repo_paths(first_attempt),
+    )
+
+    assert result.reused_existing_pr is True
+    # One copy of each logical record: the five retry files, nothing from the
+    # dead attempt.
+    assert api.tree == {
+        f'data/vals-ai/dev/model{index}/retry{index}.json' for index in range(5)
+    }
+
+
+def test_stale_paths_absent_from_the_pr_are_not_deleted(tmp_path: Path):
+    # Deleting a missing path fails the whole commit, so stale paths are
+    # filtered against the PR's actual tree.
+    data_root = _records(tmp_path, 1)
+    api = _PersistentTreeApi()
+    api.discussions.append(
+        _Discussion(title=publish.pr_title('vals_ai'), num=42)
+    )
+
+    publish.publish(
+        data_root,
+        adapter='vals_ai',
+        repo_id=REPO,
+        api=api,
+        stale_paths=['data/vals-ai/dev/ghost/never-landed.json'],
+    )
+
+    from huggingface_hub import CommitOperationDelete
+
+    deletes = [
+        operation
+        for operation in api.commits[0]['operations']
+        if isinstance(operation, CommitOperationDelete)
+    ]
+    assert deletes == []
+
+
+def test_stale_paths_without_an_open_pr_are_ignored(tmp_path: Path):
+    # The failed attempt's PR was closed or merged by a human; deleting its
+    # paths from a fresh PR would be meaningless (and they are not there).
+    data_root = _records(tmp_path, 1)
+    api = _PersistentTreeApi()
+
+    result = publish.publish(
+        data_root,
+        adapter='vals_ai',
+        repo_id=REPO,
+        api=api,
+        stale_paths=['data/vals-ai/dev/model0/old.json'],
+    )
+
+    assert result.reused_existing_pr is False

--- a/tests/test_cron_runner.py
+++ b/tests/test_cron_runner.py
@@ -8,13 +8,14 @@ from pathlib import Path
 import pytest
 
 import every_eval_ever.eval_types as ET
-from every_eval_ever.cron import publish, runner
+from every_eval_ever.cron import archive, publish, runner
 from every_eval_ever.cron.fingerprint import output_fingerprint
 from every_eval_ever.cron.schedule import CronAdapter, RawPolicy
 from every_eval_ever.cron.stamp import (
     CRON_ADDITION_TYPE,
     TYPE_OF_ADDITION_KEY,
     StampError,
+    stamp_tree,
 )
 from every_eval_ever.helpers import (
     SCHEMA_VERSION,
@@ -108,6 +109,23 @@ def _forget_recorded_payloads():
     raw_capture.reset_recorded_state()
     yield
     raw_capture.reset_recorded_state()
+
+
+@pytest.fixture(autouse=True)
+def _never_reach_the_hub(monkeypatch):
+    """Archiving talks to the Hub, so no test gets the real thing by default.
+
+    Tests that care about archiving replace this with their own stub.
+    """
+    monkeypatch.setattr(
+        runner.archive_module,
+        'archive',
+        lambda raw_dir, **kwargs: archive.ArchiveResult(
+            repo_id='evaleval/EEE_raw',
+            ledger_path='ledger/stub.jsonl',
+            uploaded=1,
+        ),
+    )
 
 
 def _refresh(tmp_path: Path, **overrides):
@@ -540,3 +558,229 @@ def test_force_publishes_even_when_the_source_is_unchanged(
     assert code == runner.EXIT_PUBLISHED
     assert summary.status == 'published'
     assert published == [ADAPTER, ADAPTER]
+
+
+def test_raw_data_is_archived_before_anything_is_published(
+    tmp_path: Path, stub_adapter, monkeypatch
+):
+    order = []
+
+    def fake_archive(raw_dir, **kwargs):
+        order.append('archive')
+        return archive.ArchiveResult(
+            repo_id='evaleval/EEE_raw',
+            ledger_path='ledger/vals_ai/2026-08-11-1-1.jsonl',
+            uploaded=1,
+            reused=0,
+            uploaded_bytes=11,
+        )
+
+    def fake_publish(data_root, **kwargs):
+        order.append('publish')
+        return publish.PublishResult(
+            pr_url='https://hf.invalid/discussions/7',
+            pr_number=7,
+            files=1,
+            commits=1,
+            reused_existing_pr=False,
+        )
+
+    monkeypatch.setattr(runner.archive_module, 'archive', fake_archive)
+    monkeypatch.setattr(runner.publish_module, 'publish', fake_publish)
+    stub_adapter()
+
+    _, summary = _refresh(tmp_path, dry_run=False)
+
+    # Records must not reach the datastore without their raw data stored.
+    assert order == ['archive', 'publish']
+    assert summary.raw_archive['status'] == 'archived'
+    assert summary.raw_archive['ledger_path'].startswith('ledger/vals_ai/')
+
+
+def test_a_failed_archive_stops_the_refresh_before_publishing(
+    tmp_path: Path, stub_adapter, monkeypatch
+):
+    published = []
+
+    def fake_archive(raw_dir, **kwargs):
+        raise archive.ArchiveError('403 forbidden')
+
+    monkeypatch.setattr(runner.archive_module, 'archive', fake_archive)
+    monkeypatch.setattr(
+        runner.publish_module,
+        'publish',
+        lambda *a, **k: published.append(1),
+    )
+    stub_adapter()
+
+    with pytest.raises(archive.ArchiveError):
+        _refresh(tmp_path, dry_run=False)
+
+    assert published == []
+
+
+def test_raw_data_is_archived_even_when_the_source_has_not_changed(
+    tmp_path: Path, stub_adapter, monkeypatch
+):
+    # The ledger's value is knowing what the source looked like on each date,
+    # and an unchanged payload costs nothing to keep.
+    calls = []
+    monkeypatch.setattr(
+        runner.archive_module,
+        'archive',
+        lambda raw_dir, **kwargs: (
+            calls.append(kwargs['run_date'])
+            or archive.ArchiveResult(repo_id='r', ledger_path='l', reused=1)
+        ),
+    )
+    monkeypatch.setattr(
+        runner.publish_module,
+        'publish',
+        lambda *a, **k: publish.PublishResult(
+            pr_url='u',
+            pr_number=1,
+            files=1,
+            commits=1,
+            reused_existing_pr=False,
+        ),
+    )
+    fingerprint = tmp_path / 'fingerprint' / ADAPTER
+    stub_adapter(verbatim=True)
+
+    _refresh(
+        tmp_path,
+        work_dir=tmp_path / 'first',
+        fingerprint_path=fingerprint,
+        dry_run=False,
+    )
+    _, second = _refresh(
+        tmp_path,
+        work_dir=tmp_path / 'second',
+        fingerprint_path=fingerprint,
+        dry_run=False,
+    )
+
+    assert second.status == 'unchanged'
+    assert len(calls) == 2
+
+
+def test_raw_data_is_archived_even_when_no_records_were_produced(
+    tmp_path: Path, monkeypatch
+):
+    calls = []
+
+    def run_adapter(adapter, *, work_dir, raw_dir, environment):
+        # What a crashing adapter leaves: the payload, and no records.
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / 'vals-ai.json').write_bytes(b'{"rows": 1}')
+        return runner.AdapterOutcome(
+            invocations=[runner.Invocation(arguments=[], returncode=1)]
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', run_adapter)
+    monkeypatch.setattr(
+        runner.archive_module,
+        'archive',
+        lambda raw_dir, **kwargs: (
+            calls.append(1)
+            or archive.ArchiveResult(repo_id='r', ledger_path='l', uploaded=1)
+        ),
+    )
+
+    code, summary = _refresh(tmp_path, dry_run=False)
+
+    assert code == runner.EXIT_FAILED
+    assert calls == [1]
+    assert summary.raw_archive['status'] == 'archived'
+
+
+def test_a_dry_run_reports_the_archive_it_would_write(
+    tmp_path: Path, stub_adapter
+):
+    stub_adapter()
+
+    _, summary = _refresh(tmp_path, dry_run=True)
+
+    assert summary.raw_archive == {
+        'status': 'skipped_dry_run',
+        'repo_id': archive.DEFAULT_RAW_REPO_ID,
+        'payloads': 1,
+    }
+
+
+def test_an_adapter_with_no_raw_data_records_that_fact(
+    tmp_path: Path, stub_adapter
+):
+    stub_adapter(raw=None)
+
+    _, summary = _refresh(tmp_path)
+
+    assert summary.raw_archive['status'] == 'nothing_captured'
+
+
+def test_the_output_fingerprint_is_the_same_before_and_after_stamping(
+    tmp_path: Path,
+):
+    # The runner computes it before stamping and archives it; the value has to
+    # be the one a later run will compare against.
+    base = tmp_path / 'data' / 'vals-ai'
+    save_evaluation_log(
+        _log(), base_dir=base, developer='dev', model_name='model'
+    )
+    before = output_fingerprint(tmp_path / 'data')
+
+    stamp_tree(tmp_path / 'data', adapter=ADAPTER, run_date='2026-08-11')
+
+    assert output_fingerprint(tmp_path / 'data') == before
+
+
+def test_the_previous_fingerprint_comes_from_the_ledger(
+    tmp_path: Path, stub_adapter, monkeypatch
+):
+    # No local fingerprint file and no build cache: the raw dataset's ledger is
+    # what stops a rerun from republishing everything.
+    stub_adapter(verbatim=True)
+    _, first = _refresh(
+        tmp_path, work_dir=tmp_path / 'first', fingerprint_path=None
+    )
+
+    monkeypatch.setattr(
+        runner.archive_module,
+        'last_gating_fingerprint',
+        lambda adapter, **kwargs: first.raw_fingerprint,
+    )
+    monkeypatch.setattr(
+        runner.publish_module,
+        'publish',
+        lambda *a, **k: publish.PublishResult(
+            pr_url='u', pr_number=1, files=1, commits=1, reused_existing_pr=True
+        ),
+    )
+    stub_adapter(verbatim=True)
+
+    code, second = _refresh(
+        tmp_path,
+        work_dir=tmp_path / 'second',
+        fingerprint_path=None,
+        dry_run=False,
+    )
+
+    assert code == runner.EXIT_NOTHING_NEW
+    assert second.status == 'unchanged'
+    assert second.previous_fingerprint == first.raw_fingerprint
+
+
+def test_a_dry_run_does_not_consult_the_ledger(
+    tmp_path: Path, stub_adapter, monkeypatch
+):
+    consulted = []
+    monkeypatch.setattr(
+        runner.archive_module,
+        'last_gating_fingerprint',
+        lambda adapter, **kwargs: consulted.append(adapter),
+    )
+    stub_adapter()
+
+    _refresh(tmp_path, fingerprint_path=None, dry_run=True)
+
+    assert consulted == []

--- a/tests/test_cron_runner.py
+++ b/tests/test_cron_runner.py
@@ -119,6 +119,7 @@ def state_store(monkeypatch):
     run-reads-its-own-fingerprint bug.
     """
     store: dict[str, dict] = {}
+    attempts: dict[str, dict] = {}
     monkeypatch.setattr(
         runner.archive_module,
         'archive',
@@ -133,11 +134,26 @@ def state_store(monkeypatch):
         'read_state',
         lambda adapter, **kwargs: store.get(adapter),
     )
+
+    def write_state(adapter, state, **kwargs):
+        store[adapter] = state
+        if kwargs.get('clear_attempt'):
+            attempts.pop(adapter, None)
+
+    monkeypatch.setattr(runner.archive_module, 'write_state', write_state)
     monkeypatch.setattr(
         runner.archive_module,
-        'write_state',
-        lambda adapter, state, **kwargs: store.__setitem__(adapter, state),
+        'read_attempt',
+        lambda adapter, **kwargs: attempts.get(adapter),
     )
+    monkeypatch.setattr(
+        runner.archive_module,
+        'write_attempt',
+        lambda adapter, attempt, **kwargs: attempts.__setitem__(
+            adapter, attempt
+        ),
+    )
+    store['__attempts__'] = attempts  # visible to tests that need them
     monkeypatch.setattr(
         runner.publish_module,
         'publish',
@@ -259,7 +275,9 @@ def test_an_adapter_that_produces_no_records_is_not_a_failure(
     assert summary.status == 'nothing_produced'
 
 
-def test_missing_credentials_skip_rather_than_fail(tmp_path: Path):
+def test_missing_credentials_fail_the_adapters_own_run(tmp_path: Path):
+    # An enabled adapter without its credential is broken configuration, not a
+    # quiet day: its job fails in isolation while the others proceed.
     code, summary = runner.refresh(
         'llm_stats',
         work_dir=tmp_path / 'work',
@@ -272,8 +290,8 @@ def test_missing_credentials_skip_rather_than_fail(tmp_path: Path):
         environment={},
     )
 
-    assert code == runner.EXIT_NOTHING_NEW
-    assert summary.status == 'skipped'
+    assert code == runner.EXIT_FAILED
+    assert summary.status == 'missing_credentials'
     assert 'LLM_STATS_API_KEY' in summary.detail
 
 
@@ -996,7 +1014,7 @@ def test_a_dry_run_does_not_consult_the_state(
     _refresh(tmp_path, dry_run=True)
 
     assert consulted == []
-    assert state_store == {}
+    assert not {k: v for k, v in state_store.items() if k != '__attempts__'}
 
 
 def test_an_oversized_payload_is_still_recorded_in_the_ledger(
@@ -1174,3 +1192,278 @@ def test_an_oversized_only_capture_still_publishes(
     assert code == runner.EXIT_PUBLISHED
     assert summary.raw_skipped == 1
     assert summary.capture_errors == []
+
+
+def test_the_write_token_never_reaches_the_adapter_subprocess(
+    tmp_path: Path, monkeypatch
+):
+    # The cron's HF token can write to the datastore and the private raw
+    # dataset; adapter code and its dependencies must never hold it.
+    seen = {}
+
+    class Completed:
+        returncode = 0
+
+    def fake_run(argv, *, cwd, env, check):
+        seen.update(env)
+        return Completed()
+
+    monkeypatch.setattr(runner.subprocess, 'run', fake_run)
+    adapter = CronAdapter(name=ADAPTER, raw_policy=RawPolicy.NOT_CAPTURED)
+
+    runner.run_adapter(
+        adapter,
+        work_dir=tmp_path / 'work',
+        raw_dir=tmp_path / 'raw',
+        environment={
+            'HF_TOKEN': 'write-capable',
+            'HUGGING_FACE_HUB_TOKEN': 'write-capable',
+            'HF_HUB_TOKEN': 'write-capable',
+            'LLM_STATS_API_KEY': 'source-key',
+            'PATH': '/usr/bin',
+        },
+    )
+
+    for name in runner.WRITE_TOKEN_ENV_NAMES:
+        assert name not in seen
+    # Source-specific credentials and ordinary variables still pass through.
+    assert seen['LLM_STATS_API_KEY'] == 'source-key'
+    assert seen['PATH'] == '/usr/bin'
+
+
+def test_a_source_hf_token_is_forwarded_only_when_declared(
+    tmp_path: Path, monkeypatch
+):
+    seen = {}
+
+    class Completed:
+        returncode = 0
+
+    def fake_run(argv, *, cwd, env, check):
+        seen.update(env)
+        return Completed()
+
+    monkeypatch.setattr(runner.subprocess, 'run', fake_run)
+    environment = {
+        'HF_TOKEN': 'write-capable',
+        runner.SOURCE_HF_TOKEN_ENV: 'read-only-source-token',
+    }
+
+    plain = CronAdapter(name=ADAPTER, raw_policy=RawPolicy.NOT_CAPTURED)
+    runner.run_adapter(
+        plain,
+        work_dir=tmp_path / 'a',
+        raw_dir=tmp_path / 'a-raw',
+        environment=environment,
+    )
+    assert 'HF_TOKEN' not in seen
+
+    seen.clear()
+    declared = CronAdapter(
+        name=ADAPTER,
+        raw_policy=RawPolicy.NOT_CAPTURED,
+        source_hf_token=True,
+    )
+    runner.run_adapter(
+        declared,
+        work_dir=tmp_path / 'b',
+        raw_dir=tmp_path / 'b-raw',
+        environment=environment,
+    )
+    # The forwarded value is the separate read token, never the cron's own.
+    assert seen['HF_TOKEN'] == 'read-only-source-token'
+
+
+def test_a_failed_publish_leaves_the_attempt_for_reconciliation(
+    tmp_path: Path, stub_adapter, state_store, monkeypatch
+):
+    attempts = state_store['__attempts__']
+    stale_seen = []
+
+    calls = []
+
+    def flaky_publish(data_root, *, stale_paths=None, **kwargs):
+        calls.append(1)
+        stale_seen.append(stale_paths)
+        if len(calls) == 1:
+            raise publish.PublishError('batch 2 of 3 failed')
+        return publish.PublishResult(
+            pr_url='u', pr_number=1, files=1, commits=1, reused_existing_pr=True
+        )
+
+    monkeypatch.setattr(runner.publish_module, 'publish', flaky_publish)
+    stub_adapter(verbatim=True)
+
+    with pytest.raises(publish.PublishError):
+        _refresh(tmp_path, work_dir=tmp_path / 'first', dry_run=False)
+
+    # The attempt record survives the failure — it is what the next run uses.
+    assert ADAPTER in attempts
+    left_behind = attempts[ADAPTER]['paths']
+    assert left_behind and all(p.startswith('data/') for p in left_behind)
+
+    stub_adapter(verbatim=True)
+    code, summary = _refresh(
+        tmp_path, work_dir=tmp_path / 'second', dry_run=False
+    )
+
+    assert code == runner.EXIT_PUBLISHED
+    # The retry handed the incomplete attempt's paths to publish() for removal,
+    # and success cleared the attempt in the same commit as the state.
+    assert stale_seen[1] == left_behind
+    assert ADAPTER not in attempts
+
+
+def test_a_dangling_attempt_forces_a_publish_even_when_unchanged(
+    tmp_path: Path, stub_adapter, state_store
+):
+    # Fingerprint equality must not skip while half an old attempt sits on the
+    # PR: the reconciliation is the point of the run.
+    attempts = state_store['__attempts__']
+    stub_adapter(verbatim=True)
+    _refresh(tmp_path, work_dir=tmp_path / 'first', dry_run=False)
+    attempts[ADAPTER] = {'run_id': 'ghost', 'paths': ['data/x/y/z/a.json']}
+
+    stub_adapter(verbatim=True)
+    code, summary = _refresh(
+        tmp_path, work_dir=tmp_path / 'second', dry_run=False
+    )
+
+    assert code == runner.EXIT_PUBLISHED
+    assert summary.status == 'published'
+    assert ADAPTER not in attempts
+
+
+def test_a_persistent_state_write_failure_fails_the_run_keeping_the_pr(
+    tmp_path: Path, stub_adapter, state_store, monkeypatch
+):
+    def broken_write(adapter, state, **kwargs):
+        raise archive.ArchiveError('503 service unavailable')
+
+    monkeypatch.setattr(runner.archive_module, 'write_state', broken_write)
+    stub_adapter(verbatim=True)
+
+    code, summary = _refresh(tmp_path, dry_run=False)
+
+    assert code == runner.EXIT_FAILED
+    assert summary.status == 'published_state_unrecorded'
+    # The publish DID happen; the URL must stay in view.
+    assert summary.pr_url == 'https://hf.invalid/discussions/0'
+    assert '503' in summary.detail
+
+
+def test_a_transient_state_write_failure_is_retried(
+    tmp_path: Path, stub_adapter, state_store, monkeypatch
+):
+    attempts = []
+    real_write = runner.archive_module.write_state
+
+    def flaky_write(adapter, state, **kwargs):
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise archive.ArchiveError('503 service unavailable')
+        return real_write(adapter, state, **kwargs)
+
+    monkeypatch.setattr(runner.archive_module, 'write_state', flaky_write)
+    stub_adapter(verbatim=True)
+
+    code, summary = _refresh(tmp_path, dry_run=False)
+
+    assert code == runner.EXIT_PUBLISHED
+    assert summary.status == 'published'
+    assert len(attempts) == 2
+
+
+def test_capture_failure_evidence_is_archived_before_the_run_fails(
+    tmp_path: Path, monkeypatch, state_store
+):
+    # The successful sibling capture and the error row must be permanent
+    # before the failure returns; the work directory is ephemeral.
+    archived = []
+
+    def recording_archive(raw_dir, **kwargs):
+        archived.append(
+            {
+                'rows': archive.ledger_rows(
+                    raw_dir, adapter='vals_ai', run_date='d', run_id='r'
+                ),
+                'reports': kwargs.get('reports'),
+            }
+        )
+        return archive.ArchiveResult(repo_id='r', ledger_path='l', uploaded=1)
+
+    monkeypatch.setattr(runner.archive_module, 'archive', recording_archive)
+
+    def run_adapter(adapter, *, work_dir, raw_dir, environment):
+        save_evaluation_log(
+            _log(),
+            base_dir=work_dir / 'data' / 'vals-ai',
+            developer='dev',
+            model_name='model',
+        )
+        reports = work_dir / 'adapter_reports'
+        reports.mkdir(parents=True)
+        (reports / 'vals-ai_failures.json').write_text('{}', encoding='utf-8')
+        monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(raw_dir))
+        raw_capture.capture_response('https://vals.invalid/ok', b'{"a": 1}')
+
+        def broken(directory, url, body, content_type):
+            raise OSError('disk full')
+
+        monkeypatch.setattr(raw_capture, '_capture', broken)
+        raw_capture.capture_response('https://vals.invalid/broken', b'{}')
+        return runner.AdapterOutcome(
+            invocations=[runner.Invocation(arguments=[], returncode=0)]
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', run_adapter)
+
+    code, summary = _refresh(tmp_path, dry_run=False)
+
+    assert code == runner.EXIT_FAILED
+    assert len(archived) == 1
+    rows = archived[0]['rows']
+    assert any(row['error'] for row in rows), 'the error row must be archived'
+    assert any(row['file_name'] for row in rows), 'the sibling capture too'
+    assert [r.name for r in archived[0]['reports']] == ['vals-ai_failures.json']
+    assert ADAPTER not in state_store
+
+
+def test_failure_reports_are_archived_even_with_no_captures(
+    tmp_path: Path, monkeypatch, state_store
+):
+    # NOT_CAPTURED adapters still produce failure reports, which embed raw
+    # source rows and must land in the private dataset, not a public artifact.
+    archived = []
+    monkeypatch.setattr(
+        runner.archive_module,
+        'archive',
+        lambda raw_dir, **kwargs: (
+            archived.append(kwargs.get('reports'))
+            or archive.ArchiveResult(repo_id='r', ledger_path='l')
+        ),
+    )
+
+    def run_adapter(adapter, *, work_dir, raw_dir, environment):
+        save_evaluation_log(
+            _log(),
+            base_dir=work_dir / 'data' / 'vals-ai',
+            developer='dev',
+            model_name='model',
+        )
+        reports = work_dir / 'adapter_reports'
+        reports.mkdir(parents=True)
+        (reports / 'report.json').write_text('{}', encoding='utf-8')
+        return runner.AdapterOutcome(
+            invocations=[runner.Invocation(arguments=[], returncode=0)]
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', run_adapter)
+
+    code, summary = _refresh(
+        tmp_path, dry_run=False, adapter=ZERO_CAPTURE_ADAPTER
+    )
+
+    assert code == runner.EXIT_PUBLISHED
+    assert [r.name for r in archived[0]] == ['report.json']
+    assert summary.raw_archive['reports'] == 1

--- a/tests/test_cron_runner.py
+++ b/tests/test_cron_runner.py
@@ -113,9 +113,11 @@ def _forget_recorded_payloads():
 
 @pytest.fixture(autouse=True)
 def _never_reach_the_hub(monkeypatch):
-    """Archiving talks to the Hub, so no test gets the real thing by default.
+    """Archiving, the ledger read and publishing all talk to the Hub.
 
-    Tests that care about archiving replace this with their own stub.
+    None of them may reach it from a test, so all three are stubbed by default.
+    Tests that care about one replace it with their own stub. Relying on each
+    test to remember is how a test suite starts making live API calls.
     """
     monkeypatch.setattr(
         runner.archive_module,
@@ -124,6 +126,22 @@ def _never_reach_the_hub(monkeypatch):
             repo_id='evaleval/EEE_raw',
             ledger_path='ledger/stub.jsonl',
             uploaded=1,
+        ),
+    )
+    monkeypatch.setattr(
+        runner.archive_module,
+        'last_gating_fingerprint',
+        lambda adapter, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        runner.publish_module,
+        'publish',
+        lambda data_root, **kwargs: publish.PublishResult(
+            pr_url='https://hf.invalid/discussions/0',
+            pr_number=0,
+            files=0,
+            commits=0,
+            reused_existing_pr=False,
         ),
     )
 
@@ -705,6 +723,7 @@ def test_a_dry_run_reports_the_archive_it_would_write(
         'status': 'skipped_dry_run',
         'repo_id': archive.DEFAULT_RAW_REPO_ID,
         'payloads': 1,
+        'skipped_payloads': 0,
     }
 
 
@@ -784,3 +803,92 @@ def test_a_dry_run_does_not_consult_the_ledger(
     _refresh(tmp_path, fingerprint_path=None, dry_run=True)
 
     assert consulted == []
+
+
+def test_an_oversized_payload_is_still_recorded_in_the_ledger(
+    tmp_path: Path, monkeypatch
+):
+    # Nothing lands on disk, but the fetch happened and the ledger has to say so.
+    # Guarding the archive on "did a payload land" skipped the row entirely.
+    archived = []
+
+    def run_adapter(adapter, *, work_dir, raw_dir, environment):
+        monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(raw_dir))
+        monkeypatch.setenv(raw_capture.RAW_CAPTURE_MAX_BYTES_ENV, '4')
+        raw_capture.capture_response('https://vals.invalid/big', b'123456')
+        save_evaluation_log(
+            _log(),
+            base_dir=work_dir / 'data' / 'vals-ai',
+            developer='dev',
+            model_name='model',
+        )
+        return runner.AdapterOutcome(
+            invocations=[runner.Invocation(arguments=[], returncode=0)]
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', run_adapter)
+    monkeypatch.setattr(
+        runner.archive_module,
+        'archive',
+        lambda raw_dir, **kwargs: (
+            archived.append(raw_dir)
+            or archive.ArchiveResult(
+                repo_id='evaleval/EEE_raw',
+                ledger_path='ledger/vals_ai/x.jsonl',
+                rows=archive.ledger_rows(
+                    raw_dir,
+                    adapter='vals_ai',
+                    run_date='2026-08-11',
+                    run_id='1',
+                ),
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        runner.publish_module,
+        'publish',
+        lambda *a, **k: publish.PublishResult(
+            pr_url='u',
+            pr_number=1,
+            files=1,
+            commits=1,
+            reused_existing_pr=False,
+        ),
+    )
+
+    _, summary = _refresh(tmp_path, dry_run=False)
+
+    assert summary.raw_payloads == 0
+    assert summary.raw_skipped == 1
+    assert len(archived) == 1, 'the ledger row was never archived'
+    assert summary.raw_archive['status'] == 'archived'
+    assert summary.raw_archive['ledger_rows'] == 1
+
+
+def test_a_run_that_captured_nothing_reports_nothing_captured(
+    tmp_path: Path, stub_adapter, monkeypatch
+):
+    archived = []
+    monkeypatch.setattr(
+        runner.archive_module,
+        'archive',
+        lambda raw_dir, **kwargs: archived.append(raw_dir),
+    )
+    stub_adapter(raw=None)
+
+    _, summary = _refresh(tmp_path, dry_run=False)
+
+    assert summary.raw_payloads == 0
+    assert summary.raw_skipped == 0
+    assert summary.raw_archive['status'] == 'nothing_captured'
+    assert archived == []
+
+
+def test_raw_bytes_counts_only_what_was_stored(tmp_path: Path, stub_adapter):
+    stub_adapter(raw=b'{"rows": 7}', verbatim=True)
+
+    _, summary = _refresh(tmp_path)
+
+    assert summary.raw_payloads == 1
+    assert summary.raw_bytes == len(b'{"rows": 7}')
+    assert summary.raw_skipped == 0

--- a/tests/test_cron_runner.py
+++ b/tests/test_cron_runner.py
@@ -105,20 +105,17 @@ def stub_adapter(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _forget_recorded_payloads():
-    raw_capture.reset_recorded_state()
-    yield
-    raw_capture.reset_recorded_state()
+def state_store(monkeypatch):
+    """Archiving, the state read/write and publishing all talk to the Hub.
 
-
-@pytest.fixture(autouse=True)
-def _never_reach_the_hub(monkeypatch):
-    """Archiving, the ledger read and publishing all talk to the Hub.
-
-    None of them may reach it from a test, so all three are stubbed by default.
-    Tests that care about one replace it with their own stub. Relying on each
-    test to remember is how a test suite starts making live API calls.
+    None of them may reach it from a test, so all are stubbed by default —
+    relying on each test to remember is how a test suite starts making live
+    API calls. The state stubs share a dict per test, so ``refresh()``'s real
+    coupling (gate reads the state a previous *successful publish* wrote) is
+    exercised rather than stubbed away; that stubbing is exactly what hid the
+    run-reads-its-own-fingerprint bug.
     """
+    store: dict[str, dict] = {}
     monkeypatch.setattr(
         runner.archive_module,
         'archive',
@@ -130,8 +127,13 @@ def _never_reach_the_hub(monkeypatch):
     )
     monkeypatch.setattr(
         runner.archive_module,
-        'last_gating_fingerprint',
-        lambda adapter, **kwargs: None,
+        'read_state',
+        lambda adapter, **kwargs: store.get(adapter),
+    )
+    monkeypatch.setattr(
+        runner.archive_module,
+        'write_state',
+        lambda adapter, state, **kwargs: store.__setitem__(adapter, state),
     )
     monkeypatch.setattr(
         runner.publish_module,
@@ -144,12 +146,13 @@ def _never_reach_the_hub(monkeypatch):
             reused_existing_pr=False,
         ),
     )
+    return store
 
 
 def _refresh(tmp_path: Path, **overrides):
     arguments = {
         'work_dir': tmp_path / 'work',
-        'fingerprint_path': tmp_path / 'fingerprint' / ADAPTER,
+        'fingerprint_path': None,
         'summary_path': tmp_path / 'summary.json',
         'repo_id': 'evaleval/EEE_datastore',
         'run_url': 'https://github.invalid/run/1',
@@ -305,7 +308,6 @@ def test_a_failing_invocation_does_not_stop_the_others(
     assert calls == ['HELM_Capabilities', 'HELM_Lite', 'HELM_MMLU']
     assert len(outcome.invocations) == 3
     assert [item.arguments[-1] for item in outcome.failed] == ['HELM_Lite']
-    assert not outcome.all_failed
 
 
 def test_records_from_a_partial_refresh_are_still_published(
@@ -418,7 +420,8 @@ def test_an_invalid_record_stops_the_refresh_and_names_the_file(
         directory = work_dir / 'data' / 'vals-ai' / 'dev' / 'model'
         directory.mkdir(parents=True)
         (directory / f'{"a" * 8}-0000-4000-8000-000000000000.json').write_text(
-            '{"schema_version": "0.3.0"}\n', encoding='utf-8'
+            json.dumps({'schema_version': SCHEMA_VERSION}) + '\n',
+            encoding='utf-8',
         )
         return runner.AdapterOutcome(
             invocations=[runner.Invocation(arguments=[], returncode=0)]
@@ -753,56 +756,161 @@ def test_the_output_fingerprint_is_the_same_before_and_after_stamping(
     assert output_fingerprint(tmp_path / 'data') == before
 
 
-def test_the_previous_fingerprint_comes_from_the_ledger(
-    tmp_path: Path, stub_adapter, monkeypatch
+def test_a_run_never_compares_against_its_own_fingerprint(
+    tmp_path: Path, stub_adapter, state_store
 ):
-    # No local fingerprint file and no build cache: the raw dataset's ledger is
-    # what stops a rerun from republishing everything.
-    stub_adapter(verbatim=True)
-    _, first = _refresh(
-        tmp_path, work_dir=tmp_path / 'first', fingerprint_path=None
-    )
-
-    monkeypatch.setattr(
-        runner.archive_module,
-        'last_gating_fingerprint',
-        lambda adapter, **kwargs: first.raw_fingerprint,
-    )
-    monkeypatch.setattr(
-        runner.publish_module,
-        'publish',
-        lambda *a, **k: publish.PublishResult(
-            pr_url='u', pr_number=1, files=1, commits=1, reused_existing_pr=True
-        ),
-    )
+    # The regression that shipped: the gate read the ledger this same run had
+    # just archived and concluded "unchanged" — every adapter published
+    # nothing, forever. The gate must only ever see what a previous successful
+    # publish recorded, so a first run over an empty store publishes.
     stub_adapter(verbatim=True)
 
+    code, summary = _refresh(tmp_path, dry_run=False)
+
+    assert code == runner.EXIT_PUBLISHED
+    assert summary.status == 'published'
+    assert summary.previous_fingerprint is None
+    # ...and only now, after the publish, is the fingerprint remembered.
+    assert state_store[ADAPTER]['gating_fingerprint'] == (
+        summary.raw_fingerprint
+    )
+
+
+def test_the_previous_fingerprint_comes_from_the_publish_state(
+    tmp_path: Path, stub_adapter, state_store
+):
+    # No local fingerprint file and no build cache: the state a successful
+    # publish wrote is what stops a rerun from republishing everything.
+    stub_adapter(verbatim=True)
+    _refresh(tmp_path, work_dir=tmp_path / 'first', dry_run=False)
+
+    stub_adapter(verbatim=True)
     code, second = _refresh(
-        tmp_path,
-        work_dir=tmp_path / 'second',
-        fingerprint_path=None,
-        dry_run=False,
+        tmp_path, work_dir=tmp_path / 'second', dry_run=False
     )
 
     assert code == runner.EXIT_NOTHING_NEW
     assert second.status == 'unchanged'
-    assert second.previous_fingerprint == first.raw_fingerprint
+    assert (
+        second.previous_fingerprint
+        == (state_store[ADAPTER]['gating_fingerprint'])
+    )
 
 
-def test_a_dry_run_does_not_consult_the_ledger(
-    tmp_path: Path, stub_adapter, monkeypatch
+def test_a_failed_publish_does_not_update_the_state(
+    tmp_path: Path, stub_adapter, state_store, monkeypatch
+):
+    # Recording the fingerprint before the publish succeeded would make the
+    # next run skip as "unchanged" and the records would never be published.
+    def failing_publish(data_root, **kwargs):
+        raise publish.PublishError('504 gateway timeout')
+
+    monkeypatch.setattr(runner.publish_module, 'publish', failing_publish)
+    stub_adapter(verbatim=True)
+
+    with pytest.raises(publish.PublishError):
+        _refresh(tmp_path, work_dir=tmp_path / 'first', dry_run=False)
+
+    assert ADAPTER not in state_store
+
+
+def test_the_run_after_a_failed_publish_publishes(
+    tmp_path: Path, stub_adapter, state_store, monkeypatch
+):
+    attempts = []
+
+    def flaky_publish(data_root, **kwargs):
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise publish.PublishError('504 gateway timeout')
+        return publish.PublishResult(
+            pr_url='u', pr_number=1, files=1, commits=1, reused_existing_pr=True
+        )
+
+    monkeypatch.setattr(runner.publish_module, 'publish', flaky_publish)
+    stub_adapter(verbatim=True)
+
+    with pytest.raises(publish.PublishError):
+        _refresh(tmp_path, work_dir=tmp_path / 'first', dry_run=False)
+    stub_adapter(verbatim=True)
+    code, summary = _refresh(
+        tmp_path, work_dir=tmp_path / 'second', dry_run=False
+    )
+
+    assert code == runner.EXIT_PUBLISHED
+    assert summary.status == 'published'
+    assert len(attempts) == 2
+
+
+def test_a_zero_capture_adapter_still_skips_when_unchanged(
+    tmp_path: Path, stub_adapter, state_store
+):
+    # hal, lexam, mt_bench and the upstream-versioned adapters archive no raw
+    # payloads. Their output fingerprint must still be remembered, or they
+    # would republish their whole set every single day.
+    stub_adapter(raw=None)
+    first_code, first = _refresh(
+        tmp_path, work_dir=tmp_path / 'first', dry_run=False
+    )
+    stub_adapter(raw=None)
+    second_code, second = _refresh(
+        tmp_path, work_dir=tmp_path / 'second', dry_run=False
+    )
+
+    assert first_code == runner.EXIT_PUBLISHED
+    assert first.fingerprint_source == 'output'
+    assert second_code == runner.EXIT_NOTHING_NEW
+    assert second.status == 'unchanged'
+
+
+def test_a_partial_publish_forces_the_next_run_to_publish(
+    tmp_path: Path, stub_adapter, state_store, monkeypatch
+):
+    # A partial run published only what converted. Skipping the next run as
+    # "unchanged" would mean the records that failed never get another attempt.
+    def partial_run(adapter, *, work_dir, raw_dir, environment):
+        save_evaluation_log(
+            _log(),
+            base_dir=work_dir / 'data' / 'vals-ai',
+            developer='dev',
+            model_name='model',
+        )
+        return runner.AdapterOutcome(
+            invocations=[
+                runner.Invocation(arguments=['--benchmark', 'a'], returncode=0),
+                runner.Invocation(arguments=['--benchmark', 'b'], returncode=1),
+            ]
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', partial_run)
+    _refresh(tmp_path, work_dir=tmp_path / 'first', dry_run=False)
+    assert state_store[ADAPTER]['partial'] is True
+
+    stub_adapter(verbatim=True)
+    code, summary = _refresh(
+        tmp_path, work_dir=tmp_path / 'second', dry_run=False
+    )
+
+    assert code == runner.EXIT_PUBLISHED
+    assert summary.status == 'published'
+    assert summary.previous_fingerprint is None
+
+
+def test_a_dry_run_does_not_consult_the_state(
+    tmp_path: Path, stub_adapter, state_store, monkeypatch
 ):
     consulted = []
     monkeypatch.setattr(
         runner.archive_module,
-        'last_gating_fingerprint',
+        'read_state',
         lambda adapter, **kwargs: consulted.append(adapter),
     )
     stub_adapter()
 
-    _refresh(tmp_path, fingerprint_path=None, dry_run=True)
+    _refresh(tmp_path, dry_run=True)
 
     assert consulted == []
+    assert state_store == {}
 
 
 def test_an_oversized_payload_is_still_recorded_in_the_ledger(

--- a/tests/test_cron_runner.py
+++ b/tests/test_cron_runner.py
@@ -1,0 +1,542 @@
+"""End-to-end behaviour of one cron refresh, without touching the network."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import every_eval_ever.eval_types as ET
+from every_eval_ever.cron import publish, runner
+from every_eval_ever.cron.fingerprint import output_fingerprint
+from every_eval_ever.cron.schedule import CronAdapter, RawPolicy
+from every_eval_ever.cron.stamp import (
+    CRON_ADDITION_TYPE,
+    TYPE_OF_ADDITION_KEY,
+    StampError,
+)
+from every_eval_ever.helpers import (
+    SCHEMA_VERSION,
+    raw_capture,
+    save_evaluation_log,
+)
+
+ADAPTER = 'vals_ai'
+
+
+def _log(model_id: str = 'dev/model', score: float = 0.5):
+    return ET.EvaluationLog(
+        schema_version=SCHEMA_VERSION,
+        evaluation_id=f'vals/{model_id}/1700000000.0',
+        retrieved_timestamp='1700000000.0',
+        source_metadata=ET.SourceMetadata(
+            source_name='Vals.ai',
+            source_type='documentation',
+            source_organization_name='Vals AI',
+            evaluator_relationship='third_party',
+        ),
+        eval_library=ET.EvalLibrary(name='unknown', version='unknown'),
+        model_info=ET.ModelInfo(
+            name=model_id.split('/')[-1],
+            id=model_id,
+            developer='dev',
+        ),
+        evaluation_results=[
+            ET.EvaluationResult(
+                evaluation_name='finance_agent',
+                source_data=ET.SourceDataUrl(
+                    dataset_name='vals-ai',
+                    source_type='url',
+                    url=['https://vals.invalid/finance'],
+                ),
+                metric_config=ET.MetricConfig(
+                    metric_name='accuracy',
+                    lower_is_better=False,
+                    score_type=ET.ScoreType.continuous,
+                    min_score=0.0,
+                    max_score=1.0,
+                ),
+                score_details=ET.ScoreDetails(score=score),
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def stub_adapter(monkeypatch):
+    """Replace the subprocess call with an in-process writer."""
+
+    def install(
+        score: float = 0.5,
+        raw: bytes | None = b'{"rows": 1}',
+        verbatim: bool = False,
+    ):
+        def run_adapter(adapter, *, work_dir, raw_dir, environment):
+            save_evaluation_log(
+                _log(score=score),
+                base_dir=work_dir / 'data' / 'vals-ai',
+                developer='dev',
+                model_name='model',
+            )
+            if raw is not None and verbatim:
+                # What the shared fetch hook does: store the body as served.
+                monkeypatch.setenv(
+                    raw_capture.RAW_CAPTURE_DIR_ENV, str(raw_dir)
+                )
+                raw_capture.capture_response(
+                    'https://vals.invalid/finance', raw
+                )
+            elif raw is not None:
+                # What an adapter's own --save-raw-json flag leaves behind.
+                raw_dir.mkdir(parents=True, exist_ok=True)
+                (raw_dir / 'vals-ai.json').write_bytes(raw)
+            return runner.AdapterOutcome(
+                invocations=[
+                    runner.Invocation(arguments=list(run), returncode=0)
+                    for run in adapter.runs
+                ]
+            )
+
+        monkeypatch.setattr(runner, 'run_adapter', run_adapter)
+
+    return install
+
+
+@pytest.fixture(autouse=True)
+def _forget_recorded_payloads():
+    raw_capture.reset_recorded_state()
+    yield
+    raw_capture.reset_recorded_state()
+
+
+def _refresh(tmp_path: Path, **overrides):
+    arguments = {
+        'work_dir': tmp_path / 'work',
+        'fingerprint_path': tmp_path / 'fingerprint' / ADAPTER,
+        'summary_path': tmp_path / 'summary.json',
+        'repo_id': 'evaleval/EEE_datastore',
+        'run_url': 'https://github.invalid/run/1',
+        'dry_run': True,
+        'force': False,
+        'environment': {},
+    }
+    arguments.update(overrides)
+    return runner.refresh(ADAPTER, **arguments)
+
+
+def test_a_dry_run_stamps_validates_and_reports_without_publishing(
+    tmp_path: Path, stub_adapter
+):
+    stub_adapter()
+
+    code, summary = _refresh(tmp_path)
+
+    assert code == runner.EXIT_PUBLISHED
+    assert summary.status == 'dry_run'
+    assert summary.records == 1
+    assert summary.collections == ['vals-ai']
+    assert summary.validation == {'files': 1, 'errors': 0, 'warnings': 0}
+    assert summary.pr_url is None
+
+    record = next((tmp_path / 'work' / 'data').glob('*/*/*/*.json'))
+    details = json.loads(record.read_text(encoding='utf-8'))['source_metadata'][
+        'additional_details'
+    ]
+    assert details[TYPE_OF_ADDITION_KEY] == CRON_ADDITION_TYPE
+    assert details['cron_run_date'] == summary.run_date
+    assert details['cron_adapter'] == ADAPTER
+    assert details['cron_run_url'] == 'https://github.invalid/run/1'
+
+
+def test_the_summary_is_written_for_the_artifact(tmp_path: Path, stub_adapter):
+    stub_adapter()
+    _refresh(tmp_path)
+
+    payload = json.loads((tmp_path / 'summary.json').read_text('utf-8'))
+
+    assert payload['adapter'] == ADAPTER
+    assert payload['status'] == 'dry_run'
+    assert payload['raw_payloads'] == 1
+    assert payload['fingerprint_source'] == 'output'
+
+
+def test_a_dump_the_adapter_wrote_is_archived_but_does_not_gate_the_run(
+    tmp_path: Path, stub_adapter
+):
+    # Archived for future reference, but it may carry its own fetch timestamp,
+    # so the run is gated on its output instead.
+    stub_adapter(raw=b'{"rows": 7}')
+
+    _, summary = _refresh(tmp_path)
+
+    assert summary.raw_payloads == 1
+    assert summary.raw_bytes == len(b'{"rows": 7}')
+    assert summary.raw_fingerprint is None
+    assert summary.fingerprint_source == 'output'
+
+
+def test_a_verbatim_wire_capture_gates_the_run(tmp_path: Path, stub_adapter):
+    stub_adapter(raw=b'{"rows": 7}', verbatim=True)
+
+    _, summary = _refresh(tmp_path)
+
+    assert summary.raw_payloads == 1
+    assert summary.raw_fingerprint
+    assert summary.fingerprint_source == 'raw'
+
+
+def test_output_fingerprint_is_used_when_no_raw_data_was_archived(
+    tmp_path: Path, stub_adapter
+):
+    stub_adapter(raw=None)
+
+    _, summary = _refresh(tmp_path)
+
+    assert summary.raw_payloads == 0
+    assert summary.raw_fingerprint is None
+    assert summary.fingerprint_source == 'output'
+    assert summary.output_fingerprint
+
+
+def test_an_adapter_that_produces_no_records_is_not_a_failure(
+    tmp_path: Path, monkeypatch
+):
+    def run_adapter(adapter, *, work_dir, raw_dir, environment):
+        work_dir.mkdir(parents=True, exist_ok=True)
+        return runner.AdapterOutcome(
+            invocations=[runner.Invocation(arguments=[], returncode=0)]
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', run_adapter)
+
+    code, summary = _refresh(tmp_path)
+
+    assert code == runner.EXIT_NOTHING_NEW
+    assert summary.status == 'nothing_produced'
+
+
+def test_missing_credentials_skip_rather_than_fail(tmp_path: Path):
+    code, summary = runner.refresh(
+        'llm_stats',
+        work_dir=tmp_path / 'work',
+        fingerprint_path=None,
+        summary_path=tmp_path / 'summary.json',
+        repo_id='evaleval/EEE_datastore',
+        run_url=None,
+        dry_run=True,
+        force=False,
+        environment={},
+    )
+
+    assert code == runner.EXIT_NOTHING_NEW
+    assert summary.status == 'skipped'
+    assert 'LLM_STATS_API_KEY' in summary.detail
+
+
+def test_a_failing_invocation_does_not_stop_the_others(
+    tmp_path: Path, monkeypatch
+):
+    calls = []
+
+    class Completed:
+        def __init__(self, returncode):
+            self.returncode = returncode
+
+    def fake_run(argv, *, cwd, env, check):
+        calls.append(argv[-1])
+        # The second leaderboard is broken; the rest must still run.
+        return Completed(1 if argv[-1] == 'HELM_Lite' else 0)
+
+    monkeypatch.setattr(runner.subprocess, 'run', fake_run)
+    adapter = CronAdapter(
+        name='helm',
+        raw_policy=RawPolicy.VIA_FETCH_HELPERS,
+        runs=(
+            ('--leaderboard_name', 'HELM_Capabilities'),
+            ('--leaderboard_name', 'HELM_Lite'),
+            ('--leaderboard_name', 'HELM_MMLU'),
+        ),
+    )
+
+    outcome = runner.run_adapter(
+        adapter,
+        work_dir=tmp_path / 'work',
+        raw_dir=tmp_path / 'raw',
+        environment={},
+    )
+
+    assert calls == ['HELM_Capabilities', 'HELM_Lite', 'HELM_MMLU']
+    assert len(outcome.invocations) == 3
+    assert [item.arguments[-1] for item in outcome.failed] == ['HELM_Lite']
+    assert not outcome.all_failed
+
+
+def test_records_from_a_partial_refresh_are_still_published(
+    tmp_path: Path, monkeypatch
+):
+    published = {}
+
+    def run_adapter(adapter, *, work_dir, raw_dir, environment):
+        save_evaluation_log(
+            _log(),
+            base_dir=work_dir / 'data' / 'vals-ai',
+            developer='dev',
+            model_name='model',
+        )
+        return runner.AdapterOutcome(
+            invocations=[
+                runner.Invocation(arguments=['--benchmark', 'a'], returncode=0),
+                runner.Invocation(arguments=['--benchmark', 'b'], returncode=1),
+            ]
+        )
+
+    def fake_publish(data_root, **kwargs):
+        published.update(kwargs)
+        published['files'] = len(list(Path(data_root).glob('*/*/*/*.json')))
+        return publish.PublishResult(
+            pr_url='https://hf.invalid/discussions/7',
+            pr_number=7,
+            files=published['files'],
+            commits=1,
+            reused_existing_pr=False,
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', run_adapter)
+    monkeypatch.setattr(runner.publish_module, 'publish', fake_publish)
+
+    code, summary = _refresh(tmp_path, dry_run=False)
+
+    assert code == runner.EXIT_PUBLISHED
+    assert summary.status == 'published_partial'
+    assert published['files'] == 1
+    assert summary.failed_invocations == [
+        {'arguments': '--benchmark b', 'returncode': 1}
+    ]
+    # The reviewer of the PR is told the source is only partly represented.
+    assert 'Partial refresh' in published['commit_description']
+
+
+def test_no_records_and_a_failing_adapter_is_a_failure(
+    tmp_path: Path, monkeypatch
+):
+    def run_adapter(adapter, *, work_dir, raw_dir, environment):
+        work_dir.mkdir(parents=True, exist_ok=True)
+        return runner.AdapterOutcome(
+            invocations=[runner.Invocation(arguments=[], returncode=1)]
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', run_adapter)
+
+    code, summary = _refresh(tmp_path)
+
+    assert code == runner.EXIT_FAILED
+    assert summary.status == 'failed'
+
+
+def test_the_adapter_runs_in_the_scratch_tree_with_capture_enabled(
+    tmp_path: Path, monkeypatch
+):
+    seen = {}
+
+    class Completed:
+        returncode = 0
+
+    def fake_run(argv, *, cwd, env, check):
+        seen['argv'] = argv
+        seen['cwd'] = cwd
+        seen['env'] = env
+        return Completed()
+
+    monkeypatch.setattr(runner.subprocess, 'run', fake_run)
+    adapter = CronAdapter(
+        name=ADAPTER,
+        raw_policy=RawPolicy.VIA_ADAPTER_FLAG,
+        raw_args=('--save-raw-json', '{raw_dir}/vals-ai.json'),
+    )
+    work_dir = tmp_path / 'work'
+    raw_dir = tmp_path / 'raw'
+
+    runner.run_adapter(
+        adapter, work_dir=work_dir, raw_dir=raw_dir, environment={'A': 'b'}
+    )
+
+    assert seen['cwd'] == work_dir
+    assert seen['argv'][1:3] == [
+        '-m',
+        'every_eval_ever.adapters.vals_ai.adapter',
+    ]
+    assert seen['argv'][-2:] == [
+        '--save-raw-json',
+        f'{raw_dir}/vals-ai.json',
+    ]
+    assert seen['env'][raw_capture.RAW_CAPTURE_DIR_ENV] == str(raw_dir)
+    assert seen['env']['A'] == 'b'
+
+
+def test_an_invalid_record_stops_the_refresh_and_names_the_file(
+    tmp_path: Path, monkeypatch
+):
+    def run_adapter(adapter, *, work_dir, raw_dir, environment):
+        # A file in the right place that is not a valid record.
+        directory = work_dir / 'data' / 'vals-ai' / 'dev' / 'model'
+        directory.mkdir(parents=True)
+        (directory / f'{"a" * 8}-0000-4000-8000-000000000000.json').write_text(
+            '{"schema_version": "0.3.0"}\n', encoding='utf-8'
+        )
+        return runner.AdapterOutcome(
+            invocations=[runner.Invocation(arguments=[], returncode=0)]
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', run_adapter)
+
+    with pytest.raises(StampError, match='not a valid EvaluationLog'):
+        _refresh(tmp_path)
+
+
+def test_output_fingerprint_ignores_the_regenerated_uuid_and_timestamp(
+    tmp_path: Path,
+):
+    first = tmp_path / 'first' / 'data' / 'vals-ai'
+    second = tmp_path / 'second' / 'data' / 'vals-ai'
+    for base in (first, second):
+        save_evaluation_log(
+            _log(), base_dir=base, developer='dev', model_name='model'
+        )
+
+    assert output_fingerprint(first.parent) == output_fingerprint(second.parent)
+
+
+def test_output_fingerprint_notices_a_changed_score(tmp_path: Path):
+    first = tmp_path / 'first' / 'data' / 'vals-ai'
+    second = tmp_path / 'second' / 'data' / 'vals-ai'
+    for base, score in ((first, 0.5), (second, 0.6)):
+        save_evaluation_log(
+            _log(score=score),
+            base_dir=base,
+            developer='dev',
+            model_name='model',
+        )
+
+    assert output_fingerprint(first.parent) != output_fingerprint(second.parent)
+
+
+def test_a_second_run_with_the_same_source_publishes_nothing(
+    tmp_path: Path, stub_adapter, monkeypatch
+):
+    published = []
+
+    def fake_publish(data_root, **kwargs):
+        published.append(kwargs['adapter'])
+        return publish.PublishResult(
+            pr_url='https://hf.invalid/discussions/7',
+            pr_number=7,
+            files=1,
+            commits=1,
+            reused_existing_pr=False,
+        )
+
+    monkeypatch.setattr(runner.publish_module, 'publish', fake_publish)
+    fingerprint = tmp_path / 'fingerprint' / ADAPTER
+    stub_adapter()
+
+    first_code, first = _refresh(
+        tmp_path,
+        work_dir=tmp_path / 'first',
+        fingerprint_path=fingerprint,
+        dry_run=False,
+    )
+    second_code, second = _refresh(
+        tmp_path,
+        work_dir=tmp_path / 'second',
+        fingerprint_path=fingerprint,
+        dry_run=False,
+    )
+
+    assert first_code == runner.EXIT_PUBLISHED
+    assert first.status == 'published'
+    assert second_code == runner.EXIT_NOTHING_NEW
+    assert second.status == 'unchanged'
+    # Published once, not twice: the second day added no duplicate records.
+    assert published == [ADAPTER]
+
+
+def test_a_changed_source_publishes_again(
+    tmp_path: Path, stub_adapter, monkeypatch
+):
+    published = []
+    monkeypatch.setattr(
+        runner.publish_module,
+        'publish',
+        lambda data_root, **kwargs: (
+            published.append(kwargs['adapter'])
+            or publish.PublishResult(
+                pr_url='https://hf.invalid/discussions/7',
+                pr_number=7,
+                files=1,
+                commits=1,
+                reused_existing_pr=True,
+            )
+        ),
+    )
+    fingerprint = tmp_path / 'fingerprint' / ADAPTER
+
+    stub_adapter(raw=b'{"rows": 1}', verbatim=True)
+    _refresh(
+        tmp_path,
+        work_dir=tmp_path / 'first',
+        fingerprint_path=fingerprint,
+        dry_run=False,
+    )
+    stub_adapter(raw=b'{"rows": 2}', verbatim=True)
+    code, summary = _refresh(
+        tmp_path,
+        work_dir=tmp_path / 'second',
+        fingerprint_path=fingerprint,
+        dry_run=False,
+    )
+
+    assert code == runner.EXIT_PUBLISHED
+    assert summary.status == 'published'
+    assert summary.previous_fingerprint != summary.raw_fingerprint
+    assert published == [ADAPTER, ADAPTER]
+
+
+def test_force_publishes_even_when_the_source_is_unchanged(
+    tmp_path: Path, stub_adapter, monkeypatch
+):
+    published = []
+    monkeypatch.setattr(
+        runner.publish_module,
+        'publish',
+        lambda data_root, **kwargs: (
+            published.append(kwargs['adapter'])
+            or publish.PublishResult(
+                pr_url='https://hf.invalid/discussions/7',
+                pr_number=7,
+                files=1,
+                commits=1,
+                reused_existing_pr=True,
+            )
+        ),
+    )
+    fingerprint = tmp_path / 'fingerprint' / ADAPTER
+    stub_adapter()
+
+    _refresh(
+        tmp_path,
+        work_dir=tmp_path / 'first',
+        fingerprint_path=fingerprint,
+        dry_run=False,
+    )
+    code, summary = _refresh(
+        tmp_path,
+        work_dir=tmp_path / 'second',
+        fingerprint_path=fingerprint,
+        dry_run=False,
+        force=True,
+    )
+
+    assert code == runner.EXIT_PUBLISHED
+    assert summary.status == 'published'
+    assert published == [ADAPTER, ADAPTER]

--- a/tests/test_cron_runner.py
+++ b/tests/test_cron_runner.py
@@ -1219,6 +1219,7 @@ def test_the_write_token_never_reaches_the_adapter_subprocess(
             'HF_TOKEN': 'write-capable',
             'HUGGING_FACE_HUB_TOKEN': 'write-capable',
             'HF_HUB_TOKEN': 'write-capable',
+            'HUGGINGFACEHUB_API_TOKEN': 'write-capable',
             'LLM_STATS_API_KEY': 'source-key',
             'PATH': '/usr/bin',
         },

--- a/tests/test_cron_runner.py
+++ b/tests/test_cron_runner.py
@@ -24,6 +24,9 @@ from every_eval_ever.helpers import (
 )
 
 ADAPTER = 'vals_ai'
+# An adapter whose registry entry declares NO capture route, for scenarios
+# where producing records without raw payloads must be legitimate.
+ZERO_CAPTURE_ADAPTER = 'mt_bench'
 
 
 def _log(model_id: str = 'dev/model', score: float = 0.5):
@@ -160,8 +163,9 @@ def _refresh(tmp_path: Path, **overrides):
         'force': False,
         'environment': {},
     }
+    adapter = overrides.pop('adapter', ADAPTER)
     arguments.update(overrides)
-    return runner.refresh(ADAPTER, **arguments)
+    return runner.refresh(adapter, **arguments)
 
 
 def test_a_dry_run_stamps_validates_and_reports_without_publishing(
@@ -230,7 +234,7 @@ def test_output_fingerprint_is_used_when_no_raw_data_was_archived(
 ):
     stub_adapter(raw=None)
 
-    _, summary = _refresh(tmp_path)
+    _, summary = _refresh(tmp_path, adapter=ZERO_CAPTURE_ADAPTER)
 
     assert summary.raw_payloads == 0
     assert summary.raw_fingerprint is None
@@ -322,6 +326,8 @@ def test_records_from_a_partial_refresh_are_still_published(
             developer='dev',
             model_name='model',
         )
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / 'vals-ai.json').write_bytes(b'{"rows": 1}')
         return runner.AdapterOutcome(
             invocations=[
                 runner.Invocation(arguments=['--benchmark', 'a'], returncode=0),
@@ -430,7 +436,7 @@ def test_an_invalid_record_stops_the_refresh_and_names_the_file(
     monkeypatch.setattr(runner, 'run_adapter', run_adapter)
 
     with pytest.raises(StampError, match='not a valid EvaluationLog'):
-        _refresh(tmp_path)
+        _refresh(tmp_path, adapter=ZERO_CAPTURE_ADAPTER)
 
 
 def test_output_fingerprint_ignores_the_regenerated_uuid_and_timestamp(
@@ -735,7 +741,7 @@ def test_an_adapter_with_no_raw_data_records_that_fact(
 ):
     stub_adapter(raw=None)
 
-    _, summary = _refresh(tmp_path)
+    _, summary = _refresh(tmp_path, adapter=ZERO_CAPTURE_ADAPTER)
 
     assert summary.raw_archive['status'] == 'nothing_captured'
 
@@ -850,11 +856,17 @@ def test_a_zero_capture_adapter_still_skips_when_unchanged(
     # would republish their whole set every single day.
     stub_adapter(raw=None)
     first_code, first = _refresh(
-        tmp_path, work_dir=tmp_path / 'first', dry_run=False
+        tmp_path,
+        work_dir=tmp_path / 'first',
+        dry_run=False,
+        adapter=ZERO_CAPTURE_ADAPTER,
     )
     stub_adapter(raw=None)
     second_code, second = _refresh(
-        tmp_path, work_dir=tmp_path / 'second', dry_run=False
+        tmp_path,
+        work_dir=tmp_path / 'second',
+        dry_run=False,
+        adapter=ZERO_CAPTURE_ADAPTER,
     )
 
     assert first_code == runner.EXIT_PUBLISHED
@@ -863,37 +875,111 @@ def test_a_zero_capture_adapter_still_skips_when_unchanged(
     assert second.status == 'unchanged'
 
 
-def test_a_partial_publish_forces_the_next_run_to_publish(
-    tmp_path: Path, stub_adapter, state_store, monkeypatch
-):
-    # A partial run published only what converted. Skipping the next run as
-    # "unchanged" would mean the records that failed never get another attempt.
-    def partial_run(adapter, *, work_dir, raw_dir, environment):
+def _partial_run_adapter(*, failures, raw=b'{"rows": 1}'):
+    """A run_adapter producing one record, a raw payload, and given failures."""
+
+    def run_adapter(adapter, *, work_dir, raw_dir, environment):
         save_evaluation_log(
             _log(),
             base_dir=work_dir / 'data' / 'vals-ai',
             developer='dev',
             model_name='model',
         )
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / 'vals-ai.json').write_bytes(raw)
         return runner.AdapterOutcome(
             invocations=[
                 runner.Invocation(arguments=['--benchmark', 'a'], returncode=0),
-                runner.Invocation(arguments=['--benchmark', 'b'], returncode=1),
+                *(
+                    runner.Invocation(
+                        arguments=['--benchmark', name], returncode=code
+                    )
+                    for name, code in failures
+                ),
             ]
         )
 
-    monkeypatch.setattr(runner, 'run_adapter', partial_run)
-    _refresh(tmp_path, work_dir=tmp_path / 'first', dry_run=False)
-    assert state_store[ADAPTER]['partial'] is True
+    return run_adapter
 
-    stub_adapter(verbatim=True)
+
+def test_an_identical_partial_run_is_not_republished(
+    tmp_path: Path, state_store, monkeypatch
+):
+    # Same records converted, same invocations failed the same way:
+    # republishing would duplicate the successes without recovering anything.
+    monkeypatch.setattr(
+        runner, 'run_adapter', _partial_run_adapter(failures=[('b', 1)])
+    )
+    first_code, first = _refresh(
+        tmp_path, work_dir=tmp_path / 'first', dry_run=False
+    )
+    second_code, second = _refresh(
+        tmp_path, work_dir=tmp_path / 'second', dry_run=False
+    )
+
+    assert first_code == runner.EXIT_PUBLISHED
+    assert first.status == 'published_partial'
+    assert state_store[ADAPTER]['partial'] is True
+    assert second_code == runner.EXIT_NOTHING_NEW
+    assert second.status == 'unchanged'
+
+
+def test_a_changed_failure_set_publishes_again(
+    tmp_path: Path, state_store, monkeypatch
+):
+    monkeypatch.setattr(
+        runner, 'run_adapter', _partial_run_adapter(failures=[('b', 1)])
+    )
+    _refresh(tmp_path, work_dir=tmp_path / 'first', dry_run=False)
+
+    monkeypatch.setattr(
+        runner,
+        'run_adapter',
+        _partial_run_adapter(failures=[('b', 1), ('c', 2)]),
+    )
+    code, summary = _refresh(
+        tmp_path, work_dir=tmp_path / 'second', dry_run=False
+    )
+
+    assert code == runner.EXIT_PUBLISHED
+    assert summary.status == 'published_partial'
+
+
+def test_a_recovered_partial_run_publishes(
+    tmp_path: Path, stub_adapter, state_store, monkeypatch
+):
+    # The failed invocation now converts: its records exist only in this run,
+    # so the fingerprint differs and the run publishes.
+    monkeypatch.setattr(
+        runner, 'run_adapter', _partial_run_adapter(failures=[('b', 1)])
+    )
+    _refresh(tmp_path, work_dir=tmp_path / 'first', dry_run=False)
+
+    def recovered(adapter, *, work_dir, raw_dir, environment):
+        for model in ('model', 'second'):
+            save_evaluation_log(
+                _log(model_id=f'dev/{model}'),
+                base_dir=work_dir / 'data' / 'vals-ai',
+                developer='dev',
+                model_name=model,
+            )
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / 'vals-ai.json').write_bytes(b'{"rows": 2}')
+        return runner.AdapterOutcome(
+            invocations=[
+                runner.Invocation(arguments=['--benchmark', 'a'], returncode=0),
+                runner.Invocation(arguments=['--benchmark', 'b'], returncode=0),
+            ]
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', recovered)
     code, summary = _refresh(
         tmp_path, work_dir=tmp_path / 'second', dry_run=False
     )
 
     assert code == runner.EXIT_PUBLISHED
     assert summary.status == 'published'
-    assert summary.previous_fingerprint is None
+    assert state_store[ADAPTER]['partial'] is False
 
 
 def test_a_dry_run_does_not_consult_the_state(
@@ -984,7 +1070,7 @@ def test_a_run_that_captured_nothing_reports_nothing_captured(
     )
     stub_adapter(raw=None)
 
-    _, summary = _refresh(tmp_path, dry_run=False)
+    _, summary = _refresh(tmp_path, dry_run=False, adapter=ZERO_CAPTURE_ADAPTER)
 
     assert summary.raw_payloads == 0
     assert summary.raw_skipped == 0
@@ -1000,3 +1086,91 @@ def test_raw_bytes_counts_only_what_was_stored(tmp_path: Path, stub_adapter):
     assert summary.raw_payloads == 1
     assert summary.raw_bytes == len(b'{"rows": 7}')
     assert summary.raw_skipped == 0
+
+
+def test_a_capture_failure_stops_publication(
+    tmp_path: Path, monkeypatch, state_store
+):
+    # Records without their source bytes archived must not be published.
+    def run_adapter(adapter, *, work_dir, raw_dir, environment):
+        save_evaluation_log(
+            _log(),
+            base_dir=work_dir / 'data' / 'vals-ai',
+            developer='dev',
+            model_name='model',
+        )
+        monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(raw_dir))
+        raw_capture.capture_response('https://vals.invalid/ok', b'{"a": 1}')
+
+        def broken(directory, url, body, content_type):
+            raise OSError('disk full')
+
+        monkeypatch.setattr(raw_capture, '_capture', broken)
+        raw_capture.capture_response('https://vals.invalid/broken', b'{}')
+        return runner.AdapterOutcome(
+            invocations=[runner.Invocation(arguments=[], returncode=0)]
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', run_adapter)
+
+    code, summary = _refresh(tmp_path, dry_run=False)
+
+    # One capture succeeded — the mixed case must still fail.
+    assert code == runner.EXIT_FAILED
+    assert summary.status == 'failed'
+    assert 'capture failure' in summary.detail
+    assert summary.capture_errors == ['https://vals.invalid/broken']
+    assert ADAPTER not in state_store
+
+
+def test_records_without_any_captured_payload_stop_publication(
+    tmp_path: Path, monkeypatch, state_store
+):
+    # vals_ai declares a capture route; records with an empty manifest mean
+    # the route silently did not run — an unexplained provenance gap.
+    def run_adapter(adapter, *, work_dir, raw_dir, environment):
+        save_evaluation_log(
+            _log(),
+            base_dir=work_dir / 'data' / 'vals-ai',
+            developer='dev',
+            model_name='model',
+        )
+        return runner.AdapterOutcome(
+            invocations=[runner.Invocation(arguments=[], returncode=0)]
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', run_adapter)
+
+    code, summary = _refresh(tmp_path, dry_run=False)
+
+    assert code == runner.EXIT_FAILED
+    assert 'captured nothing' in summary.detail
+    assert ADAPTER not in state_store
+
+
+def test_an_oversized_only_capture_still_publishes(
+    tmp_path: Path, monkeypatch, state_store
+):
+    # A deliberate ceiling skip is recorded, not an error: the ledger row says
+    # what happened and the run proceeds.
+    def run_adapter(adapter, *, work_dir, raw_dir, environment):
+        save_evaluation_log(
+            _log(),
+            base_dir=work_dir / 'data' / 'vals-ai',
+            developer='dev',
+            model_name='model',
+        )
+        monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(raw_dir))
+        monkeypatch.setenv(raw_capture.RAW_CAPTURE_MAX_BYTES_ENV, '4')
+        raw_capture.capture_response('https://vals.invalid/big', b'123456')
+        return runner.AdapterOutcome(
+            invocations=[runner.Invocation(arguments=[], returncode=0)]
+        )
+
+    monkeypatch.setattr(runner, 'run_adapter', run_adapter)
+
+    code, summary = _refresh(tmp_path, dry_run=False)
+
+    assert code == runner.EXIT_PUBLISHED
+    assert summary.raw_skipped == 1
+    assert summary.capture_errors == []

--- a/tests/test_cron_schedule.py
+++ b/tests/test_cron_schedule.py
@@ -118,36 +118,24 @@ def test_excluded_adapter_reports_why_it_is_excluded():
         get_adapter(name)
 
 
-def test_scheduling_skips_adapters_missing_credentials():
-    runnable, skipped = scheduled_adapters({})
+def test_uncredentialed_enabled_adapters_stay_scheduled():
+    # They must fail their own job visibly, not vanish from the matrix behind
+    # a green run — so scheduling ignores credentials entirely.
+    runnable, _ = scheduled_adapters({})
     needs_credentials = {
         adapter.name
         for adapter in CRON_ADAPTERS
         if adapter.requires_env and adapter.enabled
     }
     assert needs_credentials
-    assert not needs_credentials & {adapter.name for adapter in runnable}
-    reasons = {adapter.name: reason for adapter, reason in skipped}
-    for name in needs_credentials:
-        assert 'missing environment' in reasons[name]
-
-
-def test_scheduling_includes_a_credentialed_adapter_once_configured():
-    adapter = next(
-        item for item in CRON_ADAPTERS if item.requires_env and item.enabled
-    )
-    environment = {name: 'token' for name in adapter.requires_env}
-    runnable, _ = scheduled_adapters(environment)
-    assert adapter.name in {item.name for item in runnable}
+    assert needs_credentials <= {adapter.name for adapter in runnable}
 
 
 def test_blank_credentials_count_as_missing():
     adapter = next(
         item for item in CRON_ADAPTERS if item.requires_env and item.enabled
     )
-    environment = {name: '   ' for name in adapter.requires_env}
-    runnable, _ = scheduled_adapters(environment)
-    assert adapter.name not in {item.name for item in runnable}
+    assert adapter.missing_env({name: '   ' for name in adapter.requires_env})
 
 
 def test_disabled_adapters_are_never_scheduled():

--- a/tests/test_cron_schedule.py
+++ b/tests/test_cron_schedule.py
@@ -1,0 +1,165 @@
+"""The cron schedule must stay in step with the adapters that exist."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from every_eval_ever.cron.schedule import (
+    CRON_ADAPTERS,
+    EXCLUDED_ADAPTERS,
+    RAW_DIR_PLACEHOLDER,
+    CronAdapter,
+    RawPolicy,
+    adapter_directories,
+    get_adapter,
+    scheduled_adapters,
+)
+
+ADAPTERS_ROOT = (
+    Path(__file__).resolve().parent.parent / 'every_eval_ever' / 'adapters'
+)
+
+
+def test_every_adapter_is_either_scheduled_or_excluded_with_a_reason():
+    accounted = {adapter.name for adapter in CRON_ADAPTERS} | set(
+        EXCLUDED_ADAPTERS
+    )
+    unaccounted = adapter_directories() - accounted
+    assert not unaccounted, (
+        'these adapters are neither scheduled nor excluded: '
+        f'{sorted(unaccounted)}. Add them to CRON_ADAPTERS, or to '
+        'EXCLUDED_ADAPTERS with the reason a daily refresh cannot run them.'
+    )
+
+
+def test_schedule_and_exclusions_do_not_overlap():
+    scheduled = {adapter.name for adapter in CRON_ADAPTERS}
+    assert not scheduled & set(EXCLUDED_ADAPTERS)
+
+
+def test_scheduled_and_excluded_names_exist_as_adapters():
+    known = adapter_directories()
+    named = {adapter.name for adapter in CRON_ADAPTERS} | set(EXCLUDED_ADAPTERS)
+    assert not named - known, f'no such adapter: {sorted(named - known)}'
+
+
+def test_every_exclusion_states_a_reason():
+    for name, reason in EXCLUDED_ADAPTERS.items():
+        assert reason.strip(), f'{name} is excluded without a reason'
+
+
+def test_adapter_names_are_unique():
+    names = [adapter.name for adapter in CRON_ADAPTERS]
+    assert len(names) == len(set(names))
+
+
+def test_every_adapter_module_resolves_to_a_file():
+    for adapter in CRON_ADAPTERS:
+        module_path = ADAPTERS_ROOT / adapter.name / 'adapter.py'
+        assert module_path.is_file(), f'{adapter.module} does not exist'
+
+
+def test_flag_archived_adapters_declare_raw_arguments():
+    for adapter in CRON_ADAPTERS:
+        declares_flag = adapter.raw_policy is RawPolicy.VIA_ADAPTER_FLAG
+        assert declares_flag == bool(adapter.raw_args), (
+            f'{adapter.name}: raw policy {adapter.raw_policy.value} and '
+            f'raw_args {adapter.raw_args} disagree'
+        )
+        for argument in adapter.raw_args:
+            if argument.startswith('--'):
+                continue
+            assert RAW_DIR_PLACEHOLDER in argument, (
+                f'{adapter.name} writes raw data to a fixed path {argument!r}; '
+                f'use {RAW_DIR_PLACEHOLDER} so it lands in the run directory'
+            )
+
+
+def test_every_adapter_has_at_least_one_invocation():
+    for adapter in CRON_ADAPTERS:
+        assert adapter.runs, f'{adapter.name} declares no invocation'
+
+
+def test_disabled_adapters_explain_themselves():
+    for adapter in CRON_ADAPTERS:
+        if not adapter.enabled:
+            assert adapter.notes.strip(), (
+                f'{adapter.name} is disabled without saying why'
+            )
+
+
+def test_argv_substitutes_the_raw_directory():
+    adapter = CronAdapter(
+        name='vals_ai',
+        raw_policy=RawPolicy.VIA_ADAPTER_FLAG,
+        raw_args=('--save-raw-json', f'{RAW_DIR_PLACEHOLDER}/vals-ai.json'),
+    )
+    argv = adapter.argv_for(('--benchmark', 'finance'), '/tmp/run/raw')
+    assert argv == [
+        '-m',
+        'every_eval_ever.adapters.vals_ai.adapter',
+        '--benchmark',
+        'finance',
+        '--save-raw-json',
+        '/tmp/run/raw/vals-ai.json',
+    ]
+
+
+def test_unknown_adapter_names_the_registered_ones():
+    with pytest.raises(KeyError, match='unknown cron adapter'):
+        get_adapter('not_an_adapter')
+
+
+def test_excluded_adapter_reports_why_it_is_excluded():
+    name = next(iter(EXCLUDED_ADAPTERS))
+    with pytest.raises(KeyError, match='excluded from the cron'):
+        get_adapter(name)
+
+
+def test_scheduling_skips_adapters_missing_credentials():
+    runnable, skipped = scheduled_adapters({})
+    needs_credentials = {
+        adapter.name
+        for adapter in CRON_ADAPTERS
+        if adapter.requires_env and adapter.enabled
+    }
+    assert needs_credentials
+    assert not needs_credentials & {adapter.name for adapter in runnable}
+    reasons = {adapter.name: reason for adapter, reason in skipped}
+    for name in needs_credentials:
+        assert 'missing environment' in reasons[name]
+
+
+def test_scheduling_includes_a_credentialed_adapter_once_configured():
+    adapter = next(
+        item for item in CRON_ADAPTERS if item.requires_env and item.enabled
+    )
+    environment = {name: 'token' for name in adapter.requires_env}
+    runnable, _ = scheduled_adapters(environment)
+    assert adapter.name in {item.name for item in runnable}
+
+
+def test_blank_credentials_count_as_missing():
+    adapter = next(
+        item for item in CRON_ADAPTERS if item.requires_env and item.enabled
+    )
+    environment = {name: '   ' for name in adapter.requires_env}
+    runnable, _ = scheduled_adapters(environment)
+    assert adapter.name not in {item.name for item in runnable}
+
+
+def test_disabled_adapters_are_never_scheduled():
+    disabled = {
+        adapter.name for adapter in CRON_ADAPTERS if not adapter.enabled
+    }
+    runnable, skipped = scheduled_adapters(
+        {
+            name: 'token'
+            for adapter in CRON_ADAPTERS
+            for name in adapter.requires_env
+        }
+    )
+    assert not disabled & {adapter.name for adapter in runnable}
+    assert disabled <= {adapter.name for adapter, _ in skipped}

--- a/tests/test_cron_stamp.py
+++ b/tests/test_cron_stamp.py
@@ -1,0 +1,252 @@
+"""Cron records must be identifiable as cron records, and still validate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import every_eval_ever.eval_types as ET
+from every_eval_ever.cron.stamp import (
+    ADAPTER_KEY,
+    CRON_ADDITION_TYPE,
+    INFERRED_MODEL_FIELDS,
+    RUN_DATE_KEY,
+    RUN_URL_KEY,
+    TYPE_OF_ADDITION_KEY,
+    UNKNOWN,
+    UNKNOWN_FIELDS_KEY,
+    StampConflict,
+    aggregate_records,
+    stamp_file,
+    stamp_payload,
+    stamp_tree,
+)
+from every_eval_ever.helpers import SCHEMA_VERSION, save_evaluation_log
+from every_eval_ever.validate import validate_file
+
+RUN_DATE = '2026-08-11'
+
+
+def _log(
+    *,
+    model_details: dict[str, str] | None = None,
+    source_details: dict[str, str] | None = None,
+    model_id: str = 'dev/model',
+) -> ET.EvaluationLog:
+    return ET.EvaluationLog(
+        schema_version=SCHEMA_VERSION,
+        evaluation_id=f'src/{model_id}/1700000000.0',
+        retrieved_timestamp='1700000000.0',
+        source_metadata=ET.SourceMetadata(
+            source_name='Example Leaderboard',
+            source_type='documentation',
+            source_organization_name='Example',
+            evaluator_relationship='third_party',
+            additional_details=source_details,
+        ),
+        eval_library=ET.EvalLibrary(name='unknown', version='unknown'),
+        model_info=ET.ModelInfo(
+            name='model',
+            id=model_id,
+            developer='dev',
+            additional_details=model_details
+            if model_details is not None
+            else {
+                'deployment_type': 'externally_managed',
+                'model_availability': 'closed_weights',
+            },
+        ),
+        evaluation_results=[
+            ET.EvaluationResult(
+                evaluation_name='example',
+                source_data=ET.SourceDataUrl(
+                    dataset_name='example-collection',
+                    source_type='url',
+                    url=['https://example.invalid/leaderboard'],
+                ),
+                metric_config=ET.MetricConfig(
+                    metric_name='accuracy',
+                    lower_is_better=False,
+                    score_type=ET.ScoreType.continuous,
+                    min_score=0.0,
+                    max_score=1.0,
+                ),
+                score_details=ET.ScoreDetails(score=0.5),
+            )
+        ],
+    )
+
+
+def _write(tmp_path: Path, log: ET.EvaluationLog) -> Path:
+    return save_evaluation_log(
+        log,
+        base_dir=tmp_path / 'data' / 'example-collection',
+        developer=log.model_info.developer,
+        model_name=log.model_info.id.split('/')[-1],
+    )
+
+
+def test_stamp_records_that_the_cron_added_the_record_and_when():
+    stamped, _ = stamp_payload(
+        json.loads(_log().model_dump_json(exclude_none=True)),
+        adapter='vals_ai',
+        run_date=RUN_DATE,
+    )
+    details = stamped['source_metadata']['additional_details']
+    assert details[TYPE_OF_ADDITION_KEY] == CRON_ADDITION_TYPE
+    assert details[RUN_DATE_KEY] == RUN_DATE
+    assert details[ADAPTER_KEY] == 'vals_ai'
+
+
+def test_stamp_values_are_all_strings():
+    # The schema types additional_details as a string map.
+    stamped, _ = stamp_payload(
+        json.loads(_log().model_dump_json(exclude_none=True)),
+        adapter='vals_ai',
+        run_date=RUN_DATE,
+        run_url='https://example.invalid/run/1',
+    )
+    details = stamped['source_metadata']['additional_details']
+    assert all(isinstance(value, str) for value in details.values())
+    assert details[RUN_URL_KEY] == 'https://example.invalid/run/1'
+
+
+def test_stamp_keeps_details_the_adapter_already_recorded():
+    stamped, _ = stamp_payload(
+        json.loads(
+            _log(source_details={'leaderboard_version': '1.2'}).model_dump_json(
+                exclude_none=True
+            )
+        ),
+        adapter='hle',
+        run_date=RUN_DATE,
+    )
+    details = stamped['source_metadata']['additional_details']
+    assert details['leaderboard_version'] == '1.2'
+    assert details[TYPE_OF_ADDITION_KEY] == CRON_ADDITION_TYPE
+
+
+def test_stamped_record_still_validates(tmp_path: Path):
+    path = _write(tmp_path, _log())
+    stamp_file(path, adapter='vals_ai', run_date=RUN_DATE)
+    report = validate_file(path)
+    assert report.valid, report.errors
+
+
+def test_stamp_leaves_the_rest_of_the_record_byte_identical(tmp_path: Path):
+    path = _write(tmp_path, _log())
+    before = json.loads(path.read_text(encoding='utf-8'))
+    stamp_file(path, adapter='vals_ai', run_date=RUN_DATE)
+    after = json.loads(path.read_text(encoding='utf-8'))
+
+    del after['source_metadata']['additional_details']
+    assert after == before
+
+
+def test_stamp_does_not_overwrite_deployment_axes_the_source_stated(
+    tmp_path: Path,
+):
+    path = _write(tmp_path, _log())
+    unknown = stamp_file(path, adapter='vals_ai', run_date=RUN_DATE)
+    details = json.loads(path.read_text(encoding='utf-8'))['model_info'][
+        'additional_details'
+    ]
+    assert unknown == []
+    assert details['deployment_type'] == 'externally_managed'
+    assert details['model_availability'] == 'closed_weights'
+    assert (
+        UNKNOWN_FIELDS_KEY
+        not in (
+            json.loads(path.read_text(encoding='utf-8'))['source_metadata'][
+                'additional_details'
+            ]
+        )
+    )
+
+
+def test_unknown_deployment_axes_are_named_on_the_record():
+    payload = json.loads(_log().model_dump_json(exclude_none=True))
+    payload['model_info']['additional_details'] = {}
+
+    stamped, unknown = stamp_payload(
+        payload, adapter='mt_bench', run_date=RUN_DATE
+    )
+
+    assert unknown == list(INFERRED_MODEL_FIELDS)
+    model_details = stamped['model_info']['additional_details']
+    assert model_details['deployment_type'] == UNKNOWN
+    assert model_details['model_availability'] == UNKNOWN
+    # Recorded on the record itself, so a later fix can find exactly these.
+    source_details = stamped['source_metadata']['additional_details']
+    assert source_details[UNKNOWN_FIELDS_KEY] == (
+        'deployment_type,model_availability'
+    )
+
+
+def test_one_stated_axis_is_not_reported_as_unknown():
+    payload = json.loads(_log().model_dump_json(exclude_none=True))
+    payload['model_info']['additional_details'] = {
+        'model_availability': 'open_weights'
+    }
+
+    stamped, unknown = stamp_payload(
+        payload, adapter='mt_bench', run_date=RUN_DATE
+    )
+
+    assert unknown == ['deployment_type']
+    details = stamped['model_info']['additional_details']
+    assert details['deployment_type'] == UNKNOWN
+    assert details['model_availability'] == 'open_weights'
+
+
+def test_record_with_another_addition_type_is_refused():
+    payload = json.loads(
+        _log(source_details={TYPE_OF_ADDITION_KEY: 'manual'}).model_dump_json(
+            exclude_none=True
+        )
+    )
+    with pytest.raises(StampConflict, match='manual'):
+        stamp_payload(payload, adapter='vals_ai', run_date=RUN_DATE)
+
+
+def test_stamping_an_already_stamped_record_is_stable(tmp_path: Path):
+    path = _write(tmp_path, _log())
+    stamp_file(path, adapter='vals_ai', run_date=RUN_DATE)
+    first = path.read_text(encoding='utf-8')
+    stamp_file(path, adapter='vals_ai', run_date=RUN_DATE)
+    assert path.read_text(encoding='utf-8') == first
+
+
+def test_stamp_tree_covers_every_record_and_counts_unknowns(tmp_path: Path):
+    _write(tmp_path, _log(model_id='dev/first'))
+    _write(
+        tmp_path,
+        _log(model_id='dev/second', model_details={}),
+    )
+
+    summary = stamp_tree(
+        tmp_path / 'data', adapter='vals_ai', run_date=RUN_DATE
+    )
+
+    assert summary.stamped == 2
+    assert summary.unknown_inferred == {
+        'deployment_type': 1,
+        'model_availability': 1,
+    }
+    for path in summary.paths:
+        details = json.loads(path.read_text(encoding='utf-8'))[
+            'source_metadata'
+        ]['additional_details']
+        assert details[TYPE_OF_ADDITION_KEY] == CRON_ADDITION_TYPE
+
+
+def test_sample_companions_are_not_treated_as_aggregates(tmp_path: Path):
+    path = _write(tmp_path, _log())
+    companion = path.with_name(f'{path.stem}_samples.jsonl')
+    companion.write_text('{}\n', encoding='utf-8')
+
+    found = aggregate_records(tmp_path / 'data')
+
+    assert found == [path]

--- a/tests/test_cron_stamp.py
+++ b/tests/test_cron_stamp.py
@@ -250,3 +250,25 @@ def test_sample_companions_are_not_treated_as_aggregates(tmp_path: Path):
     found = aggregate_records(tmp_path / 'data')
 
     assert found == [path]
+
+
+def test_a_companion_named_with_a_json_extension_is_not_an_aggregate(
+    tmp_path: Path,
+):
+    # Recognised by the `_samples` stem, not the extension, so widening the glob
+    # to '*.json*' cannot start pulling companions into the stamp.
+    path = _write(tmp_path, _log())
+    companion = path.with_name(f'{path.stem}_samples.json')
+    companion.write_text('{}\n', encoding='utf-8')
+
+    assert aggregate_records(tmp_path / 'data') == [path]
+
+
+def test_stamping_a_tree_leaves_companions_untouched(tmp_path: Path):
+    path = _write(tmp_path, _log())
+    companion = path.with_name(f'{path.stem}_samples.jsonl')
+    companion.write_text('{"untouched": true}\n', encoding='utf-8')
+
+    stamp_tree(tmp_path / 'data', adapter='openeval', run_date=RUN_DATE)
+
+    assert companion.read_text(encoding='utf-8') == '{"untouched": true}\n'

--- a/tests/test_cron_workflow.py
+++ b/tests/test_cron_workflow.py
@@ -122,3 +122,20 @@ def test_a_no_op_refresh_does_not_fail_the_job(refresh_job: dict):
 def test_a_partial_refresh_is_annotated(refresh_job: dict):
     scripts = ' '.join(step.get('run', '') for step in refresh_job['steps'])
     assert '::warning' in scripts
+
+
+def test_credentials_are_checked_before_any_adapter_runs(workflow: dict):
+    # The refresh fails closed, so a token that cannot store raw data must be
+    # reported once up front rather than by every adapter failing at the end.
+    steps = workflow['jobs']['plan']['steps']
+    names = [step.get('name', '') for step in steps]
+    preflight = next(
+        index
+        for index, step in enumerate(steps)
+        if 'preflight' in step.get('run', '')
+    )
+    plan = next(
+        index for index, step in enumerate(steps) if step.get('id') == 'plan'
+    )
+    assert preflight < plan, f'preflight must run before planning: {names}'
+    assert 'HF_TOKEN' in steps[preflight]['env']

--- a/tests/test_cron_workflow.py
+++ b/tests/test_cron_workflow.py
@@ -75,26 +75,27 @@ def test_the_daily_run_is_not_serialised_behind_one_adapter(refresh_job: dict):
     assert refresh_job['strategy'].get('max-parallel', 2) > 1
 
 
-def test_reports_are_uploaded_even_when_the_refresh_fails(refresh_job: dict):
+def test_the_summary_is_uploaded_even_when_the_refresh_fails(
+    refresh_job: dict,
+):
     upload = next(
         step
         for step in refresh_job['steps']
         if str(step.get('uses', '')).startswith('actions/upload-artifact')
     )
     assert upload['if'] == 'always()'
-    paths = upload['with']['path']
-    assert 'adapter_reports/' in paths
-    assert 'summary.json' in paths
+    assert 'summary.json' in upload['with']['path']
 
 
-def test_raw_payloads_never_reach_a_public_artifact(refresh_job: dict):
-    # Artifacts on a public repository are downloadable by anyone signed in;
-    # raw source bodies belong solely in the private raw dataset.
+def test_no_raw_data_reaches_a_public_artifact(refresh_job: dict):
+    # Artifacts on a public repository are downloadable by anyone signed in.
+    # Raw bodies AND adapter failure reports (which embed raw source rows)
+    # belong solely in the private raw dataset.
     for step in refresh_job['steps']:
         if str(step.get('uses', '')).startswith('actions/upload-artifact'):
-            assert '/raw' not in step['with']['path'], (
-                'the artifact must not include captured raw payloads'
-            )
+            paths = step['with']['path']
+            assert '/raw' not in paths
+            assert 'adapter_reports' not in paths
 
 
 def test_two_publishes_of_one_adapter_never_run_at_once(refresh_job: dict):
@@ -177,22 +178,22 @@ def test_every_declared_adapter_credential_reaches_the_command_steps(
     from every_eval_ever.cron.schedule import CRON_ADAPTERS
 
     plan_steps = workflow['jobs']['plan']['steps']
-    plan_env = next(
-        step
-        for step in plan_steps
-        if 'every_eval_ever.cron list' in step.get('run', '')
+    preflight_env = next(
+        step for step in plan_steps if 'cron preflight' in step.get('run', '')
     )['env']
     refresh_env = _refresh_step(workflow['jobs']['refresh'])['env']
     for adapter in CRON_ADAPTERS:
         for name in adapter.requires_env:
-            assert name in plan_env, (
-                f'{adapter.name} requires {name}; the plan step must see it '
-                'to know the adapter is credentialed'
+            assert name in preflight_env, (
+                f'{adapter.name} requires {name}; preflight must see it to '
+                'report credential coverage'
             )
             assert name in refresh_env, (
                 f'{adapter.name} requires {name}; the refresh step must '
                 'receive it (scoped to matrix.adapter)'
             )
+            # Scoped: only the matching matrix job receives the key.
+            assert 'matrix.adapter ==' in refresh_env[name]
 
 
 def test_secrets_are_scoped_away_from_non_command_steps(workflow: dict):

--- a/tests/test_cron_workflow.py
+++ b/tests/test_cron_workflow.py
@@ -107,16 +107,49 @@ def test_the_plan_job_feeds_the_matrix(workflow: dict):
     assert workflow['jobs']['refresh']['needs'] == 'plan'
 
 
+def _refresh_step(refresh_job: dict) -> dict:
+    return next(
+        step
+        for step in refresh_job['steps']
+        if 'every_eval_ever.cron run' in step.get('run', '')
+    )
+
+
 def test_a_no_op_refresh_does_not_fail_the_job(refresh_job: dict):
-    # The runner exits 2 when the source had not moved. The default shell is
+    # The runner exits 3 when the source had not moved. The default shell is
     # `bash -e`, which would abort the step before that code could be read, so
     # errexit has to be off around the call.
-    step = next(
-        step for step in refresh_job['steps'] if step.get('id') == 'refresh'
-    )
-    script = step['run']
+    script = _refresh_step(refresh_job)['run']
     assert 'set +e' in script
     assert 'code=$?' in script
+    assert '-ne 3' in script
+
+
+def test_a_usage_error_fails_the_job(refresh_job: dict):
+    # Argparse exits 2 on a bad flag. If 2 were the nothing-new code, a flag
+    # typo would silently disable the whole cron while every job stayed green.
+    from every_eval_ever.cron import runner
+
+    assert runner.EXIT_NOTHING_NEW != 2
+    script = _refresh_step(refresh_job)['run']
+    assert str(runner.EXIT_NOTHING_NEW) in script
+    assert '-ne 2' not in script
+
+
+def test_every_declared_adapter_credential_reaches_the_jobs(workflow: dict):
+    # requires_env in the schedule and the workflow env block drift silently:
+    # a secret named in one but not the other means an adapter is planned and
+    # then skipped forever as 'missing environment'.
+    from every_eval_ever.cron.schedule import CRON_ADAPTERS
+
+    env = workflow.get('env', {})
+    for adapter in CRON_ADAPTERS:
+        for name in adapter.requires_env:
+            assert name in env, (
+                f'{adapter.name} requires {name}, but the workflow-level env '
+                'block does not pass it; add it there (tests cannot check the '
+                'GitHub secret itself)'
+            )
 
 
 def test_a_partial_refresh_is_annotated(refresh_job: dict):
@@ -138,4 +171,5 @@ def test_credentials_are_checked_before_any_adapter_runs(workflow: dict):
         index for index, step in enumerate(steps) if step.get('id') == 'plan'
     )
     assert preflight < plan, f'preflight must run before planning: {names}'
-    assert 'HF_TOKEN' in steps[preflight]['env']
+    # Credentials come from the workflow-level env block.
+    assert 'HF_TOKEN' in workflow.get('env', {})

--- a/tests/test_cron_workflow.py
+++ b/tests/test_cron_workflow.py
@@ -75,7 +75,7 @@ def test_the_daily_run_is_not_serialised_behind_one_adapter(refresh_job: dict):
     assert refresh_job['strategy'].get('max-parallel', 2) > 1
 
 
-def test_raw_data_is_uploaded_even_when_the_refresh_fails(refresh_job: dict):
+def test_reports_are_uploaded_even_when_the_refresh_fails(refresh_job: dict):
     upload = next(
         step
         for step in refresh_job['steps']
@@ -83,16 +83,38 @@ def test_raw_data_is_uploaded_even_when_the_refresh_fails(refresh_job: dict):
     )
     assert upload['if'] == 'always()'
     paths = upload['with']['path']
-    assert 'raw/' in paths
     assert 'adapter_reports/' in paths
     assert 'summary.json' in paths
 
 
-def test_two_refreshes_never_run_at_once(workflow: dict):
-    concurrency = workflow['concurrency']
-    assert concurrency['group']
+def test_raw_payloads_never_reach_a_public_artifact(refresh_job: dict):
+    # Artifacts on a public repository are downloadable by anyone signed in;
+    # raw source bodies belong solely in the private raw dataset.
+    for step in refresh_job['steps']:
+        if str(step.get('uses', '')).startswith('actions/upload-artifact'):
+            assert '/raw' not in step['with']['path'], (
+                'the artifact must not include captured raw payloads'
+            )
+
+
+def test_two_publishes_of_one_adapter_never_run_at_once(refresh_job: dict):
+    # Scoped to the job and keyed by adapter: a workflow-wide group would
+    # serialize unrelated adapters AND silently replace an older pending run
+    # (GitHub keeps one pending item per group).
+    assert 'concurrency' not in refresh_job.get('strategy', {})
+    concurrency = refresh_job['concurrency']
+    assert 'matrix.adapter' in concurrency['group']
+    assert 'concurrency' not in refresh_job.get('workflow', {})
     # Cancelling mid-refresh could abandon a half-committed pull request.
     assert concurrency['cancel-in-progress'] is False
+
+
+def test_dry_runs_do_not_queue_behind_publishes(refresh_job: dict):
+    assert 'dry_run' in refresh_job['concurrency']['group']
+
+
+def test_no_workflow_wide_concurrency_group(workflow: dict):
+    assert 'concurrency' not in workflow
 
 
 def test_the_workflow_asks_for_no_write_access_to_the_repository(
@@ -136,20 +158,54 @@ def test_a_usage_error_fails_the_job(refresh_job: dict):
     assert '-ne 2' not in script
 
 
-def test_every_declared_adapter_credential_reaches_the_jobs(workflow: dict):
-    # requires_env in the schedule and the workflow env block drift silently:
-    # a secret named in one but not the other means an adapter is planned and
+def test_no_secrets_at_workflow_scope(workflow: dict):
+    # Workflow-level env hands every secret to checkout, setup, install and
+    # artifact steps that have no business seeing them.
+    for name, value in workflow.get('env', {}).items():
+        assert 'secrets.' not in str(value), (
+            f'workflow-level env {name} references a secret; scope it to the '
+            'command steps that use it'
+        )
+
+
+def test_every_declared_adapter_credential_reaches_the_command_steps(
+    workflow: dict,
+):
+    # requires_env in the schedule and the step env blocks drift silently: a
+    # secret named in one but not the other means an adapter is planned and
     # then skipped forever as 'missing environment'.
     from every_eval_ever.cron.schedule import CRON_ADAPTERS
 
-    env = workflow.get('env', {})
+    plan_steps = workflow['jobs']['plan']['steps']
+    plan_env = next(
+        step
+        for step in plan_steps
+        if 'every_eval_ever.cron list' in step.get('run', '')
+    )['env']
+    refresh_env = _refresh_step(workflow['jobs']['refresh'])['env']
     for adapter in CRON_ADAPTERS:
         for name in adapter.requires_env:
-            assert name in env, (
-                f'{adapter.name} requires {name}, but the workflow-level env '
-                'block does not pass it; add it there (tests cannot check the '
-                'GitHub secret itself)'
+            assert name in plan_env, (
+                f'{adapter.name} requires {name}; the plan step must see it '
+                'to know the adapter is credentialed'
             )
+            assert name in refresh_env, (
+                f'{adapter.name} requires {name}; the refresh step must '
+                'receive it (scoped to matrix.adapter)'
+            )
+
+
+def test_secrets_are_scoped_away_from_non_command_steps(workflow: dict):
+    for job_name, job in workflow['jobs'].items():
+        for step in job['steps']:
+            runs_cron = 'every_eval_ever' in step.get('run', '')
+            if runs_cron:
+                continue
+            for name, value in step.get('env', {}).items():
+                assert 'secrets.' not in str(value), (
+                    f'{job_name} step {step.get("name", step.get("uses"))} '
+                    f'receives secret env {name} but runs no cron command'
+                )
 
 
 def test_a_partial_refresh_is_annotated(refresh_job: dict):
@@ -171,5 +227,5 @@ def test_credentials_are_checked_before_any_adapter_runs(workflow: dict):
         index for index, step in enumerate(steps) if step.get('id') == 'plan'
     )
     assert preflight < plan, f'preflight must run before planning: {names}'
-    # Credentials come from the workflow-level env block.
-    assert 'HF_TOKEN' in workflow.get('env', {})
+    # The preflight command step itself carries the token, scoped to it.
+    assert 'HF_TOKEN' in steps[preflight]['env']

--- a/tests/test_cron_workflow.py
+++ b/tests/test_cron_workflow.py
@@ -1,0 +1,124 @@
+"""The daily workflow must isolate adapters from each other.
+
+These assertions are the reason the cron can be trusted to keep going: one
+source failing, hanging, or producing nothing must not cost the others their
+refresh. They are checked here because a YAML regression is silent otherwise —
+it only shows up as a day of missing data.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parent.parent
+    / '.github'
+    / 'workflows'
+    / 'adapter_cron.yml'
+)
+
+#: GitHub cancels any job still running after six hours.
+JOB_CEILING_MINUTES = 360
+
+
+@pytest.fixture(scope='module')
+def workflow() -> dict:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding='utf-8'))
+
+
+@pytest.fixture(scope='module')
+def refresh_job(workflow: dict) -> dict:
+    return workflow['jobs']['refresh']
+
+
+def test_the_workflow_runs_daily(workflow: dict):
+    # PyYAML reads a bare `on:` key as the boolean True.
+    triggers = workflow[True]
+    schedules = triggers['schedule']
+    assert len(schedules) == 1
+    minute, hour, day, month, weekday = schedules[0]['cron'].split()
+    assert (day, month, weekday) == ('*', '*', '*'), 'not a daily schedule'
+    assert minute.isdigit() and hour.isdigit()
+
+
+def test_the_workflow_can_be_run_by_hand_for_one_adapter(workflow: dict):
+    inputs = workflow[True]['workflow_dispatch']['inputs']
+    assert 'adapter' in inputs
+    assert 'dry_run' in inputs
+
+
+def test_one_job_per_adapter(refresh_job: dict):
+    matrix = refresh_job['strategy']['matrix']
+    assert list(matrix) == ['adapter']
+    assert 'needs.plan.outputs.adapters' in matrix['adapter']
+
+
+def test_a_failing_adapter_does_not_cancel_the_others(refresh_job: dict):
+    # Without this, the first failing source aborts every adapter still queued.
+    assert refresh_job['strategy']['fail-fast'] is False
+
+
+def test_every_adapter_job_has_its_own_bounded_timeout(refresh_job: dict):
+    timeout = refresh_job['timeout-minutes']
+    assert 0 < timeout < JOB_CEILING_MINUTES, (
+        'a per-job timeout below the six-hour ceiling is what stops a hung '
+        'adapter from burning a runner and colliding with the next run'
+    )
+
+
+def test_the_daily_run_is_not_serialised_behind_one_adapter(refresh_job: dict):
+    # max-parallel may be absent (full parallelism); it must not be 1, which
+    # would queue every adapter behind the slowest one before it.
+    assert refresh_job['strategy'].get('max-parallel', 2) > 1
+
+
+def test_raw_data_is_uploaded_even_when_the_refresh_fails(refresh_job: dict):
+    upload = next(
+        step
+        for step in refresh_job['steps']
+        if str(step.get('uses', '')).startswith('actions/upload-artifact')
+    )
+    assert upload['if'] == 'always()'
+    paths = upload['with']['path']
+    assert 'raw/' in paths
+    assert 'adapter_reports/' in paths
+    assert 'summary.json' in paths
+
+
+def test_two_refreshes_never_run_at_once(workflow: dict):
+    concurrency = workflow['concurrency']
+    assert concurrency['group']
+    # Cancelling mid-refresh could abandon a half-committed pull request.
+    assert concurrency['cancel-in-progress'] is False
+
+
+def test_the_workflow_asks_for_no_write_access_to_the_repository(
+    workflow: dict,
+):
+    assert workflow['permissions'] == {'contents': 'read'}
+
+
+def test_the_plan_job_feeds_the_matrix(workflow: dict):
+    plan = workflow['jobs']['plan']
+    assert 'adapters' in plan['outputs']
+    assert workflow['jobs']['refresh']['needs'] == 'plan'
+
+
+def test_a_no_op_refresh_does_not_fail_the_job(refresh_job: dict):
+    # The runner exits 2 when the source had not moved. The default shell is
+    # `bash -e`, which would abort the step before that code could be read, so
+    # errexit has to be off around the call.
+    step = next(
+        step for step in refresh_job['steps'] if step.get('id') == 'refresh'
+    )
+    script = step['run']
+    assert 'set +e' in script
+    assert 'code=$?' in script
+
+
+def test_a_partial_refresh_is_annotated(refresh_job: dict):
+    scripts = ' '.join(step.get('run', '') for step in refresh_job['steps'])
+    assert '::warning' in scripts

--- a/tests/test_raw_capture.py
+++ b/tests/test_raw_capture.py
@@ -10,13 +10,6 @@ import pytest
 from every_eval_ever.helpers import fetch, raw_capture
 
 
-@pytest.fixture(autouse=True)
-def _forget_recorded_payloads():
-    raw_capture.reset_recorded_state()
-    yield
-    raw_capture.reset_recorded_state()
-
-
 class _Response:
     """The parts of a requests response the fetch helpers use."""
 
@@ -69,16 +62,40 @@ def test_capture_writes_the_body_verbatim_and_records_it(
     assert entry['sha256']
 
 
-def test_capture_filename_is_stable_for_a_url(monkeypatch, tmp_path: Path):
+def test_refetching_identical_bytes_reuses_the_same_file(
+    monkeypatch, tmp_path: Path
+):
     monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
     url = 'https://x.invalid/api/v1/leaderboard.json'
 
-    first = raw_capture.capture_response(url, b'a')
-    raw_capture.reset_recorded_state()
-    second = raw_capture.capture_response(url, b'bb')
+    first = raw_capture.capture_response(url, b'same')
+    second = raw_capture.capture_response(url, b'same')
 
     assert first == second
-    assert second.read_bytes() == b'bb'
+    assert len(raw_capture.read_manifest(tmp_path)) == 1
+
+
+def test_one_url_serving_two_bodies_keeps_both(monkeypatch, tmp_path: Path):
+    # Each manifest row must keep pointing at exactly the bytes it hashed:
+    # overwriting would let the archive store one body under the other's hash.
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+    url = 'https://x.invalid/api/v1/leaderboard.json'
+
+    first = raw_capture.capture_response(url, b'morning')
+    second = raw_capture.capture_response(url, b'evening')
+
+    assert first != second
+    assert first.read_bytes() == b'morning'
+    assert second.read_bytes() == b'evening'
+    rows = raw_capture.read_manifest(tmp_path)
+    assert len(rows) == 2
+    by_file = {row['file']: row['sha256'] for row in rows}
+    import hashlib
+
+    for path in (first, second):
+        assert (
+            by_file[path.name] == hashlib.sha256(path.read_bytes()).hexdigest()
+        )
 
 
 def test_two_urls_sharing_a_last_segment_do_not_collide(
@@ -158,7 +175,6 @@ def test_fingerprint_ignores_when_the_payload_was_retrieved(
     second = tmp_path / 'second'
     for directory in (first, second):
         monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(directory))
-        raw_capture.reset_recorded_state()
         raw_capture.capture_response('https://x.invalid/a.json', b'{"a": 1}')
 
     assert raw_capture.fingerprint(first) == raw_capture.fingerprint(second)
@@ -172,7 +188,6 @@ def test_fingerprint_changes_when_the_payload_changes(
     bodies = [b'{"a": 1}', b'{"a": 2}']
     for directory, body in zip((first, second), bodies):
         monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(directory))
-        raw_capture.reset_recorded_state()
         raw_capture.capture_response('https://x.invalid/a.json', body)
 
     assert raw_capture.fingerprint(first) != raw_capture.fingerprint(second)
@@ -206,7 +221,6 @@ def test_indexing_skips_the_manifest_itself(monkeypatch, tmp_path: Path):
     monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
     raw_capture.capture_response('https://x.invalid/a.json', b'{}')
 
-    raw_capture.reset_recorded_state()
     assert raw_capture.index_unlisted_payloads(tmp_path) == []
 
 
@@ -215,11 +229,11 @@ def test_an_unreadable_ceiling_falls_back_to_the_default(monkeypatch):
     assert raw_capture.max_capture_bytes() == raw_capture.DEFAULT_MAX_BYTES
 
 
-def test_the_same_filename_in_two_directories_is_recorded_in_both(
+def test_the_same_payload_in_two_directories_is_recorded_in_both(
     monkeypatch, tmp_path: Path
 ):
-    # One process can capture into several directories in turn; a payload name
-    # already seen elsewhere must not be skipped for the current directory.
+    # Dedup state lives in each directory's manifest, so one process capturing
+    # into several directories records the payload in each.
     first = tmp_path / 'first'
     second = tmp_path / 'second'
     for directory in (first, second):
@@ -229,6 +243,24 @@ def test_the_same_filename_in_two_directories_is_recorded_in_both(
     assert len(raw_capture.read_manifest(first)) == 1
     assert len(raw_capture.read_manifest(second)) == 1
     assert raw_capture.fingerprint(second) is not None
+
+
+def test_a_cleared_capture_directory_starts_from_an_empty_record(
+    monkeypatch, tmp_path: Path
+):
+    # The regression the manifest-based dedup exists for: clearing and reusing
+    # a directory must not leave phantom memory of the old contents.
+    import shutil
+
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path / 'raw'))
+    raw_capture.capture_response('https://x.invalid/a.json', b'{"a": 1}')
+    shutil.rmtree(tmp_path / 'raw')
+
+    raw_capture.capture_response('https://x.invalid/a.json', b'{"a": 1}')
+
+    rows = raw_capture.read_manifest(tmp_path / 'raw')
+    assert len(rows) == 1
+    assert (tmp_path / 'raw' / rows[0]['file']).is_file()
 
 
 def test_an_adapter_written_dump_is_archived_but_not_fingerprinted(

--- a/tests/test_raw_capture.py
+++ b/tests/test_raw_capture.py
@@ -1,0 +1,276 @@
+"""Raw source payloads are archived when asked, and never break a fetch."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from every_eval_ever.helpers import fetch, raw_capture
+
+
+@pytest.fixture(autouse=True)
+def _forget_recorded_payloads():
+    raw_capture.reset_recorded_state()
+    yield
+    raw_capture.reset_recorded_state()
+
+
+class _Response:
+    """The parts of a requests response the fetch helpers use."""
+
+    def __init__(self, body: bytes, content_type: str = 'application/json'):
+        self.content = body
+        self.text = body.decode('utf-8')
+        self.headers = {'Content-Type': content_type}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self):
+        return json.loads(self.text)
+
+
+def _serve(monkeypatch, body: bytes, content_type='application/json'):
+    def fake_get(url, **kwargs):
+        return _Response(body, content_type)
+
+    monkeypatch.setattr(fetch.requests, 'get', fake_get)
+
+
+def test_nothing_is_captured_when_the_directory_is_not_configured(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.delenv(raw_capture.RAW_CAPTURE_DIR_ENV, raising=False)
+    assert raw_capture.capture_dir() is None
+    assert raw_capture.capture_response('https://x.invalid/a', b'{}') is None
+    assert not list(tmp_path.iterdir())
+
+
+def test_capture_writes_the_body_verbatim_and_records_it(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+    body = b'{"models": [1, 2, 3]}'
+
+    path = raw_capture.capture_response(
+        'https://x.invalid/leaderboard.json',
+        body,
+        content_type='application/json',
+    )
+
+    assert path is not None
+    assert path.read_bytes() == body
+    entry = raw_capture.read_manifest(tmp_path)[0]
+    assert entry['url'] == 'https://x.invalid/leaderboard.json'
+    assert entry['bytes'] == len(body)
+    assert entry['file'] == path.name
+    assert entry['sha256']
+
+
+def test_capture_filename_is_stable_for_a_url(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+    url = 'https://x.invalid/api/v1/leaderboard.json'
+
+    first = raw_capture.capture_response(url, b'a')
+    raw_capture.reset_recorded_state()
+    second = raw_capture.capture_response(url, b'bb')
+
+    assert first == second
+    assert second.read_bytes() == b'bb'
+
+
+def test_two_urls_sharing_a_last_segment_do_not_collide(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+    first = raw_capture.capture_response('https://a.invalid/data.json', b'1')
+    second = raw_capture.capture_response('https://b.invalid/data.json', b'2')
+    assert first != second
+
+
+def test_oversized_payloads_are_reported_rather_than_written(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_MAX_BYTES_ENV, '4')
+
+    path = raw_capture.capture_response('https://x.invalid/big', b'123456')
+
+    assert path is None
+    entry = raw_capture.read_manifest(tmp_path)[0]
+    assert entry['file'] is None
+    assert 'ceiling' in entry['skipped']
+    assert entry['bytes'] == 6
+
+
+def test_a_capture_failure_does_not_break_the_fetch(monkeypatch, tmp_path):
+    # A file where the capture directory should be: writing there must fail.
+    blocked = tmp_path / 'blocked'
+    blocked.write_text('not a directory', encoding='utf-8')
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(blocked))
+    _serve(monkeypatch, b'{"ok": true}')
+
+    assert fetch.fetch_json('https://x.invalid/a.json') == {'ok': True}
+
+
+def test_fetch_json_archives_the_response(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+    _serve(monkeypatch, b'{"rows": []}')
+
+    fetch.fetch_json('https://x.invalid/rows.json')
+
+    entries = raw_capture.read_manifest(tmp_path)
+    assert [entry['url'] for entry in entries] == [
+        'https://x.invalid/rows.json'
+    ]
+
+
+def test_fetch_json_archives_a_body_it_cannot_parse(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+    _serve(monkeypatch, b'not json at all')
+
+    with pytest.raises(fetch.FetchError):
+        fetch.fetch_json('https://x.invalid/broken.json')
+
+    # The evidence for debugging the failure is exactly this payload.
+    entries = raw_capture.read_manifest(tmp_path)
+    assert (tmp_path / entries[0]['file']).read_bytes() == b'not json at all'
+
+
+def test_fetch_csv_archives_the_response(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+    _serve(monkeypatch, b'model,score\ngpt,0.5\n', content_type='text/csv')
+
+    rows = fetch.fetch_csv('https://x.invalid/board.csv')
+
+    assert rows == [{'model': 'gpt', 'score': '0.5'}]
+    assert raw_capture.read_manifest(tmp_path)[0]['bytes'] == 20
+
+
+def test_fingerprint_ignores_when_the_payload_was_retrieved(
+    monkeypatch, tmp_path: Path
+):
+    first = tmp_path / 'first'
+    second = tmp_path / 'second'
+    for directory in (first, second):
+        monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(directory))
+        raw_capture.reset_recorded_state()
+        raw_capture.capture_response('https://x.invalid/a.json', b'{"a": 1}')
+
+    assert raw_capture.fingerprint(first) == raw_capture.fingerprint(second)
+
+
+def test_fingerprint_changes_when_the_payload_changes(
+    monkeypatch, tmp_path: Path
+):
+    first = tmp_path / 'first'
+    second = tmp_path / 'second'
+    bodies = [b'{"a": 1}', b'{"a": 2}']
+    for directory, body in zip((first, second), bodies):
+        monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(directory))
+        raw_capture.reset_recorded_state()
+        raw_capture.capture_response('https://x.invalid/a.json', body)
+
+    assert raw_capture.fingerprint(first) != raw_capture.fingerprint(second)
+
+
+def test_fingerprint_is_none_when_nothing_was_captured(tmp_path: Path):
+    assert raw_capture.fingerprint(tmp_path) is None
+
+
+def test_payloads_written_by_an_adapter_flag_are_indexed(tmp_path: Path):
+    # What --save-raw-json leaves behind: a file, no manifest entry.
+    (tmp_path / 'vals-ai.json').write_bytes(b'{"rows": 2}')
+
+    added = raw_capture.index_unlisted_payloads(tmp_path)
+
+    assert added == ['vals-ai.json']
+    assert raw_capture.read_manifest(tmp_path)[0]['source'] == 'adapter_flag'
+    assert raw_capture.fingerprint(tmp_path) is not None
+
+
+def test_indexing_is_idempotent(tmp_path: Path):
+    (tmp_path / 'vals-ai.json').write_bytes(b'{"rows": 2}')
+    raw_capture.index_unlisted_payloads(tmp_path)
+    fingerprint = raw_capture.fingerprint(tmp_path)
+
+    assert raw_capture.index_unlisted_payloads(tmp_path) == []
+    assert raw_capture.fingerprint(tmp_path) == fingerprint
+
+
+def test_indexing_skips_the_manifest_itself(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+    raw_capture.capture_response('https://x.invalid/a.json', b'{}')
+
+    raw_capture.reset_recorded_state()
+    assert raw_capture.index_unlisted_payloads(tmp_path) == []
+
+
+def test_an_unreadable_ceiling_falls_back_to_the_default(monkeypatch):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_MAX_BYTES_ENV, 'lots')
+    assert raw_capture.max_capture_bytes() == raw_capture.DEFAULT_MAX_BYTES
+
+
+def test_the_same_filename_in_two_directories_is_recorded_in_both(
+    monkeypatch, tmp_path: Path
+):
+    # One process can capture into several directories in turn; a payload name
+    # already seen elsewhere must not be skipped for the current directory.
+    first = tmp_path / 'first'
+    second = tmp_path / 'second'
+    for directory in (first, second):
+        monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(directory))
+        raw_capture.capture_response('https://x.invalid/a.json', b'{"a": 1}')
+
+    assert len(raw_capture.read_manifest(first)) == 1
+    assert len(raw_capture.read_manifest(second)) == 1
+    assert raw_capture.fingerprint(second) is not None
+
+
+def test_an_adapter_written_dump_is_archived_but_not_fingerprinted(
+    tmp_path: Path,
+):
+    # An adapter's own --save-raw-* dump may wrap the payload or stamp it with a
+    # fetch time, so it must not decide whether the source moved.
+    (tmp_path / 'hle.json').write_bytes(b'{"fetched_at": "1", "rows": []}')
+    raw_capture.index_unlisted_payloads(tmp_path)
+
+    assert raw_capture.fingerprint(tmp_path) is not None
+    assert raw_capture.fingerprint(tmp_path, verbatim_only=True) is None
+
+
+def test_verbatim_captures_still_fingerprint_alongside_adapter_dumps(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+    raw_capture.capture_response('https://x.invalid/a.json', b'{"a": 1}')
+    (tmp_path / 'hle.json').write_bytes(b'{"fetched_at": "1"}')
+    raw_capture.index_unlisted_payloads(tmp_path)
+
+    verbatim = raw_capture.fingerprint(tmp_path, verbatim_only=True)
+
+    assert verbatim is not None
+    assert verbatim != raw_capture.fingerprint(tmp_path)
+
+
+def test_a_changed_adapter_dump_does_not_change_the_verbatim_fingerprint(
+    monkeypatch, tmp_path: Path
+):
+    fingerprints = []
+    for stamp in (b'1', b'2'):
+        directory = tmp_path / stamp.decode()
+        monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(directory))
+        raw_capture.capture_response('https://x.invalid/a.json', b'{"a": 1}')
+        (directory / 'hle.json').write_bytes(
+            b'{"fetched_at": "' + stamp + b'"}'
+        )
+        raw_capture.index_unlisted_payloads(directory)
+        fingerprints.append(
+            raw_capture.fingerprint(directory, verbatim_only=True)
+        )
+
+    assert fingerprints[0] == fingerprints[1]

--- a/tests/test_raw_capture.py
+++ b/tests/test_raw_capture.py
@@ -306,3 +306,45 @@ def test_a_changed_adapter_dump_does_not_change_the_verbatim_fingerprint(
         )
 
     assert fingerprints[0] == fingerprints[1]
+
+
+def test_a_capture_failure_leaves_a_durable_error_row(
+    monkeypatch, tmp_path: Path
+):
+    # The warning log dies with the subprocess; the manifest row is what lets
+    # the runner refuse to publish records whose source bytes are missing.
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+
+    def broken(directory, url, body, content_type):
+        raise OSError('disk full')
+
+    monkeypatch.setattr(raw_capture, '_capture', broken)
+    result = raw_capture.capture_response('https://x.invalid/a.json', b'{}')
+
+    assert result is None
+    errors = raw_capture.capture_errors(tmp_path)
+    assert len(errors) == 1
+    assert errors[0]['url'] == 'https://x.invalid/a.json'
+    assert 'disk full' in errors[0]['error']
+    assert errors[0]['file'] is None
+
+
+def test_error_rows_do_not_count_as_captured_payloads(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv(raw_capture.RAW_CAPTURE_DIR_ENV, str(tmp_path))
+    raw_capture.capture_response('https://x.invalid/good.json', b'{"a": 1}')
+
+    def broken(directory, url, body, content_type):
+        raise OSError('disk full')
+
+    monkeypatch.setattr(raw_capture, '_capture', broken)
+    raw_capture.capture_response('https://x.invalid/bad.json', b'{}')
+
+    assert len(raw_capture.capture_errors(tmp_path)) == 1
+    stored = [
+        entry
+        for entry in raw_capture.read_manifest(tmp_path)
+        if entry.get('file')
+    ]
+    assert len(stored) == 1


### PR DESCRIPTION
## What this does

Runs each source adapter once a day and sends its records to that adapter's own
pull request on [`EEE_datastore`](https://huggingface.co/datasets/evaleval/EEE_datastore).

Closes the cron ticket. Design notes live in
[`every_eval_ever/cron/README.md`](every_eval_ever/cron/README.md).

**This is a structural change and a new subsystem, so it belongs in the
"needs a human" lane** — I'm opening it as the concrete proposal to react to, not
as something to fast-track. The four decisions below were pre-agreed with
@evijit before implementation; everything else is up for discussion.

## The four decisions, as agreed

| Decision | Choice |
|---|---|
| Raw data storage | Permanent, in a **separate private HF dataset** with a ledger (revised after @nelaturuharsha's feedback — was artifacts) |
| Daily coverage | Every eligible adapter, one job each |
| Raw capture mechanism | One hook in `helpers/fetch.py`; **no adapter was modified** |
| De-duplication | Skip a run when the source has not changed; no record-level dedup |

## How it works

`every_eval_ever/cron/schedule.py` declares which adapters the cron may run and
how to run each one — adapter CLIs are not uniform, and this records the
differences in one place instead of spreading them through a workflow file.
**17 of 25 adapters are scheduled** now that the API keys are in place. The other 10 are listed with the
reason each is excluded:

- `arc_agi`, `livecodebenchpro`, `mercor_eval` — legacy, upstream unusable
- `bfcl`, `cocoabench`, `sciarena` — need a hand-supplied input file
- `vectara_hallucination_leaderboard` — pinned to `SOURCE_COMMIT`, so a refresh
  is a code change and a daily run could only re-emit identical records
- ~~`artificial_analysis`, `llm_stats` — waiting on API keys~~ → **now enabled**,
  their secrets are in place
- `hfopenllm_v2` — emits >4500 records per run. Enabling it before record-level
  dedup exists would add thousands of near-duplicate files to its PR every time
  the leaderboard moves, which is the problem @nelaturuharsha flagged. One-line
  change to enable once dedup lands.

`runner.py` then runs one adapter end to end: run it into a scratch tree,
archive what it fetched, stamp the records, validate them through the same CLI
the datastore bot runs, and commit.

### Tracking cron-generated records

Every record gets this in `source_metadata.additional_details`:

```json
"type_of_addition": "cron",
"cron_run_date": "2026-08-11",
"cron_adapter": "hle",
"cron_run_url": "https://github.com/evaleval/every_eval_ever/actions/runs/...",
"cron_unknown_inferred_fields": "deployment_type,model_availability"
```

The run URL is there so a record traces back to the exact run whose artifact
holds its raw data.

**On the inferred fields:** the ticket asks for `deployment_type` and
`model_availability` to be marked `unknown/unknown`. That already happens —
`ModelInfo.default_model_metadata` (added by `post_codegen.py`) defaults both.
So the cron does not fill them; it *names* the ones that came out `unknown`, per
record, which is what a post-fix actually needs to find them. It never
overwrites a value an adapter did state.

### Raw data — permanent, with a ledger

`helpers/raw_capture.py` archives response bodies when `EEE_RAW_CAPTURE_DIR` is
set, hooked into `fetch_json`/`fetch_csv`. Because those are the shared helpers,
8 adapters got raw capture with **no adapter changes at all**. Adapters with
their own `--save-raw-*` flag are pointed at the same directory. HF-dataset and
git-cloned sources are deliberately **not** re-archived — upstream already
versions them, which is the "don't download what's already in place" requirement.

Payloads then go to a private dataset of their own — `evaleval/EEE_raw`,
overridable with an `EEE_RAW_REPO_ID` repository variable:

```
blobs/<ab>/<sha256>.<ext>              # one copy per distinct payload, ever
ledger/<adapter>/<date>-<run>.jsonl    # one row per payload per run
```

Payloads are **content-addressed**, so a source that has not changed since
yesterday costs nothing but a ledger row — that is what makes keeping every day
affordable rather than duplicating a leaderboard 365 times a year. The ledger is
a dataset in its own right (`load_dataset('json',
data_files='ledger/**/*.jsonl')`), one row per payload per run carrying the
adapter, run date, run URL, source URL, SHA-256, size and blob path. A row is
written even for a payload too large to store, and even for a run that published
nothing, so it says what was fetched on **every** date rather than only the days
something changed.

Two ordering decisions worth a look:

- **Archive before publish, and fail closed.** If raw data cannot be stored, the
  run stops and publishes nothing. Records should not reach the datastore without
  their provenance stored somewhere permanent.
- **The ledger replaced the Actions cache** as the memory of the previous run's
  fingerprint. With a cache, an eviction would make an adapter forget last
  night's state and republish its entire set — precisely the duplicate flood this
  is meant to prevent. The workflow now has no cache steps at all.

Capture is best-effort and never breaks a fetch, and happens *before* parsing, so
a body that fails to parse is still archived — the smoke run below shows a
27 KB CSV kept from an adapter that then crashed.

### Not republishing unchanged data

A run fingerprints the source and stops if it matches what the *last successful
publish* recorded (`state/<adapter>.json` in the raw dataset — written only
after the datastore commit succeeds, which is what makes a failed publish retry
tomorrow instead of being skipped as "unchanged"). It is **run-level, not record-level**: a run publishes everything it produced or
nothing at all, so no individual record is ever dropped. That keeps the ticket's
"hold off on dedup" while still preventing a daily duplicate flood.

One subtlety worth flagging, because it cost a rewrite: only response bodies
stored *exactly as served* can be compared across runs. `hle`'s own
`--save-raw-json` wraps its payload in a `fetched_at` timestamp and `vals_ai`'s
is a normalized form, so fingerprinting those would report a change every single
day and the skip would never fire. Those adapters are archived-but-gated-on-output
instead. I found this by running it against the live source, not by reading it.

## What guarantees one source can't break another

Asked for explicitly, so it is enforced in three places:

1. **Job level** — one matrix job per adapter with `fail-fast: false`, so a
   failure or a hang is confined to that adapter. Each job has its own 6-hour
   budget and a 120-minute timeout, and `max-parallel: 6` means nothing queues
   behind a slow adapter. (The 6-hour ceiling is *per job*, so the matrix already
   avoids a single chokepoint — the parallelism is what removes the queueing.)
2. **Invocation level** — `helm` runs five leaderboards; one failing does not
   stop the other four, and their records still publish.
3. **Partial conversions** — this fixed a real bug in my first draft. Per
   `adapters/README.md`, an adapter reports a partial conversion by writing every
   valid record and *then* exiting non-zero. Treating non-zero as fatal would
   have thrown away good records. A partial refresh now publishes what converted,
   says so in the commit description, and raises a workflow warning
   annotation.

`tests/test_cron_workflow.py` asserts these workflow properties, because a YAML
regression here is silent — it shows up as a day of missing data.

## Verification

555 tests pass, `ruff check` clean. 186 new tests across schedule, stamping, raw
capture, archiving, publishing, preflight, the runner, and the workflow. No test
can reach the Hub, and the runner tests share a per-test state store between
consecutive refreshes instead of stubbing the change gate — stubbing the gate is
exactly what let the v3 gating bugs ship.

Smoke-tested against live sources with `--dry-run`:

| Adapter | Result |
|---|---|
| `terminal_bench_2` | 142 records, 0 errors, 0 warnings, 562 KB raw archived |
| `hle` | 50 records, 0 errors, 0 warnings, 27 KB raw archived |
| `hle` (second run) | `unchanged` — published nothing, as intended |
| `mmlu_pro` | Failed, correctly (see below) |

The `mmlu_pro` failure is a **pre-existing adapter bug this surfaced**, not
something in this PR: a leaderboard row has the model name
`seed-oss-36b-base-w-syn.`, and a trailing dot is rejected by
`_required_path_component`. The cron reported it, archived the raw CSV anyway,
and correctly classified the run as failed. Worth its own issue.

## What this does not solve

Stated plainly, since the ticket framed this as an MVP:

- **No record-level dedup.** Records accumulate in each adapter's PR until
  someone merges it. This is why `hfopenllm_v2` stays off.
- **3 adapters archive no raw data** (`hal`, `lexam`, `mt_bench`) — they call
  `requests` directly with no raw-dump flag. They are gated on output instead, so
  they still will not republish unchanged records.
- **The workflow installs `--all-extras`** because three adapters need
  `datasets`, which reaches the lock only via the `helm` extra. A dedicated
  `cron` extra would be lighter, but that needs a `uv.lock` regeneration I could
  not do here.

## Before this can run for real

- [x] `ARTIFICIAL_ANALYSIS_API_KEY` and `LLM_STATS_API_KEY` — added, so both
      adapters are now scheduled
- [x] `HF_TOKEN` — present
- [ ] **Confirm `HF_TOKEN` has the access this needs**: write on
      `EEE_datastore`, plus permission to create/write the private raw dataset.
      Worth an explicit check because the token predates this PR
      (last updated 2026-02-05) and there is also an `EEE_INGESTION_HF_TOKEN`
      secret that may be the intended one — say the word and I will switch to it.
      `uv run python -m every_eval_ever.cron preflight` answers this in one call,
      and the workflow runs it before planning.
- [ ] Merge this, since a `workflow_dispatch` only becomes available once the
      workflow exists on the default branch
- [ ] Then: dispatch with `dry_run: true` on one adapter, check the step summary,
      and only after that let the schedule run

### Verification still owed

`artificial_analysis` and `llm_stats` are the only scheduled adapters I have not
smoke-tested end to end — I never had their keys locally, and a dry run cannot
reach them. They are also two of the five that will *not* fall back to an output
fingerprint, since they fetch through `helpers.fetch` and so get a verbatim
capture. First real run for those two is worth watching.

### Revision history

- **v5** — review-anvil round 3 (all round-2 findings confirmed fixed upstream).
  Adapter subprocesses no longer receive the cron's write-capable HF token
  (scrubbed from the child env; an explicit `source_hf_token` + separate
  `EEE_SOURCE_HF_TOKEN` read token exists for sources that need authenticated
  reads). Mid-batch publish failures are retry-safe: an attempt record written
  before the first batch lets the next run delete the dead attempt's files from
  the PR and republish one clean copy. Capture-failure evidence (sibling
  captures, error rows, failure reports) is archived *before* the run fails.
  Adapter failure reports — which embed raw source rows — moved from the public
  artifact into the private dataset (`reports/<adapter>/…`); the artifact now
  carries only `summary.json`. An enabled adapter missing its credential fails
  its own job instead of silently vanishing from the matrix. A state write that
  fails after retry returns non-zero with the PR URL kept in the summary.

- **v4** — a full 8-angle review pass plus @mrshu's review-anvil findings. The
  big one: the change gate was broken three ways (a run compared against the
  ledger row it had just written; zero-capture adapters never persisted a
  fingerprint; a failed publish poisoned the next day's gate). The gate now
  reads per-adapter state written only after a successful publish. Also fixed:
  capture filenames are content-addressed so one URL serving two bodies cannot
  corrupt the blob store; a public raw dataset fails preflight **and** every
  archive commit re-verifies privacy; PR adoption is filtered by author so a
  stranger's identically-titled PR is never committed onto; the PR-creating
  commit carries the bare title (a batch suffix would have retitled the PR and
  opened a fresh one daily for >300-file adapters); nothing-new exits 3, not 2,
  so an argparse usage error can never read as a quiet success; plus the reuse/
  efficiency items (validator-shared record canonicalization, one shared record
  serializer, batched blob existence checks, dead code removed).

- **v3** — added a `preflight` command, run ahead of planning, after the API
  keys landed: it checks token identity, both destinations, and per-adapter
  credentials. It also covers a gap — a `--dry-run` refresh does not archive, so
  nothing else exercised raw-dataset access without publishing.
- **v2** — raw data moved from workflow artifacts to a permanent private dataset
  with a content-addressed store and a ledger, per @nelaturuharsha. The ledger
  also replaced the Actions cache for fingerprint memory. Artifacts remain as a
  90-day convenience copy of the reports, not as retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
