### PR TITLE
fix(schema): do not invent max attempts

### DIFF
--- a/every_eval_ever/eval_types.py
+++ b/every_eval_ever/eval_types.py
@@ -232,7 +232,7 @@ class GenerationArgs(BaseModel):
     )
     sandbox: Sandbox | None = None
     max_attempts: int | None = Field(
-        1, description='Maximum number of submission attempts (default 1).'
+        None, description='Maximum number of submission attempts.'
     )
     incorrect_attempt_feedback: str | None = Field(
         None, description='Feedback from the model after incorrect attempt.'

--- a/every_eval_ever/schemas/eval.schema.json
+++ b/every_eval_ever/schemas/eval.schema.json
@@ -531,8 +531,8 @@
                                     },
                                     "max_attempts": {
                                         "type": "integer",
-                                        "description": "Maximum number of submission attempts (default 1).",
-                                        "default": 1
+                                        "description": "Maximum number of submission attempts.",
+                                        "default": null
                                     },
                                     "incorrect_attempt_feedback": {
                                         "type": "string",

--- a/tests/test_inspect_adapter.py
+++ b/tests/test_inspect_adapter.py
@@ -338,6 +338,10 @@ def test_gaia_eval():
     assert converted_eval.model_info.inference_platform == 'openai'
     assert converted_eval.model_info.inference_engine is None
 
+    generation_config = converted_eval.evaluation_results[0].generation_config
+    assert generation_config is not None
+    assert generation_config.generation_args.max_attempts == 1
+
     results = converted_eval.evaluation_results
     assert len(results) > 0
     assert results[0].evaluation_name == 'gaia'

--- a/tests/test_lm_eval_adapter.py
+++ b/tests/test_lm_eval_adapter.py
@@ -237,6 +237,10 @@ def test_transform_from_file_generation_config():
     assert gen is not None
     assert gen.generation_args.temperature == 0.0
     assert gen.generation_args.max_tokens == 512
+    assert gen.generation_args.max_attempts is None
+    assert 'max_attempts' not in gen.generation_args.model_dump(
+        mode='json', exclude_none=True
+    )
     assert gen.additional_details['num_fewshot'] == '0'
 
 


### PR DESCRIPTION
## What / source

Changes the optional generation_args.max_attempts schema default from 1 to null and regenerates eval_types.py. Sources that do not report an attempt limit no longer materialize a claim that one attempt was allowed. Explicitly observed Inspect values remain unchanged.

Fixes #236.

## Review lane

- [ ] Fast
- [x] Needs a human — this is a material output semantics change across converters.

Design agreed in: #236, including collaborator confirmation that this is worth doing.

## Checklist

- [x] Validation is clean — 2 lm-eval aggregate records and 1 Inspect aggregate record, with 0 warnings
- [x] Offline regression tests added; full test suite green: 759 passed, 20 skipped
- [x] Ruff check clean
- [x] Content spot-checked: absent lm-eval value is omitted; explicit Inspect value remains 1

The adapter report, registry, and source-row checklist items are not applicable because this changes schema default serialization and drops no source records.

## Decisions & coverage

- Decision / where: schema_version
  Chose / instead of: keep the current version because the field remains optional and accepts the same integer values; only its non-required default annotation changes
  Confidence: high
  General: no
- Decision / where: generated model
  Chose / instead of: regenerate eval_types.py from the schema and run post_codegen, rather than hand-editing generated behavior
  Confidence: high
  General: yes
- Decision / where: explicit values
  Chose / instead of: preserve source-provided Inspect max_attempts values while omitting unobserved values
  Confidence: high
  General: yes

Coverage: 2 lm-eval source tasks to 2 valid records, 0 dropped; 1 Inspect source run to 1 valid record, 0 dropped. The lm-eval outputs contain no max_attempts key; the Inspect fixture that explicitly reports 1 still emits 1.

Commands run:

- uv run ruff check every_eval_ever tests
- env -u NO_COLOR TERM=xterm-256color uv run pytest tests -q
- uv run --extra inspect pytest tests/test_inspect_adapter.py -q
- real lm-eval and Inspect CLI conversions followed by validation at final collection/developer/model paths

## AI assistance

OpenAI Codex assisted with implementation, tests, and validation. I reviewed the diff and the generated output.