### PR TITLE
Fix LLM Stats and MMLU-Pro scheduled ingestion

### DIFF
--- a/every_eval_ever/adapters/llm_stats/adapter.py
+++ b/every_eval_ever/adapters/llm_stats/adapter.py
@@ -66,6 +66,8 @@ DEFAULT_OUTPUT_DIR = 'data/llm-stats'
 AA_OMNISCIENCE_BENCHMARK_ID = 'aa-omniscience-index'
 AA_OMNISCIENCE_MIN_SCORE = -100.0
 AA_OMNISCIENCE_MAX_SCORE = 100.0
+VENDING_BENCH_2_BENCHMARK_ID = 'vending-bench-2'
+VENDING_BENCH_2_SCALE_URL = 'https://andonlabs.com/evals/vending-bench-2'
 COMMUNITY_LEADERBOARD_EXCLUSION_REASON = (
     'community dataset leaderboard requires the separate '
     '/v1/dataset-leaderboards API and is not supported by this adapter yet'
@@ -1528,6 +1530,25 @@ def metric_bounds_and_unit(
             'aa_omniscience_signed_scale',
         )
 
+    if normalize_slug(benchmark_source_id(benchmark)) == (
+        VENDING_BENCH_2_BENCHMARK_ID
+    ):
+        if score_value < 0:
+            raise ValueError(
+                'Vending-Bench 2 final bank balance must be non-negative; '
+                f'got {score_value}'
+            )
+        # The benchmark owner defines the score as the final bank balance in
+        # dollars and explicitly documents that the benchmark has no ceiling.
+        # LLM Stats currently advertises max_score=1 for this benchmark, which
+        # is incompatible with its own dollar-valued source rows.
+        return (
+            0.0,
+            float('inf'),
+            'usd',
+            'vending_bench_2_unbounded_dollars',
+        )
+
     if min_score is not None and max_score is not None:
         if score_value > max_score and max_score == 1.0 and score_value <= 100:
             return 0.0, 100.0, 'percent', 'inferred_percent_from_score'
@@ -1648,10 +1669,26 @@ def make_metric_details(
         'raw_score_field': raw_score_field,
         'bound_strategy': bound_strategy,
     }
+    raw_min_score = first_present(
+        benchmark,
+        ('min_score', 'minScore', 'minimum_score', 'minimumScore', 'min'),
+    )
+    raw_max_score = first_present(
+        benchmark,
+        ('max_score', 'maxScore', 'maximum_score', 'maximumScore', 'max'),
+    )
+    if raw_min_score not in (None, ''):
+        details['raw_min_score'] = raw_min_score
+    if raw_max_score not in (None, ''):
+        details['raw_max_score'] = raw_max_score
     for key in BENCHMARK_DETAIL_KEYS:
         value = first_present(benchmark, (key,))
         if value not in (None, ''):
             details[f'raw_{normalize_slug(key).replace("-", "_")}'] = value
+    if normalize_slug(benchmark_source_id(benchmark)) == (
+        VENDING_BENCH_2_BENCHMARK_ID
+    ):
+        details['canonical_scale_source_url'] = VENDING_BENCH_2_SCALE_URL
     return stringify_details(details)
 
 

--- a/every_eval_ever/adapters/llm_stats/adapter.py
+++ b/every_eval_ever/adapters/llm_stats/adapter.py
@@ -44,6 +44,7 @@ from every_eval_ever.helpers import (
     EvaluationLogOutput,
     FetchError,
     SourceConversionResult,
+    SourceRecordExclusion,
     SourceRecordFailure,
     default_failure_report_path,
     fetch_json,
@@ -62,6 +63,13 @@ DEFAULT_BASE_URL = 'https://api.llm-stats.com'
 ATTRIBUTION_URL = 'https://llm-stats.com/'
 DEVELOPER_PAGE_URL = 'https://llm-stats.com/developer'
 DEFAULT_OUTPUT_DIR = 'data/llm-stats'
+AA_OMNISCIENCE_BENCHMARK_ID = 'aa-omniscience-index'
+AA_OMNISCIENCE_MIN_SCORE = -100.0
+AA_OMNISCIENCE_MAX_SCORE = 100.0
+COMMUNITY_LEADERBOARD_EXCLUSION_REASON = (
+    'community dataset leaderboard requires the separate '
+    '/v1/dataset-leaderboards API and is not supported by this adapter yet'
+)
 
 RELATIONSHIP_VALUES = {item.value for item in EvaluatorRelationship}
 
@@ -378,11 +386,18 @@ def fetch_payload(api_key: str, base_url: str) -> dict[str, Any]:
     )
 
     source_failures: list[SourceRecordFailure] = []
+    source_exclusions: list[SourceRecordExclusion] = []
     try:
         scores = fetch_json(api_url(base_url, '/v1/scores'), headers=headers)
+        source_record_count = len(extract_collection(scores, 'scores'))
     except FetchError:
+        benchmark_rows = extract_collection(benchmarks, 'benchmarks')
+        standard_benchmarks, source_exclusions = partition_community_benchmarks(
+            benchmark_rows
+        )
+        source_record_count = len(benchmark_rows)
         scores, source_failures = fetch_benchmark_score_payloads(
-            extract_collection(benchmarks, 'benchmarks'),
+            standard_benchmarks,
             base_url,
             headers,
         )
@@ -397,7 +412,41 @@ def fetch_payload(api_key: str, base_url: str) -> dict[str, Any]:
         'source_failures': [
             failure.model_dump() for failure in source_failures
         ],
+        'source_exclusions': [
+            exclusion.model_dump() for exclusion in source_exclusions
+        ],
+        'source_record_count': source_record_count,
     }
