### PR TITLE
Commit passing cron output straight to the datastore

### DIFF
--- a/.github/workflows/adapter_cron.yml
+++ b/.github/workflows/adapter_cron.yml
@@ -1,14 +1,14 @@
 # Daily adapter ingestion.
 #
-# One isolated job per adapter, and one datastore pull request per adapter.
-# Which adapters run on a given day comes from
+# One isolated job per adapter, each committing what passed validation
+# straight to the datastore. Which adapters run on a given day comes from
 # every_eval_ever/adapters/catalog.py via `cron plan`, not from this file, so
 # adding an adapter to the schedule is a catalog change with a test behind it.
 #
 # Setup this workflow needs, once:
 #   - a `cron` environment holding `HF_TOKEN`, with write access to the raw
 #     store (or permission to create it, which the first run does, private)
-#     and permission to open pull requests on the datastore;
+#     and write access to the datastore;
 #   - optional per-adapter credentials as secrets (see `cron list`);
 #   - optional `EEE_DATASTORE_REPO_ID` / `EEE_RAW_REPO_ID` repository
 #     variables to point a rehearsal run at throwaway repositories.

--- a/every_eval_ever/cron/README.md
+++ b/every_eval_ever/cron/README.md
@@ -1,7 +1,7 @@
 # Scheduled adapter ingestion
 
-A daily GitHub Actions run that refreshes one adapter at a time and sends each
-adapter's records to its own Hugging Face pull request on the datastore.
+A daily GitHub Actions run that refreshes one adapter at a time and commits
+each adapter's validated records straight to the datastore.
 
 ```bash
 uv run python -m every_eval_ever.cron list          # every adapter and its schedule
@@ -24,12 +24,12 @@ provenance  mark survivors: type_of_addition=cron, run date, adapter, run URL,
    ↓
 store     snapshot the raw source and update this adapter's ledger
    ↓
-submit    upload into this adapter's own datastore pull request
+submit    commit to the datastore, one commit series per run
 ```
 
 Nothing is shared between adapters. Each run stages into its own temporary
 directory and uploads only what it validated, so one adapter's failure cannot
-reach another adapter's pull request.
+reach another adapter's records.
 
 ## Outcomes
 
@@ -83,13 +83,15 @@ naming different sample files are two records, and `check-duplicates` has to
 keep seeing that.
 
 Fingerprints are kept in two files with different meanings, and both are
-skipped on later runs. `state/<adapter>.pending` holds records committed to
-the adapter's open pull request; `state/<adapter>.fingerprints` holds records
-whose pull request was merged. Before each run the pending set is settled
-against that pull request's fate: merged promotes it into the durable ledger,
-closed-without-merging drops it, so records a reviewer turned down are
-resubmitted in a fresh pull request instead of being filtered out of every
-later run by fingerprints for data the datastore never accepted.
+skipped on later runs. `state/<adapter>.fingerprints` holds records that are
+in the datastore; a record's fingerprint joins it the moment its commit
+lands. `state/<adapter>.pending` holds records the retired pull-request flow
+committed to an adapter's open pull request before runs published directly;
+new runs write nothing to it. While any remain, each run settles them against
+that pull request's fate: merged promotes them into the durable ledger,
+closed-without-merging drops them so the records are resubmitted instead of
+being filtered out of every later run by fingerprints for data the datastore
+never accepted.
 
 Skipping is reversible and audited: every skipped record's model id and
 fingerprint is listed in that run's `run.json`. To republish everything once,
@@ -153,18 +155,17 @@ depend on.
 evaleval/EEE_raw   (private dataset, main)
   raw/<adapter>/<date>/<run>/<sha256><ext>    payload bytes
   raw/<adapter>/<date>/<run>/manifest.jsonl   one line per capture
