### PR TITLE
fix(mt_bench): keep paper citation out of source data

### DIFF
--- a/every_eval_ever/adapters/mt_bench/adapter.py
+++ b/every_eval_ever/adapters/mt_bench/adapter.py
@@ -302,7 +302,7 @@ def make_source_data() -> SourceDataUrl:
     return SourceDataUrl(
         dataset_name='MT-Bench (single-answer GPT-4 judgments)',
         source_type='url',
-        url=[JUDGMENT_URL, GITHUB_URL, PAPER_URL],
+        url=[JUDGMENT_URL, GITHUB_URL],
         additional_details={
             'paper_url': PAPER_URL,
         },

--- a/tests/test_mt_bench_adapter.py
+++ b/tests/test_mt_bench_adapter.py
@@ -151,7 +151,15 @@ def test_source_data_url_contains_judgment_url():
     )
     log = bundles[0][0]
     overall = log.evaluation_results[0]
-    assert adapter.JUDGMENT_URL in overall.source_data.url
+    assert set(overall.source_data.url) == {
+        adapter.JUDGMENT_URL,
+        adapter.GITHUB_URL,
+    }
+    assert adapter.PAPER_URL not in overall.source_data.url
+    assert (
+        overall.source_data.additional_details['paper_url']
+        == adapter.PAPER_URL
+    )
     assert overall.source_data.source_type == 'url'
 
 


### PR DESCRIPTION
## What / source

Fixes #210.

`source_data.url` now contains only the LMSYS judgment dataset URL and the FastChat repository. The MT-Bench paper remains available as `additional_details['paper_url']`, without being duplicated as dataset provenance.

## Review lane

- [x] **Fast** — no conflicts, scoped (tests / one adapter / one file), verified by me, under ~1000 hand-written lines
- [ ] **Needs a human** — design change, cross-package, large, refactor, material change in outcome, or large agent-authored change

Design agreed in: #210 (maintainer-authored issue with the exact suggested fix)

## Checklist

- [x] `uv run python -m every_eval_ever validate <files>` is clean — **no warnings either** — at a temporary final `data/mt-bench/<dev>/<model>/` path: 34 passed, 0 warnings, 0 failed
- [x] every unconvertible source row is reported and the command exits non-zero; the live conversion had 0 dropped rows
- [x] offline unit test added + full `env -u NO_COLOR TERM=xterm-256color uv run pytest tests -q` green: 759 passed, 20 skipped
- [x] `uv run ruff check` clean
- [x] existing model/benchmark ids resolve: all 34 live-generated records pass semantic validation
- [x] content spot-checked: the two data/repository URLs remain, the arXiv citation remains only in `additional_details`, and evaluation-id construction is unchanged

## Decisions & coverage

- Decision / where: MT-Bench `SourceDataUrl.url`
  Chose / instead of: judgment dataset URL + FastChat repository only; keep the paper citation in `additional_details['paper_url']` instead of also treating it as source data
  Confidence (high/med/low): high
  General? (yes/no): yes — this follows the existing EEE field semantics and dataset-conversion skill guidance

**Coverage:** 5,440 source judgment rows → 34 aggregate model records, 0 dropped; all 34 records validated with no warnings.

**Operator asked about policy calls?** None. This does not add an id, drop data, change metrics, or re-host data.

## AI assistance disclosure

OpenAI Codex assisted with this scoped implementation and test execution. I reviewed the diff and generated records and can respond to review feedback.