+
+
+def partition_community_benchmarks(
+    benchmarks: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[SourceRecordExclusion]]:
+    """Separate dataset leaderboards from standard benchmark summaries."""
+    standard: list[dict[str, Any]] = []
+    exclusions: list[SourceRecordExclusion] = []
+    for index, benchmark in enumerate(benchmarks):
+        is_community = first_present(benchmark, ('is_community', 'isCommunity'))
+        if is_community is True or (
+            isinstance(is_community, str)
+            and is_community.strip().lower() == 'true'
+        ):
+            raw_id = first_present(benchmark, BENCHMARK_ID_KEYS)
+            source_ref = (
+                f'community benchmark {raw_id!r}'
+                if raw_id not in (None, '')
+                else f'community benchmark row {index}'
+            )
+            exclusions.append(
+                SourceRecordExclusion(
+                    source_ref=source_ref,
+                    reason=COMMUNITY_LEADERBOARD_EXCLUSION_REASON,
+                    source_record=benchmark,
+                )
+            )
+        else:
+            standard.append(benchmark)
+    return standard, exclusions
 
 
 def fetch_benchmark_score_payloads(
@@ -1462,12 +1511,56 @@ def metric_bounds_and_unit(
     max_score = parse_float(max_raw)
 
     normalized_unit = normalize_metric_unit(raw_unit)
+    if normalize_slug(benchmark_source_id(benchmark)) == (
+        AA_OMNISCIENCE_BENCHMARK_ID
+    ):
+        if not (
+            AA_OMNISCIENCE_MIN_SCORE <= score_value <= AA_OMNISCIENCE_MAX_SCORE
+        ):
+            raise ValueError(
+                'AA-Omniscience canonical score must be within [-100, 100]; '
+                f'got {score_value}'
+            )
+        return (
+            AA_OMNISCIENCE_MIN_SCORE,
+            AA_OMNISCIENCE_MAX_SCORE,
+            'points',
+            'aa_omniscience_signed_scale',
+        )
+
     if min_score is not None and max_score is not None:
         if score_value > max_score and max_score == 1.0 and score_value <= 100:
             return 0.0, 100.0, 'percent', 'inferred_percent_from_score'
+        if not min_score <= score_value <= max_score:
+            raise ValueError(
+                f'score {score_value} is outside documented benchmark bounds '
+                f'[{min_score}, {max_score}]'
+            )
         if not normalized_unit:
             normalized_unit = 'proportion' if max_score == 1.0 else 'points'
         return min_score, max_score, normalized_unit, 'benchmark_bounds'
+
+    if score_value < 0:
+        raise ValueError(
+            f'negative score {score_value} has no documented adapter-specific '
+            'lower bound'
+        )
+
+    if max_score is not None:
+        if max_score == 1.0 and score_value > max_score and score_value <= 100:
+            return 0.0, 100.0, 'percent', 'inferred_percent_from_score'
+        if max_score <= 0:
+            raise ValueError(
+                f'benchmark max_score must be positive; got {max_score}'
+            )
+        if score_value > max_score:
+            raise ValueError(
+                f'score {score_value} exceeds documented benchmark max_score '
+                f'{max_score}'
+            )
+        if not normalized_unit:
+            normalized_unit = 'proportion' if max_score == 1.0 else 'points'
+        return 0.0, max_score, normalized_unit, 'benchmark_max_with_zero_min'
 
     if normalized_unit == 'percent' or (1.0 < score_value <= 100.0):
         return 0.0, 100.0, 'percent', 'inferred_percent'
@@ -1571,6 +1664,8 @@ def make_score_details(
     raw_score_value: Any,
     raw_unit: str | None,
     urls: list[str],
+    normalized_score_value: Any = None,
+    transformation_strategy: str | None = None,
 ) -> ScoreDetails:
     details: dict[str, Any] = {
         'raw_score': raw_score_value,
@@ -1579,7 +1674,12 @@ def make_score_details(
         'raw_model_id': model_source_id(model),
         'raw_benchmark_id': benchmark_source_id(benchmark),
         'source_urls_json': urls,
+        'transformation_strategy': transformation_strategy,
     }
+    if transformation_strategy is not None:
+        # Preserve an explicit upstream null as ``"null"`` so reviewers can
+        # distinguish it from an adapter that never inspected the field.
+        details['raw_normalized_score'] = stringify(normalized_score_value)
 
     score_id = first_present(score, ('id', 'score_id', 'scoreId'))
     if score_id not in (None, ''):
@@ -1592,13 +1692,73 @@ def make_score_details(
     )
 
 
+def canonical_score_value(
+    score: dict[str, Any],
+    benchmark: dict[str, Any],
+) -> tuple[float | None, str | None, Any, Any, str | None]:
+    """Return the datastore score plus the source fields used to derive it."""
+    value, raw_score_field, raw_score_value = score_value_and_field(score)
+    if normalize_slug(benchmark_source_id(benchmark)) != (
+        AA_OMNISCIENCE_BENCHMARK_ID
+    ):
+        return value, raw_score_field, raw_score_value, None, None
+
+    normalized_raw = first_present(
+        score, ('normalized_score', 'normalizedScore')
+    )
+    if normalized_raw not in (None, ''):
+        normalized = parse_float(normalized_raw)
+        if normalized is None or not 0.0 <= normalized <= 1.0:
+            raise ValueError(
+                'AA-Omniscience normalized_score must be within [0, 1]; '
+                f'got {normalized_raw!r}'
+            )
+        return (
+            normalized * 200.0 - 100.0,
+            raw_score_field,
+            raw_score_value,
+            normalized_raw,
+            'normalized_score_to_signed_range',
+        )
+
+    self_reported = first_present(score, ('self_reported', 'selfReported'))
+    if self_reported is True:
+        if value is None:
+            raise ValueError(
+                'AA-Omniscience self-reported row has no raw score'
+            )
+        if not AA_OMNISCIENCE_MIN_SCORE <= value <= AA_OMNISCIENCE_MAX_SCORE:
+            raise ValueError(
+                'AA-Omniscience self-reported raw score must be within '
+                f'[-100, 100]; got {value}'
+            )
+        return (
+            value,
+            raw_score_field,
+            raw_score_value,
+            None,
+            'self_reported_signed_raw_score',
+        )
+
+    raise ValueError(
+        'AA-Omniscience row has no normalized_score and is not explicitly '
+        'self-reported; cannot determine its score scale'
+    )
+
+
 def make_evaluation_result(
     score: dict[str, Any],
     model: dict[str, Any],
     benchmark: dict[str, Any],
     base_url: str,
 ) -> EvaluationResult | None:
-    value, raw_score_field, raw_score_value = score_value_and_field(score)
+    (
+        value,
+        raw_score_field,
+        raw_score_value,
+        normalized_score_value,
+        transformation_strategy,
+    ) = canonical_score_value(score, benchmark)
     if value is None:
         return None
 
@@ -1660,6 +1820,8 @@ def make_evaluation_result(
             raw_score_value,
             raw_unit,
             urls,
+            normalized_score_value,
+            transformation_strategy,
         ),
     )
 
@@ -1704,6 +1866,15 @@ def convert_logs(
         )
         for failure in payload.get('source_failures', [])
         if isinstance(failure, dict)
+    ]
+    source_exclusions = [
+        SourceRecordExclusion(
+            source_ref=str(exclusion.get('source_ref') or 'unknown source'),
+            reason=str(exclusion.get('reason') or 'unknown exclusion'),
+            source_record=exclusion.get('source_record'),
+        )
+        for exclusion in payload.get('source_exclusions', [])
+        if isinstance(exclusion, dict)
     ]
     model_index = build_index(models, MODEL_ID_KEYS)
     benchmark_index = build_index(benchmarks, BENCHMARK_ID_KEYS)
@@ -1766,9 +1937,12 @@ def convert_logs(
         )
 
     failures = [*source_failures, *score_failures]
-    if not bundles and not failures:
+    if not bundles and not failures and not source_exclusions:
         raise ValueError('LLM Stats: converted 0 source records')
-    if source_failures and score_failures:
+    captured_source_count = payload.get('source_record_count')
+    if isinstance(captured_source_count, int) and captured_source_count >= 0:
+        total_records = captured_source_count
+    elif source_failures and score_failures:
         total_records = len(benchmarks) + len(scores)
     elif source_failures:
         total_records = len(benchmarks)
@@ -1779,6 +1953,7 @@ def convert_logs(
         total_records=total_records,
         records=bundles,
         failures=failures,
+        exclusions=source_exclusions,
     )
 
 
@@ -1828,13 +2003,13 @@ def run(args: argparse.Namespace) -> int:
     paths = export_logs(result.records, args.output_dir)
     for path in paths:
         print(path)
-    if result.failures:
+    if result.failures or result.exclusions:
         report_path = save_failure_report(
             result,
             args.failure_report or default_failure_report_path(args.output_dir),
         )
         print(f'Failure report: {report_path}')
-        result.raise_if_incomplete()
+    result.raise_if_incomplete()
     return len(paths)
 
 

--- a/every_eval_ever/adapters/mmlu_pro/adapter.py
+++ b/every_eval_ever/adapters/mmlu_pro/adapter.py
@@ -61,7 +61,10 @@ from every_eval_ever.helpers import (
     save_evaluation_logs,
     save_failure_report,
 )
-from every_eval_ever.helpers.io import require_identity
+from every_eval_ever.helpers.io import (
+    datastore_path_components,
+    require_identity,
+)
 
 SOURCE_NAME = 'MMLU-Pro Leaderboard'
 SOURCE_ORGANIZATION = 'TIGER-Lab'
@@ -310,6 +313,9 @@ def make_log(
     )
     model_slug = slugify(model_name)
     model_id = get_model_id(model_slug, developer)
+    _, route_developer, route_model = datastore_path_components(
+        'mmlu-pro', model_id, developer
+    )
     raw_data_source = row.get('Data Source', '').strip()
     data_source = normalize_data_source(raw_data_source)
     size_b = parse_size(row.get('Model Size(B)', ''))
@@ -380,7 +386,7 @@ def make_log(
         ),
         evaluation_results=results,
     )