-  raw/<adapter>/<date>/<run>/run.json         outcome, coverage, PR link
-  state/<adapter>.json                        PR number, last run, last status
-  state/<adapter>.fingerprints                one sha256 per merged record
-  state/<adapter>.pending                     one sha256 per record still
-                                              waiting on its pull request
+  raw/<adapter>/<date>/<run>/run.json         outcome, coverage, records committed
+  state/<adapter>.json                        last run, last status
+  state/<adapter>.fingerprints                one sha256 per published record
+  state/<adapter>.pending                     one sha256 per record the retired
+                                              flow left waiting on a pull request
   state/<adapter>.inflight                    records this run is about to
                                               publish, written before it does
 ```
 
-`<adapter>` is the catalog key, which is also the job name and the name on the
-adapter's datastore pull request. Nothing has ever been published here, so the
-first run that does is the one that sets this in stone.
+`<adapter>` is the catalog key, which is also the job name and the name in the
+datastore commit messages.
 
 `<date>` is the UTC run date and `<run>` names the run within it:
 `run-<workflow run id>-<attempt>` under Actions, `local-<HHMMSS>` otherwise,
@@ -183,71 +184,57 @@ collide loudly instead of one silently overwriting the other.
 The first carries the raw snapshot and `state/<adapter>.inflight`: the
 fingerprint and datastore paths of every record this run is about to publish.
 The second carries the run report, the ledger and an emptied in-flight file,
-with one exception: records whose batch errored while the pull request was
+with one exception: records whose batch errored while the datastore was
 unreadable stay in flight, because whether they landed is exactly the question
 the file exists to answer, and the next run settles it. Publishing is the one
 step a re-run cannot undo, so it happens between the two commits rather than
 before both. A run that uploads records and then fails to write
 its ledger, because the job was cancelled or the raw store was briefly
-unreachable, would otherwise leave them on the pull request with nothing
+unreachable, would otherwise leave them in the datastore with nothing
 naming them, and the next run would publish the same evaluations again under
 fresh UUID paths.
 
 A non-empty in-flight file at the start of a run is exactly that case. Each
-record it names is checked against the pull request it was headed for (against
-the datastore itself if that pull request has since merged): the ones that
-arrived are recorded, the ones that did not are published again, and a pull
-request closed without merging in the meantime forgets them. A check the Hub
-cannot answer stops the run, since one wrong guess buries records and the
-other duplicates them. Settling the same file twice settles it the same way,
-so a run that dies before its own commit costs nothing.
+record it names is checked against where it was headed — the datastore, or
+for a file the retired pull-request flow wrote, the pull request it was
+publishing into: the ones that arrived are recorded, the ones that did not
+are published again. A check the Hub cannot answer stops the run, since one
+wrong guess buries records and the other duplicates them. Settling the same
+file twice settles it the same way, so a run that dies before its own commit
+costs nothing.
 
-## The pull request
+## Publishing
 
-One per adapter, titled `[Submission] cron: <adapter> (automated ingestion)`,
-with `eee-cron-adapter: <adapter>` in the body.
+Records go straight to the datastore's default branch: one commit series per
+adapter run, batched at 300 files per commit so a single giant commit cannot
+time out ambiguously, and batches never split a record across two commits, so
+each commit publishes whole records or none of them. The review that used to
+happen on a pull request happens before publication instead — the packaged
+validator must pass with no warnings, the ledger drops records already
+published, and every record carries `type_of_addition: cron` with its run's
+date, adapter and workflow URL — so a human reviewing after the fact can find
+and correct any batch. Each commit's message is
+`cron: <adapter> <date> (<n> record(s))` and its description carries what the
+pull request body used to: run date, status, coverage line, raw snapshot path
+and workflow run.
 
-Two things identify it, and neither is the title. Only pull requests opened by
-the account the token resolves to are candidates at all. The datastore is
-public, so anyone can open one carrying our marker, and adopting it would
-commit records onto a branch and a description a stranger controls. Among
-those, the body marker says which adapter it belongs to. The number is
-remembered in the ledger, and both it and any cold-start lookup are confirmed
-against both checks before anything is uploaded.
+A commit that errors after the Hub accepted it is adopted rather than
+repeated: the datastore's file listing arbitrates, a batch proven present
+counts as committed, and the upload carries on. A batch that provably never
+landed fails the run with everything earlier recorded in the ledger, so the
+retry publishes only the remainder. A batch that cannot be checked either way
+stays in flight (see above) for the next run to settle.
 
-So renaming a pull request does not strand it, and titling one to look like
-ours does not hand it our records. Merged or closed means a fresh one is
-opened. If two open pull requests claim the same adapter the run stops rather
-than guessing.
+### What remains of the pull-request flow
 
-The same two checks answer the awkward case where the commit that opens a
-pull request errors after the Hub accepted it. The number is in the reply that
-never arrived, so the run would otherwise fail knowing nothing and the next
-run would open a second pull request holding the same records. Instead the
-lookup runs again: a marked pull request from this account means the commit
-landed, and this run adopts it and carries on with the remaining batches.
-Whether its first batch is on the ref decides whether those records count as
-published, and a ref that cannot be read stops the run with the number
-recorded, since inspecting one pull request beats duplicating a batch.
-
-The description is rewritten after each run that adds records: the run date,
-the status, the coverage line (source rows, records produced, dropped, skipped
-as unchanged, uploaded), the raw snapshot path and the workflow run. A pull
-request stays open across many runs, so a body written when it opened would
-describe whichever run happened to be first. The rewrite carries the
-`eee-cron-adapter` marker like any other body, since that line is what claims
-the pull request for the adapter. A refresh the Hub refuses is reported in the
-run report and the step summary rather than failing the run, because by then
-the records are published.
-
-A submission that lands completely ends by posting `/eee validate changed` as
-a fresh comment on the pull request, because the datastore's validator runs on
-that command rather than on push — records nobody comments on are records
-nobody validated. It is posted last, after the records and the description, so
-what it validates is the finished submission, and never after a partial one: a
-retry that completes the submission asks instead. A comment the Hub refuses is
-reported like a refused description rewrite, with a note asking a human to
-post the command by hand.
+Earlier versions published into one open pull request per adapter, identified
+by the opening account plus an `eee-cron-adapter: <adapter>` line in the
+body, with fingerprints held pending until a reviewer merged. Runs now settle
+whatever that flow left behind: pending fingerprints are promoted when their
+pull request turns out merged and dropped when it was closed without merging,
+and an old in-flight file is checked against the pull request it named. The
+settling machinery in `submit.py` can be deleted once no adapter's state
+names a pull request.
 
 ## Setup
 
@@ -267,9 +254,9 @@ post the command by hand.
    stops the run, because a 500 is not evidence that a public dataset is
    absent.
 2. Add a `cron` environment to the GitHub repository with an `HF_TOKEN`
-   secret that can write to the raw store and open pull requests on the
-   datastore. A read-only token is rejected before the adapter starts, as is
-   a datastore this token cannot read.
+   secret that can write to the raw store and to the datastore. A read-only
+   token is rejected before the adapter starts, as is a datastore this token
+   cannot read.
 3. Per-adapter credentials as secrets. `uv run python -m
    every_eval_ever.cron list` shows which adapters want one. Every adapter
    that names one needs it: without it that adapter's job fails, naming the
@@ -297,7 +284,7 @@ Give heavy adapters `cadence='weekly'` with a `weekday`, and a realistic
 that plus `JOB_TIMEOUT_BUFFER_MINUTES`, because the job also checks out the
 repository, installs the environment, uploads the snapshot and commits the
 records. A job cancelled during that last part is the one case where records
-reach a pull request with nothing in the ledger recording them.
+reach the datastore with nothing in the ledger recording them.
 
 ## Operating it
 
@@ -343,7 +330,9 @@ This is a deliberate MVP.
   fingerprint ledger stops unchanged records piling up; reconciling genuine
   updates against records already in the datastore is not attempted here.
 - Records already in the datastore are not backfilled with the cron marker.
-- The cron never merges its own pull requests.
+- Published records pass the packaged validator and carry provenance, but
+  nothing reviews them for sense before they land; a bad batch is found and
+  corrected after the fact via its `cron_*` provenance fields.
 - A source that outgrows a capture cap fails its adapter until the cap is
   raised. Nothing splits or streams a large payload.
 - The write token is checked for a reported read-only role, which a

--- a/every_eval_ever/cron/__init__.py
+++ b/every_eval_ever/cron/__init__.py
@@ -6,7 +6,7 @@ The pipeline is deliberately linear and each stage refuses to guess:
     -> ``runner``     stage into a private tree, validate, fingerprint
     -> ``provenance`` mark the surviving records as cron-produced
     -> ``store``      snapshot raw payloads and the per-adapter ledger
-    -> ``submit``     upload to that adapter's own datastore pull request
+    -> ``submit``     commit to the datastore, one commit series per run
 
 Run it with ``uv run python -m every_eval_ever.cron``.
 """

--- a/every_eval_ever/cron/__main__.py
+++ b/every_eval_ever/cron/__main__.py
@@ -169,13 +169,15 @@ def _reconcile_pending(
 ) -> str | None:
     """Settle what the last pull request's fingerprints mean, before running.
 
-    The ledger's pending fingerprints describe records committed to a pull
+    Runs commit straight to the datastore now and write no new pending
+    fingerprints; this settles what the retired pull-request flow left
+    behind. Its pending fingerprints describe records committed to a pull
     request, not records merged into the datastore. While that pull request
     is open they mean "already queued" and keep unchanged records from being
     uploaded twice. Once it is merged they are durable. Once it is closed
     without merging they mean nothing, and treating them as published would
     filter the same records out of every later run before publication is
-    ever attempted, so the replacement pull request could never open.
+    ever attempted, so the resubmission could never happen.
 
     Mutates ``state`` and returns a line for the run report, or ``None`` when
     there was nothing to settle. The mutation is persisted by the same
@@ -214,16 +216,14 @@ def _reconcile_pending(
             f'pull request {number} was merged; {count} record(s) are now in '
             'the datastore ledger'
         )
-    # Closed without merging: a reviewer looked at those records and turned
-    # them down, so the next pull request must carry them again, visibly,
-    # rather than pretending they were published.
+    # Closed without merging: those records never reached the datastore, so
+    # forgetting their fingerprints is what lets the next run publish them.
     state.pending_fingerprints.clear()
     state.pull_request_number = None
     state.pull_request_url = None
     return (
         f'pull request {number} was closed without merging; its {count} '
-        'record(s) are forgotten from the ledger and will be resubmitted in '
-        'a fresh pull request'
+        'record(s) are forgotten from the ledger and will be resubmitted'
     )
 
 
@@ -264,10 +264,10 @@ def _still_inflight(
     """Return what the run's closing commit leaves in flight.
 
     Usually nothing: what landed is in the ledger, and what never reached
-    the pull request is safe to upload again. The exception is a batch whose
-    commit errored while the pull request ref was unreadable. Its records
-    are neither recorded nor known to be absent, and clearing them would
-    make the next run publish them a second time on top of copies that may
+    the datastore is safe to upload again. The exception is a batch whose
+    commit errored while the datastore was unreadable. Its records are
+    neither recorded nor known to be absent, and clearing them would make
+    the next run publish them a second time on top of copies that may
     already be there. They stay in flight, and the next run settles them the
     way it settles any interrupted run's.
     """
@@ -286,11 +286,7 @@ def _still_inflight(
         adapter=spec.key,
         run_date=outcome.run_date.isoformat(),
         run_token=run_token,
-        pull_request_number=(
-            failure.pull_request.number
-            if failure.pull_request is not None
-            else None
-        ),
+        destination=store.DIRECT_DESTINATION,
         records=records,
     )
 
@@ -304,15 +300,16 @@ def _reconcile_inflight(
 
     Publication is written down before it happens, because it is the one step
     that cannot be undone by repeating it. A run that uploaded records and
-    then failed to commit its ledger leaves them on the pull request with
+    then failed to commit its ledger leaves them in the datastore with
     nothing naming them, and the run after that would send the same
     evaluations again under fresh UUID paths.
 
-    So the in-flight file is read back here and checked against the pull
-    request the records were headed for. The ones that arrived are recorded;
-    the ones that did not are forgotten, so this run uploads them. A question
-    the Hub cannot answer stops the run, because the two wrong answers are
-    losing records and duplicating them.
+    So the in-flight file is read back here and checked against where the
+    records were headed: the datastore itself, or the pull request the
+    retired flow was publishing into when it wrote the file. The ones that
+    arrived are recorded; the ones that did not are forgotten, so this run
+    uploads them. A question the Hub cannot answer stops the run, because
+    the two wrong answers are losing records and duplicating them.
 
     Mutates ``state`` and returns a line for the run report, or ``None`` when
     there was nothing in flight. Running it twice settles the same batch the
@@ -325,6 +322,29 @@ def _reconcile_inflight(
         return None
 
     count = len(batch.records)
+    if batch.destination == store.DIRECT_DESTINATION:
+        present = submitter.paths_present(batch.paths)
+        if present is None:
+            raise submit.SubmissionError(
+                f'could not read {submitter.repo_id} to settle {count} '
+                'record(s) an earlier run published without recording them; '
+                'a re-run would publish them a second time, so inspect the '
+                'datastore first'
+            )
+        landed = [
+            record['fingerprint']
+            for record in batch.records
+            if all(path in present for path in record['paths'])
+        ]
+        state.fingerprints.update(landed)
+        return (
+            f'an earlier run published {len(landed)} of {count} record(s) to '
+            'the datastore without recording them; they are recorded now and '
+            'the rest are published again'
+        )
+
+    # What follows settles an in-flight file the retired pull-request flow
+    # wrote, against the pull request its records were headed for.
     pull_request = None
     if batch.pull_request_number is None:
         # A cold start: the upload itself was to open the pull request, so
@@ -390,18 +410,17 @@ def _publish(
     outcome: runner.RunOutcome,
     *,
     spec: catalog.AdapterSpec,
-    state: store.AdapterState,
     submitter: submit.DatastoreSubmitter,
     run_url: str | None,
     raw_reference: str,
     notes: list[str],
 ) -> submit.Submission | None:
-    """Put this run's records into the adapter's own pull request."""
+    """Commit this run's records to the datastore."""
     operations = submit.upload_operations(outcome.upload_dir)
     if not operations:
         return None
 
-    description = submit.pull_request_description(
+    description = submit.commit_description(
         spec.key,
         coverage_line=outcome.coverage_line(),
         run_date=outcome.run_date.isoformat(),
@@ -410,18 +429,7 @@ def _publish(
         raw_reference=raw_reference,
         notes=notes,
     )
-
-    pull_request = None
-    if state.pull_request_number is not None:
-        pull_request = submitter.resolve_known(
-            spec.key, state.pull_request_number
-        )
-    if pull_request is None:
-        pull_request = submitter.find_by_marker(spec.key)
-
     return submitter.publish(
-        spec.key,
-        pull_request=pull_request,
         operations=operations,
         description=description,
         message=(
@@ -530,7 +538,6 @@ def _finish(
 ) -> int:
     notes: list[str] = []
     raw_reference = store.raw_prefix(spec.key, outcome.run_date, run_token)
-    pull_request = None
     committed_paths: tuple[str, ...] = ()
     publish_failure: submit.PartialSubmissionError | None = None
     raw_manifest: list[dict] = []
@@ -539,7 +546,7 @@ def _finish(
     if raw_store is not None:
         # The snapshot and the intention to publish, before the publishing.
         # Uploading records and then failing to write the ledger leaves them
-        # on the pull request with nothing naming them, and the next run
+        # in the datastore with nothing naming them, and the next run
         # sends the same evaluations again under fresh UUID paths. What this
         # commit writes is enough for that next run to find them instead.
         previous = (
@@ -559,7 +566,7 @@ def _finish(
                     adapter=spec.key,
                     run_date=outcome.run_date.isoformat(),
                     run_token=run_token,
-                    pull_request_number=state.pull_request_number,
+                    destination=store.DIRECT_DESTINATION,
                     records=(
                         []
                         if dry_run
@@ -590,45 +597,32 @@ def _finish(
             submission = _publish(
                 outcome,
                 spec=spec,
-                state=state,
                 submitter=submitter,
                 run_url=run_url,
                 raw_reference=raw_reference,
                 notes=notes,
             )
         except submit.PartialSubmissionError as exc:
-            # Some batches landed. Fall through so the pull request number
-            # and the fingerprints that reached it are still written to the
-            # ledger, then fail the job. Losing them would republish those
-            # records under fresh paths on the next run.
+            # Some batches landed. Fall through so the fingerprints that
+            # reached the datastore are still written to the ledger, then
+            # fail the job. Losing them would republish those records under
+            # fresh paths on the next run.
             publish_failure = exc
-            pull_request = exc.pull_request
             committed_paths = exc.committed_paths
             notes.append(str(exc))
         else:
             if submission is not None:
-                pull_request = submission.pull_request
                 committed_paths = submission.committed_paths
-                for note in (
-                    submission.description_note,
-                    submission.validation_note,
-                ):
-                    if note:
-                        notes.append(note)
-                        outcome.messages.append(note)
+
+    landed = _landed_fingerprints(outcome, committed_paths)
 
     report = outcome.to_manifest()
     report['raw_reference'] = raw_reference
     report['run_token'] = run_token
     report['dry_run'] = dry_run
+    report['records_committed'] = len(landed)
     if publish_failure is not None:
         report['publish_error'] = str(publish_failure)
-        report['records_committed'] = len(committed_paths)
-    if pull_request is not None:
-        report['pull_request'] = {
-            'number': pull_request.number,
-            'url': pull_request.url,
-        }
 
     if raw_store is not None:
         operations = [store.run_report_operation(report, prefix=raw_reference)]
@@ -641,26 +635,21 @@ def _finish(
         if raw_manifest:
             state.last_raw_date = outcome.run_date.isoformat()
             state.last_raw_prefix = raw_reference
-        if pull_request is not None:
-            state.pull_request_number = pull_request.number
-            state.pull_request_url = pull_request.url
-            # Only fingerprints that actually reached the pull request are
-            # remembered, so a failed upload is retried rather than
-            # forgotten, and a batch that landed before a later one failed
-            # is not published a second time. They are remembered as
-            # pending, not durable: they name records on a pull request a
-            # reviewer may still close, and only its merge promotes them.
-            state.pending_fingerprints.update(
-                _landed_fingerprints(outcome, committed_paths)
-            )
+        # Only fingerprints that actually reached the datastore are
+        # remembered, so a failed upload is retried rather than forgotten,
+        # and a batch that landed before a later one failed is not
+        # published a second time. They land on the default branch, so they
+        # are durable the moment they land; there is no reviewer left to
+        # close them out.
+        state.fingerprints.update(landed)
         operations.extend(store.state_operations(state))
         # Nothing is in flight any more: either it is in the ledger above or
-        # it never reached the pull request. Written empty rather than
+        # it never reached the datastore. Written empty rather than
         # deleted, so every run makes the same commit. The exception is a
-        # batch whose commit errored while the pull request ref was
-        # unreadable: those records may have landed anyway, so they stay in
-        # flight for the next run to settle instead of being uploaded again
-        # on top of copies that may already be there.
+        # batch whose commit errored while the datastore was unreadable:
+        # those records may have landed anyway, so they stay in flight for
+        # the next run to settle instead of being uploaded again on top of
+        # copies that may already be there.
         operations.append(
             store.inflight_operation(
                 _still_inflight(
@@ -680,7 +669,7 @@ def _finish(
             parent_commit=parent_commit,
         )
 
-    _report(outcome, spec=spec, pull_request=pull_request, dry_run=dry_run)
+    _report(outcome, spec=spec, published=len(landed), dry_run=dry_run)
     if publish_failure is not None:
         print(str(publish_failure), file=sys.stderr)
         return 1
@@ -691,7 +680,7 @@ def _report(
     outcome: runner.RunOutcome,
     *,
     spec: catalog.AdapterSpec,
-    pull_request: submit.PullRequest | None,
+    published: int,
     dry_run: bool,
 ) -> None:
     lines = [
@@ -699,12 +688,14 @@ def _report(
         '',
         f'- Coverage: {outcome.coverage_line()}',
     ]
-    if pull_request is not None:
-        lines.append(f'- Pull request: {pull_request.url}')
+    if published:
+        lines.append(
+            f'- Published: {published} record(s) committed to the datastore'
+        )
     elif outcome.has_upload and dry_run:
-        lines.append('- Pull request: not opened (dry run)')
+        lines.append('- Published: nothing (dry run)')
     elif not outcome.has_upload and outcome.ok:
-        lines.append('- Pull request: unchanged, nothing to submit')
+        lines.append('- Published: nothing, unchanged since the last run')
     for message in outcome.messages:
         lines.append(f'- {message.splitlines()[0]}')
 
@@ -783,7 +774,10 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument(
         '--run-url',
         default=None,
-        help='Link recorded on every published record and in the PR body.',
+        help=(
+            'Link recorded on every published record and in the datastore '
+            'commit descriptions.'
+        ),
     )
     run_parser.add_argument(
         '--run-id',

--- a/every_eval_ever/cron/store.py
+++ b/every_eval_ever/cron/store.py
@@ -70,6 +70,9 @@ UNCHANGED_MARKER = 'same_as'
 #: How many times a state commit re-reads the head and tries again when
 #: another adapter's job moved the branch first.
 COMMIT_ATTEMPTS = 5
+#: :attr:`InflightBatch.destination` for records committed straight to the
+#: datastore's default branch.
+DIRECT_DESTINATION = 'datastore'
 
 
 class StoreError(RuntimeError):
@@ -162,22 +165,28 @@ class InflightBatch:
 
     Written in the same commit as the raw snapshot, ahead of the datastore
     upload, and emptied by the commit that records the run, except for
-    records whose batch errored while the pull request was unreadable: those
+    records whose batch errored while the datastore was unreadable: those
     stay in flight, since whether they landed is exactly the question this
     file exists to answer. Finding a non-empty one at the start of a run
     means a previous run uploaded records, or may have, without recording
-    them, so they are on the pull request with no fingerprint naming them.
+    them, so they are in the datastore with no fingerprint naming them.
 
-    Each record is its fingerprint and every datastore path it consists of, so
-    the next run can ask the pull request which of them arrived rather than
+    Each record is its fingerprint and every datastore path it consists of,
+    so the next run can ask the datastore which of them arrived rather than
     assuming all or none did.
     """
 
     adapter: str
     run_date: str | None = None
     run_token: str | None = None
-    #: The pull request the records were headed for, when one was known
-    #: already. ``None`` on a cold start, where the upload itself opens it.
+    #: Where the records were headed. :data:`DIRECT_DESTINATION` means the
+    #: datastore's default branch, which is where every run now publishes.
+    #: ``None`` is a file written by the retired pull-request flow: its
+    #: records were headed for :attr:`pull_request_number`, or for a pull
+    #: request the upload itself was to open.
+    destination: str | None = None
+    #: The pull request the records were headed for, when the flow that
+    #: wrote the file used one and knew its number already.
     pull_request_number: int | None = None
     records: list[dict[str, Any]] = field(default_factory=list)
 
@@ -188,6 +197,7 @@ class InflightBatch:
                     'adapter': self.adapter,
                     'run_date': self.run_date,
                     'run_token': self.run_token,
+                    'destination': self.destination,
                     'pull_request_number': self.pull_request_number,
                     'records': [
                         {
@@ -454,6 +464,7 @@ class RawStore:
             )
         batch.run_date = payload.get('run_date')
         batch.run_token = payload.get('run_token')
+        batch.destination = payload.get('destination')
         batch.pull_request_number = payload.get('pull_request_number')
         for record in payload.get('records') or ():
             fingerprint = (record or {}).get('fingerprint')
@@ -668,6 +679,7 @@ def state_operations(state: AdapterState) -> list[CommitOperationAdd]:
 __all__ = [
     'COMMIT_ATTEMPTS',
     'DEFAULT_RAW_REPO',
+    'DIRECT_DESTINATION',
     'MANIFEST_NAME',
     'RAW_DIR',
     'RUN_REPORT_NAME',

--- a/every_eval_ever/cron/submit.py
+++ b/every_eval_ever/cron/submit.py
@@ -1,19 +1,18 @@
-"""Send one adapter's records to that adapter's own datastore pull request.
+"""Commit one adapter's records straight to the datastore.
 
-The rule the ticket asks for is one pull request per adapter, reused across
-runs. Getting that wrong is expensive in both directions: opening a fresh
-pull request every day buries reviewers, and guessing at which existing one
-to reuse can push a scrape into somebody else's submission. So the pull
-request is remembered by number, re-checked before use, and identified by two
-things the cron itself controls, never by "the newest open one".
+Cron output used to go up as one pull request per adapter, reused across
+runs, waiting on a human merge. The review that matters happens before
+publication: nothing reaches this module that the packaged validator has not
+passed, records are de-duplicated against the per-adapter ledger, and every
+record names its run in `source_metadata.additional_details`. The pull
+request added only a click to that, so passing runs now commit directly to
+the datastore's default branch, one commit series per adapter run.
 
-Those two are the account that opened it and the ``eee-cron-adapter`` line in
-its body. The account matters most: the datastore is public, so anyone can
-open a pull request whose first comment carries our marker, and a run that
-adopted it would commit records onto a branch a stranger controls. The marker
-then says which adapter it belongs to.
-
-An ambiguous match is an error. There is no safe guess.
+The pull-request machinery that remains, finding a pull request by author
+and marker and asking what became of it, exists to settle what the retired
+flow left behind: pending fingerprints waiting on a pull request a reviewer
+may yet merge or close, and in-flight batches that were headed for one. It
+can go once no adapter's state names a pull request.
 """
 
 from __future__ import annotations
@@ -24,7 +23,8 @@ from typing import Any, Sequence
 from huggingface_hub import CommitOperationAdd
 
 DEFAULT_DATASTORE_REPO = 'evaleval/EEE_datastore'
-#: Machine-readable line in the pull request body identifying its adapter.
+#: Machine-readable line the retired flow wrote into a pull request body to
+#: identify its adapter. Still how a leftover pull request is recognised.
 MARKER_PREFIX = 'eee-cron-adapter:'
 #: A single commit of thousands of files can 504 with the commit still
 #: landing server-side, so batches are kept small.
@@ -32,11 +32,6 @@ DEFAULT_BATCH_SIZE = 300
 #: How an instance-level sidecar is named after its aggregate. The two are
 #: one record and are committed together.
 SAMPLES_SUFFIX = '_samples.jsonl'
-#: The comment that asks the datastore's validation bot to check what a pull
-#: request now carries. Validation on the Hub side runs on request, not on
-#: push: a pull request nobody comments on is a pull request nobody
-#: validated (see evaleval/EEE_datastore discussion 168).
-VALIDATION_COMMAND = '/eee validate changed'
 
 
 class SubmissionError(RuntimeError):
@@ -55,32 +50,26 @@ class PartialSubmissionError(SubmissionError):
     UUID paths, which is the duplicate this exists to prevent.
 
     ``unresolved_paths`` names the one batch that is neither: its commit
-    errored and the pull request ref could not be read to arbitrate, so the
-    records may or may not have landed. A caller must keep them in flight
-    rather than treat them as absent, because re-uploading them blind is the
-    same duplicate by another route.
+    errored and the datastore could not be read to arbitrate, so the records
+    may or may not have landed. A caller must keep them in flight rather
+    than treat them as absent, because re-uploading them blind is the same
+    duplicate by another route.
     """
 
     def __init__(
         self,
         message: str,
         *,
-        pull_request: PullRequest | None,
         committed_paths: Sequence[str],
         unresolved_paths: Sequence[str] = (),
     ) -> None:
         super().__init__(message)
-        self.pull_request = pull_request
         self.committed_paths = tuple(committed_paths)
         self.unresolved_paths = tuple(unresolved_paths)
 
 
 def marker(adapter: str) -> str:
     return f'{MARKER_PREFIX} {adapter}'
-
-
-def pull_request_title(adapter: str) -> str:
-    return f'[Submission] cron: {adapter} (automated ingestion)'
 
 
 def _opening_comment(details: Any) -> Any | None:
@@ -101,7 +90,7 @@ def _first_comment(details: Any) -> str:
 
 @dataclass(frozen=True)
 class PullRequest:
-    """The datastore pull request one adapter publishes into."""
+    """A datastore pull request the retired flow published into."""
 
     number: int
     url: str
@@ -113,16 +102,7 @@ class PullRequest:
 class Submission:
     """What one publish attempt actually put in the datastore."""
 
-    pull_request: PullRequest
     committed_paths: tuple[str, ...]
-    #: Why the pull request body still describes an earlier run, when it does.
-    #: Not a failure: the records are published either way.
-    description_note: str | None = None
-    #: Why the datastore's validator was not asked to check this pull
-    #: request, when it was not. Not a failure either, but worth a human
-    #: reading: an unvalidated pull request sits unreviewed until somebody
-    #: posts the command by hand.
-    validation_note: str | None = None
 
 
 def _discussion_number(discussion: Any) -> int | None:
@@ -159,7 +139,7 @@ def _is_open_pull_request(discussion: Any) -> bool:
 
 
 class DatastoreSubmitter:
-    """Find or open one adapter's pull request, and upload into it."""
+    """Commit an adapter's records to the datastore's default branch."""
 
     def __init__(
         self,
@@ -175,6 +155,10 @@ class DatastoreSubmitter:
         self.batch_size = batch_size
         self._identity: dict[str, Any] | None = None
 
+    @property
+    def repo_url(self) -> str:
+        return f'https://huggingface.co/datasets/{self.repo_id}'
+
     def _resolve_identity(self) -> dict[str, Any]:
         """Return who this token is, asked once and cached."""
         if self._identity is not None:
@@ -189,7 +173,7 @@ class DatastoreSubmitter:
         if not isinstance(identity, dict) or not identity.get('name'):
             raise SubmissionError(
                 'the Hub reported no username for this token; refusing to '
-                'reuse a pull request without knowing who opened it'
+                'settle pull requests without knowing who opened them'
             )
         self._identity = identity
         return identity
@@ -198,10 +182,10 @@ class DatastoreSubmitter:
     def author(self) -> str:
         """Return the account this run publishes as.
 
-        Nothing this cron did not open is a candidate for reuse. A token
-        without a resolvable identity is an error rather than an empty filter,
-        because an empty filter is how every open pull request on a public
-        datastore becomes adoptable.
+        Nothing this cron did not open counts when settling leftover pull
+        requests. A token without a resolvable identity is an error rather
+        than an empty filter, because an empty filter is how every open pull
+        request on a public datastore becomes adoptable.
         """
         return self._resolve_identity()['name']
 
@@ -224,8 +208,8 @@ class DatastoreSubmitter:
         if role == 'read':
             raise SubmissionError(
                 f'the token authenticates as {identity["name"]} but is '
-                f'read-only. Opening a pull request on {self.repo_id} and '
-                'writing the raw store both need write access.'
+                f'read-only. Committing to {self.repo_id} and writing the '
+                'raw store both need write access.'
             )
         try:
             self.api.repo_info(repo_id=self.repo_id, repo_type='dataset')
@@ -235,6 +219,119 @@ class DatastoreSubmitter:
                 f'{type(exc).__name__}: {exc}. Check EEE_DATASTORE_REPO_ID '
                 'and that this token may read it.'
             ) from exc
+
+    # -- publishing -------------------------------------------------------
+
+    def publish(
+        self,
+        *,
+        operations: Sequence[CommitOperationAdd],
+        description: str,
+        message: str,
+    ) -> Submission:
+        """Commit records to the datastore, in bounded batches.
+
+        Batches are whole records (see :func:`_batches`), so every commit
+        either publishes a record completely or not at all. Each commit
+        carries ``description``, so the provenance a reviewer used to read
+        in a pull request body is on the commits themselves.
+
+        A commit that errored after the Hub accepted it is adopted rather
+        than repeated: the datastore's file listing arbitrates, and a batch
+        proven present counts as committed and the upload carries on.
+
+        A failure after something landed raises
+        :class:`PartialSubmissionError` carrying what did, so the caller can
+        record it and retry the remainder instead of publishing it twice.
+        """
+        batches = _batches(operations, self.batch_size)
+        committed: list[str] = []
+        total = len(batches)
+        for index, batch in enumerate(batches, start=1):
+            suffix = f' ({index}/{total})' if total > 1 else ''
+            try:
+                self.api.create_commit(
+                    repo_id=self.repo_id,
+                    repo_type='dataset',
+                    operations=list(batch),
+                    commit_message=f'{message}{suffix}',
+                    commit_description=description,
+                )
+            except Exception as exc:  # noqa: BLE001 - re-raised with context
+                landed = self._landed_anyway(batch)
+                if landed:
+                    # The Hub accepted the commit and only the reply was
+                    # lost, so this batch is in the datastore and the upload
+                    # carries on. Stopping here instead would end a run
+                    # whose every batch landed as a failure nothing retries,
+                    # because its records are all accounted for.
+                    committed.extend(landed)
+                    continue
+                unresolved: list[str] = []
+                if landed is None:
+                    unresolved = [
+                        operation.path_in_repo for operation in batch
+                    ]
+                    hint = (
+                        ' Whether the failing batch landed could not be '
+                        'checked either; if the error was a timeout whose '
+                        'commit went through, a retry would duplicate its '
+                        f'records, so inspect {self.repo_url} before '
+                        're-running.'
+                    )
+                else:
+                    hint = ''
+                raise PartialSubmissionError(
+                    f'could not commit records to {self.repo_id}: '
+                    f'{type(exc).__name__}: {exc}.{hint}',
+                    committed_paths=committed,
+                    unresolved_paths=unresolved,
+                ) from exc
+            committed.extend(operation.path_in_repo for operation in batch)
+        return Submission(committed_paths=tuple(committed))
+
+    def _landed_anyway(
+        self, batch: Sequence[CommitOperationAdd]
+    ) -> list[str] | None:
+        """Return the failed batch's paths if its commit landed regardless.
+
+        A ``create_commit`` can time out after the Hub has accepted the
+        commit (see :data:`DEFAULT_BATCH_SIZE`), so the error alone does not
+        say the batch is absent. The datastore is the arbiter: a Hub commit
+        is atomic, so either every path in the batch is there or none is.
+        ``None`` means the datastore could not be read, which the caller
+        reports rather than resolves.
+        """
+        paths = [operation.path_in_repo for operation in batch]
+        present = self.paths_present(paths)
+        if present is None:
+            return None
+        return paths if len(present) == len(paths) else []
+
+    def paths_present(
+        self, paths: Sequence[str], *, revision: str | None = None
+    ) -> set[str] | None:
+        """Return which of ``paths`` exist at ``revision``, or ``None``.
+
+        ``revision`` defaults to the datastore's default branch, where runs
+        publish; settling a leftover pull request passes its ref instead.
+        ``None`` means the question could not be asked, which callers report
+        rather than resolve: an empty answer and an unanswerable one mean
+        opposite things about whether records were published.
+        """
+        try:
+            files = set(
+                self.api.list_repo_files(
+                    repo_id=self.repo_id,
+                    repo_type='dataset',
+                    revision=revision,
+                )
+            )
+        except Exception:  # noqa: BLE001 - the caller decides what it means
+            return None
+        return {path for path in paths if path in files}
+
+    # -- settling what the retired pull-request flow left behind ----------
 
     def _open_pull_requests(self) -> list[Any]:
         """Return the open pull requests this account opened, and no others."""
@@ -266,12 +363,12 @@ class DatastoreSubmitter:
         """Return whether a pull request body claims this adapter.
 
         Which adapter a pull request belongs to is the ``eee-cron-adapter``
-        line the cron wrote into the body, not the title. A title is display
-        metadata: anyone can edit it to something that looks like ours, and a
-        reviewer renaming ours does not hand it to somebody else. A body that
-        cannot be read is an error rather than a "no", because silently
-        treating it as unowned opens a second pull request for the same
-        adapter.
+        line the retired flow wrote into the body, not the title. A title is
+        display metadata: anyone can edit it to something that looks like
+        ours, and a reviewer renaming ours does not hand it to somebody
+        else. A body that cannot be read is an error rather than a "no",
+        because silently treating it as unowned would mis-settle whatever is
+        still waiting on that pull request.
 
         Callers reach this only for pull requests :attr:`author` opened, so
         the marker answers "which adapter", not "is this ours".
@@ -288,72 +385,6 @@ class DatastoreSubmitter:
                 f'{type(exc).__name__}: {exc}'
             ) from exc
         return marker(adapter) in _first_comment(details)
-
-    def update_description(
-        self, pull_request: PullRequest, description: str
-    ) -> None:
-        """Rewrite a reused pull request's body to describe this run.
-
-        A pull request is opened once and published into for as long as it
-        stays open, so a body written at open time describes whichever run
-        happened to be first. A reviewer opening it a month later reads that
-        run's date, its coverage line and its raw-snapshot path, none of which
-        are true of what is in front of them.
-
-        The rewritten body carries the ``eee-cron-adapter`` marker like any
-        other, since that line is what says which adapter the pull request
-        belongs to and dropping it would orphan it from the next run.
-        """
-        try:
-            details = self.api.get_discussion_details(
-                repo_id=self.repo_id,
-                repo_type='dataset',
-                discussion_num=pull_request.number,
-            )
-        except Exception as exc:  # noqa: BLE001 - re-raised with context
-            raise SubmissionError(
-                f'could not read pull request {pull_request.number} on '
-                f'{self.repo_id} to refresh its description: '
-                f'{type(exc).__name__}: {exc}'
-            ) from exc
-        comment = _opening_comment(details)
-        comment_id = getattr(comment, 'id', None) if comment else None
-        if not comment_id:
-            raise SubmissionError(
-                f'pull request {pull_request.number} on {self.repo_id} has no '
-                'readable opening comment to refresh'
-            )
-        try:
-            self.api.edit_discussion_comment(
-                repo_id=self.repo_id,
-                repo_type='dataset',
-                discussion_num=pull_request.number,
-                comment_id=comment_id,
-                new_content=description,
-            )
-        except Exception as exc:  # noqa: BLE001 - re-raised with context
-            raise SubmissionError(
-                f'could not refresh the description of pull request '
-                f'{pull_request.number} on {self.repo_id}: '
-                f'{type(exc).__name__}: {exc}'
-            ) from exc
-
-    def request_validation(self, pull_request: PullRequest) -> None:
-        """Post :data:`VALIDATION_COMMAND` on a pull request, as a new
-        comment, which is what makes the datastore validate it."""
-        try:
-            self.api.comment_discussion(
-                repo_id=self.repo_id,
-                repo_type='dataset',
-                discussion_num=pull_request.number,
-                comment=VALIDATION_COMMAND,
-            )
-        except Exception as exc:  # noqa: BLE001 - re-raised with context
-            raise SubmissionError(
-                f'could not request validation on pull request '
-                f'{pull_request.number} on {self.repo_id}: '
-                f'{type(exc).__name__}: {exc}'
-            ) from exc
 
     def pull_request_status(self, number: int) -> str:
         """Return ``open``, ``merged`` or ``closed`` for a pull request.
@@ -397,14 +428,12 @@ class DatastoreSubmitter:
         return status
 
     def resolve_known(self, adapter: str, number: int) -> PullRequest | None:
-        """Return the remembered pull request if it is still usable.
+        """Return the remembered pull request if it still answers for itself.
 
-        Usable means: opened by this account, still open, still a pull
+        That means: opened by this account, still open, still a pull
         request, and still carrying this adapter's marker in its body. A
-        merged, closed, or repurposed discussion is treated as gone, so the
-        next run opens a fresh one rather than pushing into something a
-        reviewer has finished with. A remembered number that now points at
-        somebody else's pull request is treated as gone for the same reason.
+        merged, closed, or repurposed discussion returns ``None``, as does a
+        remembered number that now points at somebody else's pull request.
         """
         for discussion in self._open_pull_requests():
             if _discussion_number(discussion) != number:
@@ -422,13 +451,13 @@ class DatastoreSubmitter:
         return None
 
     def find_by_marker(self, adapter: str) -> PullRequest | None:
-        """Find this adapter's pull request when no number is remembered.
+        """Find an adapter's leftover pull request when no number is known.
 
-        Every open pull request this account opened is checked for the marker,
-        including ones whose title no longer looks like ours, because a title
-        edit must not strand the pull request the cron has been publishing
-        into. Two matches is an error rather than a choice: picking one would
-        mean appending a scrape to a pull request nobody expected it in.
+        Every open pull request this account opened is checked for the
+        marker, including ones whose title no longer looks like ours,
+        because a title edit must not strand a pull request records are
+        waiting on. Two matches is an error rather than a choice: picking
+        one would settle records against a pull request nobody sent them to.
         """
         matches = []
         for discussion in self._open_pull_requests():
@@ -460,319 +489,6 @@ class DatastoreSubmitter:
             )
         return matches[0]
 
-    def open_pull_request(
-        self,
-        adapter: str,
-        *,
-        operations: Sequence[CommitOperationAdd],
-        description: str,
-    ) -> tuple[PullRequest, bool]:
-        """Open this adapter's pull request with its first batch of records.
-
-        Returns the pull request and whether this call is what created it. A
-        ``create_commit`` can time out after the Hub accepted it, and the call
-        that opens a pull request is the one where that matters most: the
-        number is reported in the reply nobody received, so the run fails
-        knowing nothing, and the next run opens a second pull request holding
-        the same records.
-
-        So a failure here asks the Hub whether the pull request exists after
-        all, by the same account-plus-marker rule used everywhere else. Finding
-        it means the commit landed and this call simply lost the answer.
-        Finding nothing means it did not, which is the error it always was.
-        """
-        try:
-            commit = self.api.create_commit(
-                repo_id=self.repo_id,
-                repo_type='dataset',
-                operations=list(operations),
-                commit_message=pull_request_title(adapter),
-                commit_description=description,
-                create_pr=True,
-            )
-        except Exception as exc:  # noqa: BLE001 - re-raised with context
-            landed = self._opened_despite(adapter)
-            if landed is not None:
-                return landed, False
-            raise SubmissionError(
-                f'could not open a pull request on {self.repo_id}: '
-                f'{type(exc).__name__}: {exc}'
-            ) from exc
-
-        url = getattr(commit, 'pr_url', None)
-        number = getattr(commit, 'pr_num', None)
-        if number is None and isinstance(url, str) and '/discussions/' in url:
-            try:
-                number = int(url.rsplit('/discussions/', 1)[-1].strip('/'))
-            except ValueError:
-                number = None
-        if number is None:
-            landed = self._opened_despite(adapter)
-            if landed is not None:
-                return landed, True
-            raise SubmissionError(
-                'the Hub accepted the commit but did not report a pull '
-                'request number; check the repository before re-running so '
-                'a second pull request is not opened'
-            )
-        revision = getattr(commit, 'pr_revision', None) or f'refs/pr/{number}'
-        return (
-            PullRequest(
-                number=number,
-                url=url
-                or f'https://huggingface.co/datasets/{self.repo_id}/discussions/{number}',
-                revision=revision,
-                title=pull_request_title(adapter),
-            ),
-            True,
-        )
-
-    def _opened_despite(self, adapter: str) -> PullRequest | None:
-        """Return this adapter's pull request if one exists after a failure.
-
-        Answering "did the commit land" by looking for what it would have
-        created. Only pull requests this account opened carrying this
-        adapter's marker count, the same rule that governs reuse anywhere
-        else, so nothing is adopted that the cron did not open.
-
-        A lookup that itself fails answers nothing, and the caller reports the
-        original failure. The pull request, if there is one, is found by the
-        next run instead.
-        """
-        try:
-            return self.find_by_marker(adapter)
-        except AmbiguousPullRequestError:
-            raise
-        except SubmissionError:
-            return None
-
-    def upload(
-        self,
-        pull_request: PullRequest,
-        *,
-        operations: Sequence[CommitOperationAdd],
-        message: str,
-    ) -> list[Any]:
-        """Add records to an existing pull request, in bounded batches."""
-        return self._upload_batches(
-            pull_request,
-            batches=_batches(operations, self.batch_size),
-            message=message,
-            committed=[],
-        )
-
-    def _upload_batches(
-        self,
-        pull_request: PullRequest,
-        *,
-        batches: Sequence[Sequence[CommitOperationAdd]],
-        message: str,
-        committed: list[str],
-        offset: int = 0,
-        total: int | None = None,
-    ) -> list[Any]:
-        commits = []
-        total = len(batches) + offset if total is None else total
-        for index, batch in enumerate(batches, start=offset + 1):
-            suffix = f' ({index}/{total})' if total > 1 else ''
-            try:
-                commits.append(
-                    self.api.create_commit(
-                        repo_id=self.repo_id,
-                        repo_type='dataset',
-                        revision=pull_request.revision,
-                        operations=list(batch),
-                        commit_message=f'{message}{suffix}',
-                    )
-                )
-            except Exception as exc:  # noqa: BLE001 - re-raised with context
-                landed = self._paths_on_ref(pull_request, batch)
-                if landed:
-                    # The Hub accepted the commit and only the reply was
-                    # lost, so this batch is on the pull request and the
-                    # upload carries on. Stopping here instead would end a
-                    # run whose every batch landed as a failure nothing
-                    # retries, because its records are all accounted for.
-                    committed.extend(landed)
-                    continue
-                unresolved: list[str] = []
-                if landed is None:
-                    unresolved = [operation.path_in_repo for operation in batch]
-                    hint = (
-                        ' Whether the failing batch landed could not be '
-                        'checked either; if the error was a timeout whose '
-                        'commit went through, a retry would duplicate its '
-                        f'records, so inspect {pull_request.url} before '
-                        're-running.'
-                    )
-                else:
-                    hint = ''
-                raise PartialSubmissionError(
-                    f'could not add records to {pull_request.url}: '
-                    f'{type(exc).__name__}: {exc}.{hint}',
-                    pull_request=pull_request,
-                    committed_paths=committed,
-                    unresolved_paths=unresolved,
-                ) from exc
-            committed.extend(operation.path_in_repo for operation in batch)
-        return commits
-
-    def _paths_on_ref(
-        self,
-        pull_request: PullRequest,
-        batch: Sequence[CommitOperationAdd],
-    ) -> list[str] | None:
-        """Return the failed batch's paths if its commit landed regardless.
-
-        A ``create_commit`` can time out after the Hub has accepted the
-        commit (see :data:`DEFAULT_BATCH_SIZE`), so the error alone does not
-        say the batch is absent. Reporting only the earlier batches in that
-        case makes the caller's ledger forget the ambiguous one, and the
-        retry republishes it under fresh UUID paths. The pull request ref is
-        the arbiter: a Hub commit is atomic, so either every path in the
-        batch is there or none is. ``None`` means the ref could not be read,
-        which the caller reports rather than resolves.
-        """
-        paths = [operation.path_in_repo for operation in batch]
-        present = self.paths_present(paths, revision=pull_request.revision)
-        if present is None:
-            return None
-        return paths if len(present) == len(paths) else []
-
-    def paths_present(
-        self, paths: Sequence[str], *, revision: str | None = None
-    ) -> set[str] | None:
-        """Return which of ``paths`` exist at ``revision``, or ``None``.
-
-        ``None`` means the question could not be asked, which callers report
-        rather than resolve: an empty answer and an unanswerable one mean
-        opposite things about whether records were published.
-        """
-        try:
-            files = set(
-                self.api.list_repo_files(
-                    repo_id=self.repo_id,
-                    repo_type='dataset',
-                    revision=revision,
-                )
-            )
-        except Exception:  # noqa: BLE001 - the caller decides what it means
-            return None
-        return {path for path in paths if path in files}
-
-    def publish(
-        self,
-        adapter: str,
-        *,
-        pull_request: PullRequest | None,
-        operations: Sequence[CommitOperationAdd],
-        description: str,
-        message: str,
-    ) -> Submission:
-        """Send one adapter's records, opening its pull request if needed.
-
-        Every commit is bounded, including the one that opens the pull
-        request: a cold start is the largest upload an adapter ever does, so
-        exempting it from the batch size aimed the ambiguous-timeout problem
-        at exactly the run most likely to hit it.
-
-        Batches are whole records (see :func:`_batches`), so every commit
-        either publishes a record completely or not at all.
-
-        A reused pull request has its description rewritten afterwards, so the
-        body a reviewer reads describes the run that last added to it rather
-        than whichever run opened it.
-
-        A submission that lands completely ends by requesting validation
-        (see :meth:`request_validation`); a partial one leaves that to the
-        retry that completes it.
-
-        An opening commit that errored after landing is adopted rather than
-        repeated, and what it left on the ref decides whether its batch counts
-        as published.
-
-        A failure after something landed raises
-        :class:`PartialSubmissionError` carrying what did, so the caller can
-        record it and retry the remainder instead of publishing it twice.
-        """
-        batches = _batches(operations, self.batch_size)
-        committed: list[str] = []
-        reused = pull_request is not None
-        offset = 0
-        if pull_request is None:
-            first = batches[0] if batches else []
-            pull_request, opened = self.open_pull_request(
-                adapter, operations=first, description=description
-            )
-            batches = batches[1:]
-            offset = 1
-            if opened:
-                committed.extend(operation.path_in_repo for operation in first)
-            else:
-                # The pull request exists, so the commit that created it
-                # landed and this run only lost the reply. Its files are on
-                # the ref or they are not; either answer is better than
-                # assuming, because assuming they landed loses records and
-                # assuming they did not duplicates them.
-                landed = self._paths_on_ref(pull_request, first)
-                if landed is None:
-                    raise PartialSubmissionError(
-                        f'a pull request for {adapter} was opened at '
-                        f'{pull_request.url} but the error hid its reply, and '
-                        'whether its first batch landed could not be checked; '
-                        'inspect it before re-running',
-                        pull_request=pull_request,
-                        committed_paths=(),
-                        unresolved_paths=[
-                            operation.path_in_repo for operation in first
-                        ],
-                    )
-                if landed:
-                    committed.extend(landed)
-                else:
-                    # An empty pull request from an earlier interrupted run.
-                    # Send this batch into it rather than opening another.
-                    batches = [first, *batches]
-                    offset = 0
-        self._upload_batches(
-            pull_request,
-            batches=batches,
-            message=message,
-            committed=committed,
-            offset=offset,
-            total=len(batches) + offset,
-        )
-        note = None
-        if reused:
-            # After the records, not before: a body describing an upload that
-            # then failed is worse than one describing last week's.
-            try:
-                self.update_description(pull_request, description)
-            except SubmissionError as exc:
-                # The records are in. A stale body is worth reporting and not
-                # worth failing a run that published everything it meant to.
-                note = f'{exc}; the body still describes an earlier run'
-        validation_note = None
-        # Last, once the pull request holds everything this run meant to
-        # publish, so the validator reads the finished submission. A partial
-        # submission never reaches here, which is deliberate: asking for
-        # validation of half an upload wastes the reviewer the command
-        # summons.
-        try:
-            self.request_validation(pull_request)
-        except SubmissionError as exc:
-            # The records are in, same bargain as the description: report
-            # that nobody asked for validation rather than fail the run.
-            validation_note = (
-                f'{exc}; post `{VALIDATION_COMMAND}` on it manually'
-            )
-        return Submission(
-            pull_request=pull_request,
-            committed_paths=tuple(committed),
-            description_note=note,
-            validation_note=validation_note,
-        )
-
 
 def _record_key(path_in_repo: str) -> str:
     """Return the aggregate a staged datastore path belongs to."""
@@ -791,12 +507,11 @@ def _batches(
     therefore what makes "this record landed" a question with an answer.
 
     Chunking the flat file list could put an aggregate in one commit and its
-    sidecar in the next. When the second failed, the first was already on the
-    pull request, the record could not be recorded as published because half
+    sidecar in the next. When the second failed, the first was already in the
+    datastore, the record could not be recorded as published because half
     of it had not arrived, and the retry sent the whole record again under a
-    fresh UUID. The abandoned half stayed on the pull request declaring a
-    companion file that does not exist, which a human then has to clear out
-    before it can be merged.
+    fresh UUID. The abandoned half stayed behind declaring a companion file
+    that does not exist, which a human then has to clear out.
 
     A record larger than ``size`` gets a commit to itself rather than being
     split, since splitting is the thing this exists to prevent.
@@ -836,7 +551,7 @@ def upload_operations(upload_dir: Any) -> list[CommitOperationAdd]:
     return operations
 
 
-def pull_request_description(
+def commit_description(
     adapter: str,
     *,
     coverage_line: str,
@@ -846,12 +561,9 @@ def pull_request_description(
     raw_reference: str | None = None,
     notes: Sequence[str] = (),
 ) -> str:
-    """Compose the body a reviewer reads, including the machine marker."""
+    """Compose the description every datastore commit of one run carries."""
     lines = [
-        f'Automated daily ingestion for the `{adapter}` adapter.',
-        '',
-        'Records accumulate here across runs. The figures below describe the '
-        'run that last added to this pull request.',
+        f'Automated ingestion for the `{adapter}` adapter.',
         '',
         f'- **Run date**: {run_date}',
         f'- **Status**: {status}',
@@ -869,12 +581,10 @@ def pull_request_description(
         '',
         'Adapter code lives in '
         '[`every_eval_ever`](https://github.com/evaleval/every_eval_ever) '
-        'under `every_eval_ever/adapters/`; this pull request carries data '
-        'only.',
+        'under `every_eval_ever/adapters/`; this commit carries data only.',
     ]
     if notes:
         lines += ['', '### Notes', *[f'- {note}' for note in notes]]
-    lines += ['', marker(adapter)]
     return '\n'.join(lines)
 
 
@@ -889,9 +599,7 @@ __all__ = [
     'Submission',
     'SubmissionError',
     'SAMPLES_SUFFIX',
-    'VALIDATION_COMMAND',
+    'commit_description',
     'marker',
-    'pull_request_description',
-    'pull_request_title',
     'upload_operations',
 ]

--- a/tests/test_cron_cli.py
+++ b/tests/test_cron_cli.py
@@ -272,7 +272,7 @@ def test_a_token_that_cannot_publish_stops_the_run_before_the_adapter(
 # --- what a finished run commits -----------------------------------------
 
 
-def test_a_successful_run_opens_a_pull_request_and_records_it(
+def test_a_successful_run_commits_its_records_and_remembers_them(
     tmp_path,
 ) -> None:
     hub = FakeHub()
@@ -281,15 +281,17 @@ def test_a_successful_run_opens_a_pull_request_and_records_it(
 
     assert finish(outcome, hub) == 0
 
-    assert datastore_commits(hub)[0]['create_pr'] is True
+    upload_commit = datastore_commits(hub)[0]
+    assert 'create_pr' not in upload_commit
+    assert 'revision' not in upload_commit
     state = json.loads(hub.files['state/hle.json'])
-    assert state['pull_request_number'] == 42
+    assert state['pull_request_number'] is None
     assert state['last_run_date'] == '2026-08-10'
     assert state['last_status'] == 'completed'
-    # Committed to a pull request is not merged into the datastore, so the
-    # fingerprint waits in the pending ledger until the pull request does.
-    assert hub.files['state/hle.pending'] == 'fingerprint-0\n'
-    assert hub.files['state/hle.fingerprints'] == ''
+    # On the default branch a record is durable the moment its commit lands,
+    # so its fingerprint goes straight into the durable ledger.
+    assert hub.files['state/hle.fingerprints'] == 'fingerprint-0\n'
+    assert hub.files['state/hle.pending'] == ''
 
 
 def test_the_snapshot_is_committed_before_the_records_are_published(
@@ -335,11 +337,16 @@ def test_the_snapshot_is_committed_before_the_records_are_published(
     assert json.loads(hub.files['state/hle.inflight'])['records'] == []
     report = json.loads(hub.files[f'{RAW_PREFIX}/run.json'])
     assert report['status'] == 'completed'
-    assert report['pull_request']['number'] == 42
+    assert report['records_committed'] == 1
     assert report['raw_reference'] == RAW_PREFIX
 
 
-def test_a_second_run_reuses_the_remembered_pull_request(tmp_path) -> None:
+def test_a_run_with_a_leftover_pull_request_still_commits_directly(
+    tmp_path,
+) -> None:
+    """A state file remembering the retired flow's pull request must not pull
+    new records back into it; the pull request only matters for settling the
+    pending fingerprints still waiting on it."""
     hub = FakeHub(
         {
             'state/hle.json': json.dumps(
@@ -359,34 +366,15 @@ def test_a_second_run_reuses_the_remembered_pull_request(tmp_path) -> None:
     assert finish(outcome, hub) == 0
 
     upload_commit = datastore_commits(hub)[0]
-    assert upload_commit['revision'] == 'refs/pr/12'
     assert 'create_pr' not in upload_commit
-    # The merged ledger is untouched; the new record waits on the still-open
-    # pull request it was just committed to.
-    assert hub.files['state/hle.fingerprints'] == 'known-0\n'
-    assert hub.files['state/hle.pending'] == 'fingerprint-0\n'
-    # The body now describes this run, not whichever one opened the request.
-    assert [number for number, _ in hub.edited_comments] == [12]
-    body = hub.discussions[0].body
-    assert RAW_PREFIX in body
-    assert '2026-08-10' in body
-
-
-def test_a_stale_description_is_reported_and_not_fatal(tmp_path) -> None:
-    """The records reached the pull request; only its body did not."""
-    hub = FakeHub(
-        {'state/hle.json': json.dumps({'pull_request_number': 12})},
-        discussions=[cron_pr(12)],
-    )
-    hub.edit_comment_error = RuntimeError('403 Forbidden')
-    outcome = make_outcome(tmp_path)
-    write_capture(outcome.raw_dir)
-
-    assert finish(outcome, hub) == 0
-
-    assert hub.files['state/hle.pending'] == 'fingerprint-0\n'
-    report = json.loads(hub.files[f'{RAW_PREFIX}/run.json'])
-    assert any('403 Forbidden' in message for message in report['messages'])
+    assert 'revision' not in upload_commit
+    # The new record is durable in the datastore; nothing new waits on the
+    # old pull request.
+    assert set(hub.files['state/hle.fingerprints'].split()) == {
+        'known-0',
+        'fingerprint-0',
+    }
+    assert hub.files['state/hle.pending'] == ''
 
 
 # --- records published but never recorded --------------------------------
@@ -450,8 +438,47 @@ def test_records_that_never_arrived_are_published_again() -> None:
     assert 'published 1 of 2' in note
 
 
+def test_a_direct_batch_in_flight_is_settled_against_the_datastore() -> None:
+    """What lands on the default branch is durable, so the settled
+    fingerprints go straight into the durable ledger."""
+    hub = FakeHub()
+    hub.files[record_entry(0)['paths'][0]] = '{}'
+    inflight(
+        hub,
+        destination=store.DIRECT_DESTINATION,
+        records=[record_entry(0), record_entry(1)],
+    )
+    state = store.AdapterState(adapter='hle')
+
+    note = cli._reconcile_inflight(
+        state, store.RawStore(hub), submit.DatastoreSubmitter(hub)
+    )
+
+    assert state.fingerprints == {'fingerprint-0'}
+    assert state.pending_fingerprints == set()
+    assert 'published 1 of 2' in note
+
+
+def test_an_unanswerable_direct_settle_stops_the_run() -> None:
+    """Both guesses lose: one buries records, the other duplicates them."""
+    hub = FakeHub()
+    hub.list_files_error = ConnectionError('network is unreachable')
+    inflight(
+        hub,
+        destination=store.DIRECT_DESTINATION,
+        records=[record_entry(0)],
+    )
+    state = store.AdapterState(adapter='hle')
+
+    with pytest.raises(submit.SubmissionError, match='without recording'):
+        cli._reconcile_inflight(
+            state, store.RawStore(hub), submit.DatastoreSubmitter(hub)
+        )
+
+
 def test_a_batch_in_flight_to_no_pull_request_is_published_again() -> None:
-    """A cold start whose opening commit never landed."""
+    """A cold start under the retired flow, whose opening commit never
+    landed."""
     hub = FakeHub()
     inflight(hub, records=[record_entry(0)])
     state = store.AdapterState(adapter='hle')
@@ -656,7 +683,7 @@ def test_records_from_a_closed_pull_request_are_resubmitted(
 ) -> None:
     """The end-to-end shape of the requeue: the closed pull request's
     fingerprints are not handed to the runner as known, so the unchanged
-    records upload again, and a fresh pull request opens to carry them."""
+    records upload again, straight to the datastore this time."""
     hub = FakeHub(
         {
             'state/hle.json': json.dumps({'pull_request_number': 12}),
@@ -690,10 +717,11 @@ def test_records_from_a_closed_pull_request_are_resubmitted(
 
     assert exit_code == 0
     assert seen['known'] == set()
-    assert any(commit.get('create_pr') for commit in hub.commits)
+    assert not any(commit.get('create_pr') for commit in hub.commits)
     state = json.loads(hub.files['state/hle.json'])
-    assert state['pull_request_number'] == 42
-    assert hub.files['state/hle.pending'] == 'fingerprint-0\n'
+    assert state['pull_request_number'] is None
+    assert hub.files['state/hle.fingerprints'] == 'fingerprint-0\n'
+    assert hub.files['state/hle.pending'] == ''
     report = json.loads(hub.files[f'{RAW_PREFIX}/run.json'])
     assert any(
         'closed without merging' in message for message in report['messages']
@@ -707,10 +735,9 @@ def test_records_that_landed_before_a_failure_are_still_remembered(
 
     The batches that landed are irreversible. Leaving their fingerprints out
     of the ledger would make the next run publish them again under fresh
-    paths, so the pull request would hold each evaluation twice.
+    paths, so the datastore would hold each evaluation twice.
     """
-    hub = FakeHub(discussions=[cron_pr(12)])
-    hub.files['state/hle.json'] = json.dumps({'pull_request_number': 12})
+    hub = FakeHub()
     outcome = make_outcome(tmp_path, uploaded=3)
     write_capture(outcome.raw_dir)
     submitter = submit.DatastoreSubmitter(hub, batch_size=1)
@@ -719,8 +746,9 @@ def test_records_that_landed_before_a_failure_are_still_remembered(
     def fail_after_the_first_batch(**kwargs):
         # Only the datastore batches fail. The raw-store commit that records
         # what landed has to go through, which is the point of the test.
-        if kwargs.get('revision') == 'refs/pr/12' and any(
-            commit.get('revision') == 'refs/pr/12' for commit in hub.commits
+        if kwargs.get('repo_id') != store.DEFAULT_RAW_REPO and any(
+            commit.get('repo_id') != store.DEFAULT_RAW_REPO
+            for commit in hub.commits
         ):
             raise RuntimeError('504 Gateway Timeout')
         return real_create_commit(**kwargs)
@@ -729,9 +757,8 @@ def test_records_that_landed_before_a_failure_are_still_remembered(
 
     assert finish(outcome, hub, submitter=submitter) == 1
 
-    remembered = set(hub.files['state/hle.pending'].split())
+    remembered = set(hub.files['state/hle.fingerprints'].split())
     assert remembered == {'fingerprint-0'}
-    assert json.loads(hub.files['state/hle.json'])['pull_request_number'] == 12
 
 
 def test_the_snapshot_pointer_only_moves_when_a_snapshot_was_written(
@@ -920,33 +947,21 @@ def test_an_upload_failure_leaves_the_fingerprints_unrecorded(
 
     hub.create_commit = fail_the_datastore
 
-    with pytest.raises(submit.SubmissionError):
-        finish(outcome, hub)
+    assert finish(outcome, hub) == 1
 
-    assert 'state/hle.fingerprints' not in hub.files
-    # The snapshot commit went first, so the records this run meant to
-    # publish are named even though the publication failed. Nothing landed,
-    # so the next run's reconciliation finds nothing on the pull request and
-    # publishes them again.
-    assert json.loads(hub.files['state/hle.inflight'])['records'] == [
-        {
-            'fingerprint': 'fingerprint-0',
-            'paths': [
-                'data/hle/org/model0/00000000-0000-4000-8000-000000000000.json'
-            ],
-        }
-    ]
+    # The batch provably never reached the datastore, so no fingerprint is
+    # recorded and nothing stays in flight: the next run simply publishes
+    # the records again.
+    assert hub.files['state/hle.fingerprints'] == ''
+    assert json.loads(hub.files['state/hle.inflight'])['records'] == []
 
 
 def test_an_unanswerable_batch_stays_in_flight(tmp_path) -> None:
-    """The commit errored, the ref could not be read, and the records may be
-    on the pull request anyway. Clearing the in-flight file here is how the
-    next run uploads them a second time; keeping them in it is what lets that
-    run ask the pull request instead of guessing."""
-    hub = FakeHub(
-        {'state/hle.json': json.dumps({'pull_request_number': 12})},
-        discussions=[cron_pr(12)],
-    )
+    """The commit errored, the datastore could not be read, and the records
+    may have landed anyway. Clearing the in-flight file here is how the next
+    run uploads them a second time; keeping them in it is what lets that run
+    ask the datastore instead of guessing."""
+    hub = FakeHub()
     outcome = make_outcome(tmp_path, uploaded=3)
     write_capture(outcome.raw_dir)
     real_create_commit = hub.create_commit
@@ -971,17 +986,18 @@ def test_an_unanswerable_batch_stays_in_flight(tmp_path) -> None:
     assert exit_code == 1
     # The batch that landed is in the ledger; the never-attempted third
     # record is safe to upload again, so neither stays in flight. Only the
-    # unanswerable second record does, addressed to the pull request the
-    # next run must ask about it.
-    assert hub.files['state/hle.pending'] == 'fingerprint-0\n'
+    # unanswerable second record does, addressed to the datastore the next
+    # run must ask about it.
+    assert hub.files['state/hle.fingerprints'] == 'fingerprint-0\n'
     batch = json.loads(hub.files['state/hle.inflight'])
-    assert batch['pull_request_number'] == 12
+    assert batch['destination'] == store.DIRECT_DESTINATION
+    assert batch['pull_request_number'] is None
     assert [record['fingerprint'] for record in batch['records']] == [
         'fingerprint-1'
     ]
 
 
-def test_the_run_url_reaches_the_pull_request_body(tmp_path) -> None:
+def test_the_run_url_reaches_the_commit_description(tmp_path) -> None:
     hub = FakeHub()
     outcome = make_outcome(tmp_path)
     write_capture(outcome.raw_dir)

--- a/tests/test_cron_store_and_submit.py
+++ b/tests/test_cron_store_and_submit.py
@@ -1,9 +1,10 @@
-"""The cron's memory and its one-pull-request-per-adapter rule.
+"""The cron's memory, its datastore commits, and the leftover pull requests.
 
-Both are places where a plausible-looking shortcut loses data: a state read
+All are places where a plausible-looking shortcut loses data: a state read
 that swallows an auth error forgets every fingerprint and republishes the
-whole history, and a pull-request lookup that falls back to "the newest open
-one" pushes a scrape into somebody else's submission.
+whole history, a failed batch dropped from the accounting is republished
+under fresh paths, and settling the retired flow's pull requests against
+"the newest open one" hands records to somebody else's submission.
 """
 
 from __future__ import annotations
@@ -59,10 +60,6 @@ class FakeHub:
         self.download_error: Exception | None = None
         self.commit_error: Exception | None = None
         self.details_error: Exception | None = None
-        self.edit_comment_error: Exception | None = None
-        self.edited_comments: list[tuple[int, str]] = []
-        self.comment_error: Exception | None = None
-        self.posted_comments: list[tuple[int, str]] = []
         self.list_files_error: Exception | None = None
         self.whoami_error: Exception | None = None
         self.repo_info_error: Exception | None = None
@@ -139,26 +136,6 @@ class FakeHub:
                     },
                 )()
         raise EntryNotFoundError(f'discussion {discussion_num} not found')
-
-    def edit_discussion_comment(
-        self, *, discussion_num, comment_id, new_content, **kwargs
-    ):
-        if self.edit_comment_error is not None:
-            raise self.edit_comment_error
-        for discussion in self.discussions:
-            if discussion.num == discussion_num:
-                if comment_id != f'comment-{discussion.num}':
-                    raise ValueError(f'no comment {comment_id}')
-                discussion.body = new_content
-                self.edited_comments.append((discussion_num, new_content))
-                return type('Comment', (), {'content': new_content})()
-        raise EntryNotFoundError(f'discussion {discussion_num} not found')
-
-    def comment_discussion(self, *, discussion_num, comment, **kwargs):
-        if self.comment_error is not None:
-            raise self.comment_error
-        self.posted_comments.append((discussion_num, comment))
-        return type('Comment', (), {'content': comment})()
 
     def list_repo_files(self, repo_id=None, **kwargs):
         if self.list_files_error is not None:
@@ -743,7 +720,7 @@ def test_the_run_report_lands_beside_the_snapshot() -> None:
     assert b'completed' in operation.path_or_fileobj
 
 
-# --- pull requests -------------------------------------------------------
+# --- pull requests the retired flow left behind ---------------------------
 
 
 def submitter(
@@ -754,15 +731,13 @@ def submitter(
 
 
 def cron_pr(num: int, adapter: str = 'hle', **kwargs: Any) -> FakeDiscussion:
-    """An open pull request carrying the cron's ownership marker."""
+    """A pull request the retired flow opened, carrying its marker."""
     return FakeDiscussion(
         num,
-        submit.pull_request_title(adapter),
-        body=submit.pull_request_description(
-            adapter,
-            coverage_line='1 record',
-            run_date='2026-08-10',
-            status='completed',
+        f'[Submission] cron: {adapter} (automated ingestion)',
+        body=(
+            f'Automated daily ingestion for the `{adapter}` adapter.\n\n'
+            f'{submit.marker(adapter)}'
         ),
         **kwargs,
     )
@@ -804,7 +779,13 @@ def test_a_title_that_looks_like_ours_is_not_enough() -> None:
     a stranger's submission.
     """
     sub, _ = submitter(
-        [FakeDiscussion(12, submit.pull_request_title('hle'), body='no marker')]
+        [
+            FakeDiscussion(
+                12,
+                '[Submission] cron: hle (automated ingestion)',
+                body='no marker',
+            )
+        ]
     )
 
     assert sub.resolve_known('hle', 12) is None
@@ -937,58 +918,55 @@ def test_a_lookup_failure_is_reported_not_widened() -> None:
         submit.DatastoreSubmitter(hub).find_by_marker('hle')
 
 
-def test_opening_a_pull_request_returns_its_number_and_ref(tmp_path) -> None:
-    sub, hub = submitter([])
+# --- publishing ------------------------------------------------------------
+
+
+def _upload_tree(tmp_path, count: int) -> Path:
     upload = tmp_path / 'upload' / 'data' / 'hle' / 'org' / 'model'
     upload.mkdir(parents=True)
-    (upload / 'a.json').write_text('{}', encoding='utf-8')
+    for index in range(count):
+        (upload / f'{index}.json').write_text('{}', encoding='utf-8')
+    return tmp_path / 'upload'
 
-    opened, is_new = sub.open_pull_request(
+
+def test_records_are_committed_to_the_default_branch(tmp_path) -> None:
+    """No pull request, no ref: a passing run's records go straight in."""
+    tree = _upload_tree(tmp_path, 2)
+    hub = FakeHub()
+    sub = submit.DatastoreSubmitter(hub)
+    description = submit.commit_description(
         'hle',
-        operations=submit.upload_operations(tmp_path / 'upload'),
-        description=submit.pull_request_description(
-            'hle',
-            coverage_line='1 record(s) produced -> 1 uploaded',
-            run_date='2026-08-10',
-            status='completed',
-        ),
+        coverage_line='2 record(s) produced -> 2 uploaded',
+        run_date='2026-08-10',
+        status='completed',
     )
 
-    assert is_new
-    assert opened.number == 42
-    assert opened.revision == 'refs/pr/42'
-    assert hub.commits[0]['create_pr'] is True
-    assert submit.marker('hle') in hub.commits[0]['commit_description']
-
-
-def test_uploads_target_the_pull_request_ref(tmp_path) -> None:
-    sub, hub = submitter([])
-    upload = tmp_path / 'upload' / 'data' / 'hle' / 'org' / 'model'
-    upload.mkdir(parents=True)
-    (upload / 'a.json').write_text('{}', encoding='utf-8')
-
-    sub.upload(
-        submit.PullRequest(12, 'https://x/12', 'refs/pr/12', 'cron: hle'),
-        operations=submit.upload_operations(tmp_path / 'upload'),
-        message='hle 2026-08-10',
+    submission = sub.publish(
+        operations=submit.upload_operations(tree),
+        description=description,
+        message='cron: hle 2026-08-10 (2 record(s))',
     )
 
-    assert hub.commits[0]['revision'] == 'refs/pr/12'
-    assert 'create_pr' not in hub.commits[0]
+    assert len(hub.commits) == 1
+    commit = hub.commits[0]
+    assert 'create_pr' not in commit
+    assert 'revision' not in commit
+    assert commit['commit_message'] == 'cron: hle 2026-08-10 (2 record(s))'
+    # The provenance a reviewer used to read in a pull request body is on
+    # the commit itself.
+    assert commit['commit_description'] == description
+    assert len(submission.committed_paths) == 2
 
 
 def test_a_large_batch_is_split_and_numbered(tmp_path) -> None:
     """A single huge commit can 504 while still landing server-side."""
-    upload = tmp_path / 'upload' / 'data' / 'hle' / 'org' / 'model'
-    upload.mkdir(parents=True)
-    for index in range(7):
-        (upload / f'{index}.json').write_text('{}', encoding='utf-8')
+    tree = _upload_tree(tmp_path, 7)
     hub = FakeHub()
     sub = submit.DatastoreSubmitter(hub, batch_size=3)
 
-    sub.upload(
-        submit.PullRequest(12, 'https://x/12', 'refs/pr/12', 'cron: hle'),
-        operations=submit.upload_operations(tmp_path / 'upload'),
+    submission = sub.publish(
+        operations=submit.upload_operations(tree),
+        description='body',
         message='hle 2026-08-10',
     )
 
@@ -998,6 +976,12 @@ def test_a_large_batch_is_split_and_numbered(tmp_path) -> None:
         'hle 2026-08-10 (2/3)',
         'hle 2026-08-10 (3/3)',
     ]
+    assert [len(commit['operations']) for commit in hub.commits] == [3, 3, 1]
+    # Every commit of the run describes it, not just the first.
+    assert all(
+        commit['commit_description'] == 'body' for commit in hub.commits
+    )
+    assert len(submission.committed_paths) == 7
 
 
 def test_a_record_and_its_sidecar_are_never_split_across_commits(
@@ -1007,7 +991,7 @@ def test_a_record_and_its_sidecar_are_never_split_across_commits(
 
     Split across two, a failure on the second leaves the aggregate public,
     unrecordable (its companion never arrived), and republished under a fresh
-    UUID next run, with the abandoned half still on the pull request naming a
+    UUID next run, with the abandoned half still in the datastore naming a
     sidecar that does not exist.
     """
     upload = tmp_path / 'upload' / 'data' / 'hle' / 'org' / 'model'
@@ -1018,9 +1002,9 @@ def test_a_record_and_its_sidecar_are_never_split_across_commits(
     hub = FakeHub()
     sub = submit.DatastoreSubmitter(hub, batch_size=3)
 
-    sub.upload(
-        submit.PullRequest(12, 'https://x/12', 'refs/pr/12', 'cron: hle'),
+    sub.publish(
         operations=submit.upload_operations(tmp_path / 'upload'),
+        description='body',
         message='hle 2026-08-10',
     )
 
@@ -1037,43 +1021,23 @@ def test_a_record_and_its_sidecar_are_never_split_across_commits(
     assert len(hub.commits) == 4
 
 
-def _upload_tree(tmp_path, count: int) -> Path:
-    upload = tmp_path / 'upload' / 'data' / 'hle' / 'org' / 'model'
-    upload.mkdir(parents=True)
-    for index in range(count):
-        (upload / f'{index}.json').write_text('{}', encoding='utf-8')
-    return tmp_path / 'upload'
-
-
-def test_a_cold_start_is_batched_like_any_other_upload(tmp_path) -> None:
-    """The first run is the biggest one an adapter ever does.
-
-    Opening the pull request with every operation in one commit aimed the
-    ambiguous timeout that batching exists to avoid at exactly the run most
-    likely to trip it.
-    """
-    tree = _upload_tree(tmp_path, 7)
+def test_a_failure_before_anything_landed_reports_nothing_committed(
+    tmp_path,
+) -> None:
+    tree = _upload_tree(tmp_path, 2)
     hub = FakeHub()
-    sub = submit.DatastoreSubmitter(hub, batch_size=3)
+    hub.commit_error = RuntimeError('502 Bad Gateway')
+    sub = submit.DatastoreSubmitter(hub)
 
-    submission = sub.publish(
-        'hle',
-        pull_request=None,
-        operations=submit.upload_operations(tree),
-        description=submit.pull_request_description(
-            'hle',
-            coverage_line='7 record(s)',
-            run_date='2026-08-10',
-            status='completed',
-        ),
-        message='hle 2026-08-10',
-    )
+    with pytest.raises(submit.PartialSubmissionError) as caught:
+        sub.publish(
+            operations=submit.upload_operations(tree),
+            description='body',
+            message='hle 2026-08-10',
+        )
 
-    assert [len(commit['operations']) for commit in hub.commits] == [3, 3, 1]
-    assert hub.commits[0]['create_pr'] is True
-    assert all('create_pr' not in commit for commit in hub.commits[1:])
-    assert all(commit['revision'] == 'refs/pr/42' for commit in hub.commits[1:])
-    assert len(submission.committed_paths) == 7
+    assert caught.value.committed_paths == ()
+    assert caught.value.unresolved_paths == ()
 
 
 def test_a_failure_after_the_first_batch_reports_what_landed(
@@ -1081,13 +1045,12 @@ def test_a_failure_after_the_first_batch_reports_what_landed(
 ) -> None:
     """A retry must not republish records that already reached the Hub.
 
-    They would land under fresh UUID paths, so the pull request would hold
+    They would land under fresh UUID paths, so the datastore would hold
     the same evaluation twice with no way to tell which copy to keep.
     """
     tree = _upload_tree(tmp_path, 7)
     hub = FakeHub()
     sub = submit.DatastoreSubmitter(hub, batch_size=3)
-    pull_request = submit.PullRequest(12, 'https://x/12', 'refs/pr/12', 'x')
 
     real_create_commit = hub.create_commit
 
@@ -1100,33 +1063,29 @@ def test_a_failure_after_the_first_batch_reports_what_landed(
 
     with pytest.raises(submit.PartialSubmissionError) as caught:
         sub.publish(
-            'hle',
-            pull_request=pull_request,
             operations=submit.upload_operations(tree),
-            description='',
+            description='body',
             message='hle 2026-08-10',
         )
 
-    assert caught.value.pull_request is pull_request
     assert len(caught.value.committed_paths) == 3
     assert all(
         path.startswith('data/hle/') for path in caught.value.committed_paths
     )
+    assert caught.value.unresolved_paths == ()
 
 
 def test_a_batch_that_landed_despite_the_error_does_not_stop_the_upload(
     tmp_path,
 ) -> None:
     """The ambiguous timeout: the Hub accepted the commit, the client saw an
-    error. The pull request ref is the arbiter of what actually landed, and a
-    batch that is on it is a success, so the upload carries on. Stopping
-    instead turned a run whose final batch landed this way into a failure
-    with every record accounted for, which no retry ever completed and so
-    nothing ever validated."""
+    error. The datastore is the arbiter of what actually landed, and a batch
+    that is in it is a success, so the upload carries on. Stopping instead
+    would end a run whose final batch landed this way as a failure with
+    every record accounted for, which no retry ever completes."""
     tree = _upload_tree(tmp_path, 7)
-    hub = FakeHub(discussions=[cron_pr(12)])
+    hub = FakeHub()
     sub = submit.DatastoreSubmitter(hub, batch_size=3)
-    pull_request = submit.PullRequest(12, 'https://x/12', 'refs/pr/12', 'x')
 
     real_create_commit = hub.create_commit
 
@@ -1139,27 +1098,23 @@ def test_a_batch_that_landed_despite_the_error_does_not_stop_the_upload(
     hub.create_commit = land_then_time_out
 
     submission = sub.publish(
-        'hle',
-        pull_request=pull_request,
         operations=submit.upload_operations(tree),
         description='body',
         message='hle 2026-08-10',
     )
 
     # The clean first batch and the two ambiguous ones all count; nothing is
-    # left for a retry, and the finished submission is validated.
+    # left for a retry.
     assert len(submission.committed_paths) == 7
-    assert hub.posted_comments == [(12, submit.VALIDATION_COMMAND)]
-    assert submission.validation_note is None
 
 
-def test_an_unanswerable_reconciliation_claims_nothing(tmp_path) -> None:
-    """When the ref cannot be read either, the batch is not guessed onto the
-    ledger; the error says the pull request needs a look before a retry."""
+def test_an_unanswerable_batch_is_reported_as_unresolved(tmp_path) -> None:
+    """When the datastore cannot be read either, the batch is not guessed
+    onto the ledger; the error says the datastore needs a look before a
+    retry."""
     tree = _upload_tree(tmp_path, 7)
     hub = FakeHub()
     sub = submit.DatastoreSubmitter(hub, batch_size=3)
-    pull_request = submit.PullRequest(12, 'https://x/12', 'refs/pr/12', 'x')
 
     real_create_commit = hub.create_commit
 
@@ -1173,10 +1128,8 @@ def test_an_unanswerable_reconciliation_claims_nothing(tmp_path) -> None:
 
     with pytest.raises(submit.PartialSubmissionError) as caught:
         sub.publish(
-            'hle',
-            pull_request=pull_request,
             operations=submit.upload_operations(tree),
-            description='',
+            description='body',
             message='hle 2026-08-10',
         )
 
@@ -1187,287 +1140,10 @@ def test_an_unanswerable_reconciliation_claims_nothing(tmp_path) -> None:
     assert not (
         set(caught.value.unresolved_paths) & set(caught.value.committed_paths)
     )
-    assert 'inspect https://x/12 before re-running' in str(caught.value)
-
-
-def test_an_opening_commit_that_landed_despite_the_error_is_adopted(
-    tmp_path,
-) -> None:
-    """The Hub can accept the commit and lose the reply on the way back.
-
-    Opening a second pull request on the next run would put the same records
-    up twice, under fresh UUID paths, with nothing saying which copy to keep.
-    """
-    tree = _upload_tree(tmp_path, 5)
-    hub = FakeHub(discussions=[cron_pr(12)])
-    sub = submit.DatastoreSubmitter(hub, batch_size=2)
-    operations = submit.upload_operations(tree)
-    # The first batch is on the pull request; the reply never arrived.
-    for operation in _batch_paths(operations, 2)[0]:
-        hub.files[operation] = '{}'
-
-    def time_out_the_open(**kwargs):
-        if kwargs.get('create_pr'):
-            raise RuntimeError('504 Gateway Timeout')
-        return FakeHub.create_commit(hub, **kwargs)
-
-    hub.create_commit = time_out_the_open
-
-    submission = sub.publish(
-        'hle',
-        pull_request=None,
-        operations=operations,
-        description='body',
-        message='hle 2026-08-10',
-    )
-
-    assert submission.pull_request.number == 12
-    # Its own batch counted once, and the rest sent to the adopted request.
-    assert len(submission.committed_paths) == 5
-    assert all(
-        commit['revision'] == 'refs/pr/12'
-        for commit in hub.commits
-        if 'revision' in commit
-    )
-
-
-def test_an_opening_commit_that_did_not_land_still_fails(tmp_path) -> None:
-    tree = _upload_tree(tmp_path, 3)
-    hub = FakeHub()
-    hub.create_commit = _raise(RuntimeError('504 Gateway Timeout'))
-    sub = submit.DatastoreSubmitter(hub, batch_size=2)
-
-    with pytest.raises(submit.SubmissionError, match='could not open'):
-        sub.publish(
-            'hle',
-            pull_request=None,
-            operations=submit.upload_operations(tree),
-            description='body',
-            message='hle 2026-08-10',
-        )
-
-
-def test_an_adopted_request_whose_ref_is_unreadable_is_reported(
-    tmp_path,
-) -> None:
-    """Neither answer is safe to assume, so the number is recorded and the
-    run stops rather than guessing at what is on the pull request."""
-    tree = _upload_tree(tmp_path, 3)
-    hub = FakeHub(discussions=[cron_pr(12)])
-    hub.list_files_error = ConnectionError('network is unreachable')
-    sub = submit.DatastoreSubmitter(hub, batch_size=2)
-    hub.create_commit = _raise(RuntimeError('504 Gateway Timeout'))
-
-    with pytest.raises(submit.PartialSubmissionError) as caught:
-        sub.publish(
-            'hle',
-            pull_request=None,
-            operations=submit.upload_operations(tree),
-            description='body',
-            message='hle 2026-08-10',
-        )
-
-    assert caught.value.pull_request.number == 12
-    assert caught.value.committed_paths == ()
-    # The opening batch may be on the adopted pull request, so it is carried
-    # as unresolved for the caller to keep in flight.
-    assert len(caught.value.unresolved_paths) == 2
-    assert 'inspect it before re-running' in str(caught.value)
-
-
-def test_two_requests_claiming_one_adapter_stop_an_adoption(tmp_path) -> None:
-    tree = _upload_tree(tmp_path, 3)
-    hub = FakeHub(discussions=[cron_pr(12), cron_pr(13)])
-    hub.create_commit = _raise(RuntimeError('504 Gateway Timeout'))
-    sub = submit.DatastoreSubmitter(hub, batch_size=2)
-
-    with pytest.raises(submit.AmbiguousPullRequestError):
-        sub.publish(
-            'hle',
-            pull_request=None,
-            operations=submit.upload_operations(tree),
-            description='body',
-            message='hle 2026-08-10',
-        )
-
-
-def _batch_paths(operations, size: int) -> list[list[str]]:
-    return [
-        [operation.path_in_repo for operation in batch]
-        for batch in submit._batches(operations, size)
-    ]
-
-
-# --- the description describes the latest run -----------------------------
-
-
-def test_a_reused_pull_request_gets_its_description_rewritten(
-    tmp_path,
-) -> None:
-    """Opened in August and published into ever since, the body otherwise
-    still reports August's date, coverage and snapshot path."""
-    tree = _upload_tree(tmp_path, 2)
-    discussion = cron_pr(12)
-    hub = FakeHub(discussions=[discussion])
-    sub = submit.DatastoreSubmitter(hub)
-    pull_request = submit.PullRequest(12, 'https://x/12', 'refs/pr/12', 'x')
-    description = submit.pull_request_description(
-        'hle',
-        coverage_line='2 record(s)',
-        run_date='2026-09-14',
-        status='completed',
-        raw_reference='raw/hle/2026-09-14/run-9-1',
-    )
-
-    submission = sub.publish(
-        'hle',
-        pull_request=pull_request,
-        operations=submit.upload_operations(tree),
-        description=description,
-        message='hle 2026-09-14',
-    )
-
-    assert submission.description_note is None
-    assert hub.edited_comments == [(12, description)]
-    assert '2026-09-14' in discussion.body
-    assert '2026-08-10' not in discussion.body
-    # The marker says which adapter the pull request belongs to, so a refresh
-    # that dropped it would orphan it from the next run.
-    assert submit.marker('hle') in discussion.body
-    assert sub.carries_marker(12, 'hle')
-
-
-def test_a_newly_opened_pull_request_is_not_edited_again(tmp_path) -> None:
-    """It was opened with this run's body a moment ago."""
-    tree = _upload_tree(tmp_path, 2)
-    hub = FakeHub()
-    sub = submit.DatastoreSubmitter(hub)
-
-    sub.publish(
-        'hle',
-        pull_request=None,
-        operations=submit.upload_operations(tree),
-        description=submit.pull_request_description(
-            'hle',
-            coverage_line='2 record(s)',
-            run_date='2026-08-10',
-            status='completed',
-        ),
-        message='hle 2026-08-10',
-    )
-
-    assert hub.edited_comments == []
-
-
-def test_a_description_that_cannot_be_refreshed_does_not_fail_the_run(
-    tmp_path,
-) -> None:
-    """The records are published. A stale body is worth saying, not failing."""
-    tree = _upload_tree(tmp_path, 2)
-    hub = FakeHub(discussions=[cron_pr(12)])
-    hub.edit_comment_error = RuntimeError('403 Forbidden')
-    sub = submit.DatastoreSubmitter(hub)
-    pull_request = submit.PullRequest(12, 'https://x/12', 'refs/pr/12', 'x')
-
-    submission = sub.publish(
-        'hle',
-        pull_request=pull_request,
-        operations=submit.upload_operations(tree),
-        description='body',
-        message='hle 2026-08-10',
-    )
-
-    assert len(submission.committed_paths) == 2
-    assert '403 Forbidden' in submission.description_note
-    assert 'describes an earlier run' in submission.description_note
-
-
-# --- validation is asked for once everything is in ------------------------
-
-
-def test_a_full_submission_into_a_reused_pull_request_asks_for_validation(
-    tmp_path,
-) -> None:
-    """The datastore validates on request, so a run that published records
-    has to post the command or nothing checks them."""
-    tree = _upload_tree(tmp_path, 2)
-    hub = FakeHub(discussions=[cron_pr(12)])
-    sub = submit.DatastoreSubmitter(hub)
-    pull_request = submit.PullRequest(12, 'https://x/12', 'refs/pr/12', 'x')
-
-    submission = sub.publish(
-        'hle',
-        pull_request=pull_request,
-        operations=submit.upload_operations(tree),
-        description='body',
-        message='hle 2026-08-10',
-    )
-
-    assert hub.posted_comments == [(12, submit.VALIDATION_COMMAND)]
-    assert submission.validation_note is None
-
-
-def test_a_newly_opened_pull_request_asks_for_validation(tmp_path) -> None:
-    tree = _upload_tree(tmp_path, 2)
-    hub = FakeHub()
-    sub = submit.DatastoreSubmitter(hub)
-
-    submission = sub.publish(
-        'hle',
-        pull_request=None,
-        operations=submit.upload_operations(tree),
-        description='body',
-        message='hle 2026-08-10',
-    )
-
-    number = submission.pull_request.number
-    assert hub.posted_comments == [(number, submit.VALIDATION_COMMAND)]
-    assert submission.validation_note is None
-
-
-def test_a_validation_request_that_fails_does_not_fail_the_run(
-    tmp_path,
-) -> None:
-    """The records are published either way; the note tells a human to post
-    the command by hand."""
-    tree = _upload_tree(tmp_path, 2)
-    hub = FakeHub(discussions=[cron_pr(12)])
-    hub.comment_error = RuntimeError('403 Forbidden')
-    sub = submit.DatastoreSubmitter(hub)
-    pull_request = submit.PullRequest(12, 'https://x/12', 'refs/pr/12', 'x')
-
-    submission = sub.publish(
-        'hle',
-        pull_request=pull_request,
-        operations=submit.upload_operations(tree),
-        description='body',
-        message='hle 2026-08-10',
-    )
-
-    assert len(submission.committed_paths) == 2
-    assert '403 Forbidden' in submission.validation_note
-    assert submit.VALIDATION_COMMAND in submission.validation_note
-
-
-def test_a_partial_submission_asks_for_no_validation(tmp_path) -> None:
-    """Validation of half an upload wastes the reviewer it summons; the
-    retry that completes the submission asks instead."""
-    tree = _upload_tree(tmp_path, 2)
-    hub = FakeHub(discussions=[cron_pr(12)])
-    hub.commit_error = RuntimeError('504 Gateway Timeout')
-    sub = submit.DatastoreSubmitter(hub)
-    pull_request = submit.PullRequest(12, 'https://x/12', 'refs/pr/12', 'x')
-
-    with pytest.raises(submit.PartialSubmissionError):
-        sub.publish(
-            'hle',
-            pull_request=pull_request,
-            operations=submit.upload_operations(tree),
-            description='body',
-            message='hle 2026-08-10',
-        )
-
-    assert hub.posted_comments == []
+    assert (
+        'inspect https://huggingface.co/datasets/evaleval/EEE_datastore '
+        'before re-running'
+    ) in str(caught.value)
 
 
 # --- what happened to the last pull request -------------------------------
@@ -1523,8 +1199,8 @@ def test_upload_operations_use_repository_relative_posix_paths(
     ]
 
 
-def test_the_description_carries_coverage_and_the_marker() -> None:
-    description = submit.pull_request_description(
+def test_the_description_carries_coverage_and_provenance() -> None:
+    description = submit.commit_description(
         'hle',
         coverage_line='12 source row(s) -> 10 record(s) produced, 2 dropped',
         run_date='2026-08-10',
@@ -1538,7 +1214,6 @@ def test_the_description_carries_coverage_and_the_marker() -> None:
     assert 'https://ci.example/run/7' in description
     assert 'raw/hle/2026-08-10' in description
     assert 'raw capture degraded' in description
-    assert description.rstrip().endswith(submit.marker('hle'))
     assert 'type_of_addition' in description
 
 


### PR DESCRIPTION
## What

Passing cron output now commits **straight to the datastore's default branch** instead of opening a per-adapter HF pull request. One commit series per adapter run (each data source publishes independently), batched at 300 files per commit, batches never splitting a record.

## Why

Per discussion with @nelaturuharsha: the review that matters happens before publication — the packaged validator must pass with no warnings, the fingerprint ledger de-duplicates against everything already published, and every record carries `type_of_addition: cron` with its run date, adapter and workflow URL in `source_metadata.additional_details` (e.g. [EEE_datastore #199](https://huggingface.co/datasets/evaleval/EEE_datastore/discussions/199)). That provenance is what makes a bad batch findable and correctable after the fact, so the pull request added only an unmerged queue.

## How

- `DatastoreSubmitter.publish()` commits to the default branch; each commit's description carries what the PR body used to (run date, status, coverage, raw snapshot path, workflow run). Commit messages are `cron: <adapter> <date> (<n> record(s))`.
- **Fingerprints are durable on landing**: no new pending fingerprints; the ledger records a record the moment its commit is on the branch.
- **Failure semantics preserved**: a commit that errored after the Hub accepted it is adopted via the file listing and the upload continues; a batch that provably never landed fails the run with everything earlier recorded; a batch whose fate is unreadable stays in flight (`destination: datastore`) for the next run to settle against the branch.
- **The retired flow still settles**: pending fingerprints are promoted/forgotten by their leftover PR's fate (merged/closed), old in-flight files still settle against the PR they name, and the marker/author machinery remains solely for that. It can be deleted once no adapter state names a pull request.
- The `/eee validate changed` comment step (#252) is gone with the PRs — validation runs pre-publish in the runner.
- README, workflow comments and tests updated throughout; net −600 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)