-    return log, developer, model_slug
+    return log, route_developer, route_model
 
 
 def convert_logs(

--- a/every_eval_ever/adapters/mmlu_pro/adapter.py
+++ b/every_eval_ever/adapters/mmlu_pro/adapter.py
@@ -52,6 +52,7 @@ from every_eval_ever.helpers import (
     SCHEMA_VERSION,
     EvaluationLogOutput,
     SourceConversionResult,
+    SourceRecordExclusion,
     SourceRecordFailure,
     default_failure_report_path,
     get_developer,
@@ -109,6 +110,40 @@ DATA_SOURCE_NORMALIZATIONS: dict[str, str] = {
 # A few MMLU-Pro models aren't covered by the helpers/developer.py
 # pattern map. Provide explicit overrides for those.
 DEVELOPER_OVERRIDES: dict[str, str] = {
+    'llemma': 'eleutherai',
+    # Some Gemini rows include a parenthesized MM/YY date. Match the family
+    # before get_developer mistakes that slash for an organization namespace.
+    'gemini': 'google',
+    'openchat': 'openchat',
+    'zephyr': 'huggingface',
+    'neo': 'm-a-p',
+    # The upstream CSV and paper spell Starling-7B as "Staring-7B".
+    'staring': 'berkeley-nest',
+    'internmath': 'shanghai-ai-lab',
+    'mathstral': 'mistralai',
+    'magnum': 'anthracite',
+    # The leaderboard does not publish an organization for this self-reported
+    # model. Keep a stable family namespace instead of silently losing it.
+    'rrd2.5': 'rrd',
+    'ministral': 'mistralai',
+    'smollm': 'huggingface',
+    'qwq': 'alibaba',
+    'skythought': 'novasky',
+    'minimax': 'minimax-ai',
+    'hunyuan': 'tencent',
+    'doubao': 'bytedance',
+    'azerogpt': 'soundai',
+    'llada': 'gsai',
+    'reka': 'reka-ai',
+    'nemotron': 'nvidia',
+    'mimo': 'xiaomi',
+    'general-reasoner': 'tiger-lab',
+    'echo_ego': 'mythworx',
+    'ernie': 'baidu',
+    'seed': 'bytedance',
+    'intern-s1': 'internlm',
+    'longcat': 'meituan',
+    'k2.5': 'moonshotai',
     'exaone': 'lg-ai',
     'mammoth': 'tiger-lab',
     'smaug': 'abacus-ai',
@@ -404,6 +439,7 @@ def convert_logs(
     # survive and exact dupes are dropped.
     seen: set[tuple[str, str, str]] = set()
     failures: list[SourceRecordFailure] = []
+    exclusions: list[SourceRecordExclusion] = []
     for index, row in enumerate(rows):
         try:
             result = make_log(row, timestamp)
@@ -443,6 +479,13 @@ def convert_logs(
         )
         key = (log.model_info.id, data_source, overall)
         if key in seen:
+            exclusions.append(
+                SourceRecordExclusion(
+                    source_ref=f'CSV row {index + 2}',
+                    reason='exact duplicate leaderboard row',
+                    source_record=row,
+                )
+            )
             continue
         seen.add(key)
         bundles.append((log, developer, slug))
@@ -453,6 +496,7 @@ def convert_logs(
         total_records=len(rows),
         records=bundles,
         failures=failures,
+        exclusions=exclusions,
     )
 
 
@@ -492,12 +536,13 @@ def run(args: argparse.Namespace) -> int:
     paths = export(result.records, args.output_dir)
     for path in paths:
         print(path)
-    if result.failures:
+    if result.failures or result.exclusions:
         report_path = save_failure_report(
             result,
             args.failure_report or default_failure_report_path(args.output_dir),
         )
         print(f'Failure report: {report_path}')
+    if result.failures:
         result.raise_if_incomplete()
     return len(paths)
 

--- a/every_eval_ever/helpers/io.py
+++ b/every_eval_ever/helpers/io.py
@@ -177,8 +177,16 @@ def sanitize_filename(name: str) -> str:
     Returns:
         Sanitized string safe for filesystem use
     """
-    # Replace characters invalid on Windows/Unix filesystems
-    return re.sub(r'[<>:"/\\|?*]', '_', name)
+    # ``/`` is not part of ``_INVALID_PATH_CHARS`` because it is meaningful
+    # while parsing model namespaces. It is never safe inside one filename.
+    sanitized = _INVALID_PATH_CHARS.sub('_', name.replace('/', '_'))
+    sanitized = sanitized.rstrip('. ')
+    if (
+        sanitized
+        and sanitized.split('.', 1)[0].upper() in _WINDOWS_RESERVED_NAMES
+    ):
+        sanitized = f'_{sanitized}'
+    return sanitized
 
 
 def require_identity(value: str | None, field_name: str) -> str:

--- a/tests/test_io_helpers.py
+++ b/tests/test_io_helpers.py
@@ -12,6 +12,7 @@ from every_eval_ever.helpers.io import (
     generate_output_path,
     raise_for_failed_records,
     require_uuid4,
+    sanitize_filename,
     save_failure_report,
 )
 
@@ -54,6 +55,20 @@ def test_basic_output_path_replaces_colons_for_windows(tmp_path):
     )
 
     assert path == tmp_path / 'developer' / 'model__revision'
+
+
+@pytest.mark.parametrize(
+    ('raw_name', 'safe_name'),
+    [
+        ('model. ', 'model'),
+        ('model\x00name\x1fname', 'model_name_name'),
+        ('CON', '_CON'),
+        ('con.json', '_con.json'),
+        ('LPT9', '_LPT9'),
+    ],
+)
+def test_sanitize_filename_produces_portable_names(raw_name, safe_name):
+    assert sanitize_filename(raw_name) == safe_name
 
 
 def test_evaluation_output_flattens_nested_model_path_and_colons():

--- a/tests/test_llm_stats_adapter.py
+++ b/tests/test_llm_stats_adapter.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from every_eval_ever.adapters.llm_stats import adapter
 from every_eval_ever.eval_types import EvaluationLog
 from every_eval_ever.helpers.io import SourceRecordsError
@@ -219,6 +221,212 @@ def test_fallback_fetch_failures_are_preserved_and_fail_conversion(
         )
     else:
         raise AssertionError('expected incomplete benchmark fetch to fail')
+
+
+def aa_omniscience_payload() -> dict:
+    detail = {
+        'benchmark_id': 'aa-omniscience-index',
+        'name': 'AA Omniscience Index',
+        'description': 'Signed Artificial Analysis omniscience index.',
+        'max_score': 200,
+        'models': [
+            {
+                'model_id': 'grok-4-heavy',
+                'model_name': 'Grok 4 Heavy',
+                'organization_id': 'xai',
+                'organization_name': 'xAI',
+                'score': 126,
+                'normalized_score': 0.63,
+                'self_reported': False,
+                'self_reported_source': 'https://artificialanalysis.ai/',
+                'analysis_method': 'Raw signed index 26, shifted by 100.',
+            },
+            {
+                'model_id': 'lfm2-24b-a2b',
+                'model_name': 'LFM2-24B-A2B',
+                'organization_id': 'liquid-ai',
+                'organization_name': 'Liquid AI',
+                'score': -29.5,
+                'normalized_score': None,
+                'self_reported': True,
+                'self_reported_source': 'https://www.liquid.ai/',
+                'analysis_method': 'Reported directly on signed scale.',
+            },
+        ],
+    }
+    return {
+        'models': [],
+        'benchmarks': [],
+        'scores': adapter.scores_from_benchmark_detail(detail),
+        'source_record_count': 2,
+    }
+
+
+def test_aa_omniscience_normalizes_mixed_live_scores_and_validates(
+    tmp_path: Path,
+):
+    result = adapter.convert_logs(
+        aa_omniscience_payload(), retrieved_timestamp='1234567890.0'
+    )
+
+    assert result.failures == []
+    by_name = {
+        bundle.log.model_info.name: bundle.log.evaluation_results[0]
+        for bundle in result.records
+    }
+    grok = by_name['Grok 4 Heavy']
+    liquid = by_name['LFM2-24B-A2B']
+
+    assert grok.score_details.score == pytest.approx(26.0)
+    assert liquid.score_details.score == pytest.approx(-29.5)
+    for evaluation_result in (grok, liquid):
+        assert evaluation_result.metric_config.min_score == -100
+        assert evaluation_result.metric_config.max_score == 100
+        assert evaluation_result.metric_config.metric_unit == 'points'
+
+    assert grok.score_details.details['raw_score'] == '126'
+    assert grok.score_details.details['raw_normalized_score'] == '0.63'
+    assert grok.score_details.details['transformation_strategy'] == (
+        'normalized_score_to_signed_range'
+    )
+    assert liquid.score_details.details['raw_score'] == '-29.5'
+    assert liquid.score_details.details['raw_normalized_score'] == 'null'
+    assert liquid.score_details.details['transformation_strategy'] == (
+        'self_reported_signed_raw_score'
+    )
+
+    output_dir = tmp_path / 'data' / 'llm-stats'
+    paths = adapter.export_logs(result.records, output_dir)
+    assert len(paths) == 2
+    for path in paths:
+        report = validate_file(
+            path,
+            repo_path=str(path.relative_to(tmp_path)),
+            available_files=frozenset(),
+            run_semantic_checks=True,
+        )
+        assert report.valid, report.errors
+
+
+def test_aa_omniscience_ambiguous_scale_is_a_row_failure():
+    payload = aa_omniscience_payload()
+    ambiguous = payload['scores'][0]
+    ambiguous['normalized_score'] = None
+    ambiguous['self_reported'] = False
+    payload['scores'] = [ambiguous]
+    payload['source_record_count'] = 1
+
+    result = adapter.convert_logs(payload, retrieved_timestamp='1234567890.0')
+
+    assert result.records == []
+    assert len(result.failures) == 1
+    assert 'cannot determine its score scale' in result.failures[0].reason
+    assert result.failures[0].source_record == ambiguous
+
+
+def test_generic_bounds_use_documented_max_and_reject_unbounded_negative():
+    assert adapter.metric_bounds_and_unit(
+        6.0, None, {'id': 'example', 'max_score': 10}
+    ) == (0.0, 10.0, 'points', 'benchmark_max_with_zero_min')
+    assert adapter.metric_bounds_and_unit(
+        63.0, None, {'id': 'percent-example', 'max_score': 1}
+    ) == (0.0, 100.0, 'percent', 'inferred_percent_from_score')
+    with pytest.raises(ValueError, match='no documented adapter-specific'):
+        adapter.metric_bounds_and_unit(-1.0, None, {'id': 'example'})
+
+
+def test_community_benchmarks_are_excluded_without_fetching_details(
+    monkeypatch, tmp_path: Path
+):
+    benchmarks = {
+        'data': [
+            {
+                'id': 'gpqa',
+                'name': 'GPQA',
+                'max_score': 1,
+                'is_community': False,
+            },
+            {
+                'id': 'community:2256e9c9-b256-4444-b639-7cc3b1855d96',
+                'name': 'nolima',
+                'dataset_id': '2256e9c9-b256-4444-b639-7cc3b1855d96',
+                'model_count': 52,
+                'is_community': True,
+            },
+        ]
+    }
+    models = {
+        'data': [
+            {
+                'id': 'gpt-5',
+                'name': 'GPT-5',
+                'provider': {'slug': 'openai', 'name': 'OpenAI'},
+            }
+        ]
+    }
+    fetched_urls: list[str] = []
+
+    def fake_fetch(url, *, headers):
+        del headers
+        fetched_urls.append(url)
+        if url.endswith('/v1/models'):
+            return models
+        if url.endswith('/leaderboard/benchmarks'):
+            return benchmarks
+        if url.endswith('/v1/scores'):
+            raise adapter.FetchError('scores endpoint unavailable')
+        if url.endswith('/leaderboard/benchmarks/gpqa'):
+            return {
+                'benchmark_id': 'gpqa',
+                'name': 'GPQA',
+                'max_score': 1,
+                'models': [
+                    {
+                        'model_id': 'gpt-5',
+                        'model_name': 'GPT-5',
+                        'score': 0.9,
+                        'self_reported': True,
+                    }
+                ],
+            }
+        raise AssertionError(f'unexpected fetch: {url}')
+
+    monkeypatch.setattr(adapter, 'fetch_json', fake_fetch)
+    monkeypatch.setattr(adapter, 'fetch_text', lambda _url: '')
+
+    raw_path = tmp_path / 'raw' / 'combined.json'
+    report_path = tmp_path / 'reports' / 'llm-stats.json'
+    args = adapter.parse_args(
+        [
+            '--api-key',
+            'secret',
+            '--base-url',
+            'https://example.test',
+            '--output-dir',
+            str(tmp_path / 'data' / 'llm-stats'),
+            '--save-raw-json',
+            str(raw_path),
+            '--failure-report',
+            str(report_path),
+        ]
+    )
+
+    assert adapter.run(args) == 1
+    assert not any(
+        'community%3A' in url or 'community:' in url for url in fetched_urls
+    )
+
+    captured = json.loads(raw_path.read_text(encoding='utf-8'))
+    assert captured['source_record_count'] == 2
+    assert len(captured['source_exclusions']) == 1
+    assert (
+        captured['source_exclusions'][0]['source_record']['model_count'] == 52
+    )
+
+    report = json.loads(report_path.read_text(encoding='utf-8'))
+    assert report['total_source_records'] == 2
+    assert report['failed_record_count'] == 0
+    assert report['excluded_record_count'] == 1
 
 
 def test_export_paths_follow_datastore_layout(tmp_path: Path):

--- a/tests/test_llm_stats_adapter.py
+++ b/tests/test_llm_stats_adapter.py
@@ -335,6 +335,82 @@ def test_generic_bounds_use_documented_max_and_reject_unbounded_negative():
         adapter.metric_bounds_and_unit(-1.0, None, {'id': 'example'})
 
 
+def vending_bench_2_payload() -> dict:
+    benchmark = {
+        'benchmark_id': 'vending-bench-2',
+        'name': 'Vending-Bench 2',
+        'description': 'Final bank balance after one simulated year.',
+        'max_score': 1.0,
+    }
+    rows = [
+        ('claude-opus-4-6', 'Claude Opus 4.6', 'anthropic', 8017.59),
+        ('glm-5.1', 'GLM-5.1', 'zhipu-ai', 5634.41),
+        ('gemini-3-pro-preview', 'Gemini 3 Pro', 'google', 5478.16),
+        ('gemini-3-flash-preview', 'Gemini 3 Flash', 'google', 3635.0),
+    ]
+    return {
+        'models': [],
+        'benchmarks': [],
+        'scores': [
+            {
+                'id': f'vending-bench-2::{model_id}',
+                'model_id': model_id,
+                'model_name': model_name,
+                'organization_id': organization,
+                'organization_name': organization,
+                'score': score,
+                'normalized_score': None,
+                'self_reported': True,
+                'source_url': adapter.VENDING_BENCH_2_SCALE_URL,
+                'benchmark': benchmark,
+            }
+            for model_id, model_name, organization, score in rows
+        ],
+        'source_record_count': len(rows),
+    }
+
+
+def test_vending_bench_2_uses_unbounded_dollar_scale_and_validates(
+    tmp_path: Path,
+):
+    result = adapter.convert_logs(
+        vending_bench_2_payload(), retrieved_timestamp='1234567890.0'
+    )
+
+    assert result.failures == []
+    scores = sorted(
+        evaluation_result.score_details.score
+        for bundle in result.records
+        for evaluation_result in bundle.log.evaluation_results
+    )
+    assert scores == [3635.0, 5478.16, 5634.41, 8017.59]
+    for bundle in result.records:
+        evaluation_result = bundle.log.evaluation_results[0]
+        metric = evaluation_result.metric_config
+        assert metric.min_score == 0
+        assert metric.max_score == float('inf')
+        assert metric.metric_unit == 'usd'
+        assert metric.additional_details['bound_strategy'] == (
+            'vending_bench_2_unbounded_dollars'
+        )
+        assert metric.additional_details['raw_max_score'] == '1.0'
+        assert metric.additional_details['canonical_scale_source_url'] == (
+            adapter.VENDING_BENCH_2_SCALE_URL
+        )
+
+    output_dir = tmp_path / 'data' / 'llm-stats'
+    paths = adapter.export_logs(result.records, output_dir)
+    assert len(paths) == 4
+    for path in paths:
+        report = validate_file(
+            path,
+            repo_path=str(path.relative_to(tmp_path)),
+            available_files=frozenset(),
+            run_semantic_checks=True,
+        )
+        assert report.valid, report.errors
+
+
 def test_community_benchmarks_are_excluded_without_fetching_details(
     monkeypatch, tmp_path: Path
 ):

--- a/tests/test_mmlu_pro_adapter.py
+++ b/tests/test_mmlu_pro_adapter.py
@@ -225,11 +225,33 @@ def test_data_source_typos_are_normalized():
 
 
 def test_exact_duplicate_rows_are_dropped():
-    bundles = adapter.make_logs(sample_rows(), retrieved_timestamp='123.0')
+    result = adapter.convert_logs(sample_rows(), retrieved_timestamp='123.0')
+    bundles = result.records
     duplicated = [
         b for b in bundles if 'gpt-4-turbo' in b[0].model_info.id.lower()
     ]
     assert len(duplicated) == 1
+    assert len(result.exclusions) == 1
+    assert result.exclusions[0].source_ref == 'CSV row 6'
+    assert result.exclusions[0].reason == 'exact duplicate leaderboard row'
+
+
+def test_current_live_model_families_have_stable_developers():
+    expected = {
+        'Gemini-3-Flash(12/25)': 'google',
+        'Llemma-7B': 'eleutherai',
+        'OpenChat-3.5-8B': 'openchat',
+        'Staring-7B': 'berkeley-nest',
+        'RRD2.5-9B': 'rrd',
+        'ECHO_Ego_v2_14B': 'mythworx',
+        'Seed2.0-Pro': 'bytedance',
+        'K2.5-1T-A32B': 'moonshotai',
+        'Nemotron-3-Nano-30B-A3B(BF16)': 'nvidia',
+    }
+
+    assert {
+        model: adapter.normalize_developer(model) for model in expected
+    } == expected
 
 
 def test_export_preflights_all_paths_before_writing(tmp_path):

--- a/tests/test_mmlu_pro_adapter.py
+++ b/tests/test_mmlu_pro_adapter.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from every_eval_ever.adapters.mmlu_pro import adapter
 from every_eval_ever.eval_types import EvaluationLog
 from every_eval_ever.helpers.io import SourceRecordsError
+from every_eval_ever.validate import validate_file
 
 
 def sample_rows() -> list[dict]:
@@ -243,6 +246,72 @@ def test_export_preflights_all_paths_before_writing(tmp_path):
         raise AssertionError('expected invalid output identity to fail')
 
     assert list(output_dir.rglob('*.json')) == []
+
+
+def test_seed_model_names_use_portable_paths_and_preserve_source_names(
+    tmp_path: Path,
+):
+    source_names = [
+        'Seed-OSS-36B-Base(w/ syn.)',
+        'Seed-OSS-36B-Base(w/o syn.)',
+    ]
+    rows = [
+        {
+            'Models': name,
+            'Data Source': 'TIGER-Lab',
+            'Model Size(B)': '36',
+            'Overall': '0.5',
+        }
+        for name in source_names
+    ]
+
+    bundles = adapter.make_logs(rows, retrieved_timestamp='123.0')
+
+    assert [bundle[2] for bundle in bundles] == [
+        'seed-oss-36b-base-w-syn',
+        'seed-oss-36b-base-w-o-syn',
+    ]
+    assert [bundle[0].model_info.name for bundle in bundles] == source_names
+    assert [
+        bundle[0].model_info.additional_details['raw_model_name']
+        for bundle in bundles
+    ] == source_names
+
+    output_dir = tmp_path / 'data' / 'mmlu-pro'
+    paths = adapter.export(bundles, output_dir)
+    assert {path.parent.name for path in paths} == {
+        'seed-oss-36b-base-w-syn',
+        'seed-oss-36b-base-w-o-syn',
+    }
+    for path in paths:
+        report = validate_file(
+            path,
+            repo_path=str(path.relative_to(tmp_path)),
+            available_files=frozenset(),
+            run_semantic_checks=True,
+        )
+        assert report.valid, report.errors
+
+
+def test_unsafe_mmlu_route_is_reported_with_its_csv_row(monkeypatch):
+    monkeypatch.setattr(adapter, 'slugify', lambda _value: 'unsafe.')
+
+    result = adapter.convert_logs(
+        [
+            {
+                'Models': 'GPT-4o',
+                'Data Source': 'TIGER-Lab',
+                'Overall': '0.5',
+            }
+        ],
+        retrieved_timestamp='123.0',
+    )
+
+    assert result.records == []
+    assert result.failures[0].source_ref == 'CSV row 2'
+    assert 'not a safe single datastore path component' in (
+        result.failures[0].reason
+    )
 
 
 def test_developer_override_for_exaone():


### PR DESCRIPTION
## What / source

Fix the two daily-ingestion failures exposed by the new adapter cron:

- normalize AA-Omniscience onto its documented signed `[-100, 100]` scale while preserving the raw and normalized values plus the transformation strategy;
- treat Vending-Bench 2 as final bank balance in USD with `[0, Infinity]` bounds, as documented by [Andon Labs](https://andonlabs.com/evals/vending-bench-2), while preserving LLM Stats' incorrect raw `max_score=1` metadata;
- exclude `is_community=true` dataset summaries before the unsupported standard-detail request, with audited provenance and runtime source counts;
- make shared filename sanitization portable across Windows and Unix, fixing the two live MMLU-Pro Seed model paths;
- validate each MMLU-Pro datastore route inside the CSV row conversion boundary and cover the current live model-family attributions;
- record the exact duplicate MMLU-Pro row as an audited exclusion instead of silently dropping it.

There are no schema, catalog, cron-schedule, or datastore migration changes. The failed cron runs uploaded no evaluation records. Community dataset ingestion remains separate and is tracked in #253.

## Review lane

- [x] **Fast** — this changes score normalization and a shared path helper
- [x] **Needs a human** — review the adapter-specific scale choices and source attribution mappings

Design context: follow-up to #249 and its live cron runs; #253 tracks the intentionally deferred community-leaderboard support.

## Checklist

- [x] semantic validation is clean at final `data/<collection>/<dev>/<model>/` paths
- [x] ambiguous/unconvertible rows are retained in `adapter_reports/` and fail the command
- [x] offline regression tests added for exact live AA, Vending-Bench 2, MMLU-Pro, community, and sanitizer cases
- [x] targeted adapter/helper/cron suite: 91 passed
- [x] `ruff check .` clean; all changed files pass `ruff format --check`
- [x] captured live replays pass conversion and semantic validation
- [x] separate branch-based `dry_run=true` workflows pass for both adapters

Full-suite result locally: 769 passed, 20 skipped. One unrelated, independently reproducible Rich terminal-color assertion in `tests/test_validate.py::TestWarningVisibility::test_failure_with_warning_stays_red` fails because the captured console strips ANSI codes; deselecting that existing test gives 769 passed, 20 skipped, 1 deselected.

## Decisions & coverage

- **AA-Omniscience:** rows with `normalized_score` use `normalized_score * 200 - 100`; explicitly self-reported rows without it may use a raw score already inside `[-100, 100]`. Ambiguous rows fail instead of guessing.
- **Vending-Bench 2:** the canonical metric is final bank balance in USD and the owner explicitly documents no ceiling, so records use `[0, Infinity]` even though LLM Stats currently reports `max_score=1`.
- **Community summaries:** audited exclusions replace unsupported standard-detail requests. Unexpected failures for ordinary benchmarks remain red. Full support is tracked in #253, updated with all 19 current IDs and dataset metadata.
- **MMLU-Pro paths and identity:** portable path components are generated while source model names remain unchanged in JSON. Current live developer mappings are explicit; the unattributed self-reported `RRD2.5-9B` uses the stable `rrd` family namespace.

### Fixture coverage

- AA exact Grok `126/0.63` and Liquid `-29.5/null`: 2 source rows → 2 records, 0 failures, 0 validation errors.
- Vending-Bench 2 exact live values `8017.59`, `5634.41`, `5478.16`, and `3635.0`: 4 source rows → 4 records, 0 failures, 0 validation errors.
- MMLU-Pro exact Seed path names plus live family mappings: portable directories, unchanged JSON names, and semantic validation.
- Community fixture: unsupported community detail endpoint is never called; exclusions-only reports remain successful.

### Live branch dry runs (`b318ee0`)

- [LLM-Stats](https://github.com/evaleval/every_eval_ever/actions/runs/31737312943): 681 source rows → 353 records, **0 failed**, 19 audited community exclusions (matching the live `is_community` count), 0 validation errors, no publication.
- [MMLU-Pro](https://github.com/evaleval/every_eval_ever/actions/runs/31737337373): 262 source rows → 261 records, **0 failed**, 1 audited exact-duplicate exclusion, 0 validation errors, no publication.