### PR TITLE
[Feature] Add reviewed PwC DrugBank protocol adapter

### DIFF
--- a/every_eval_ever/adapters/README.md
+++ b/every_eval_ever/adapters/README.md
@@ -34,8 +34,8 @@ An adapter that automation runs must therefore:
   `save_failure_report` + a non-zero exit, which is what lets a partial refresh be
   told apart from a crash.
 
-`bfcl`, `cocoabench` and `sciarena` are registered as `runnable=False`: they need a
-local input file and have no live fetch path.
+`bfcl`, `cocoabench`, `paperswithcode_drugbank`, and `sciarena` are registered as
+`runnable=False`: they need local inputs and have no live fetch path.
 
 ### Skipping a run whose source has not changed
 
@@ -90,12 +90,46 @@ re-hosting bytes that are already durably stored.
 | `terminal_bench_2` | tbench.ai | Fetches Terminal-Bench 2.0 agentic coding benchmark results. |
 | `hle` | Scale SEAL leaderboard | Converts the Scale SEAL Humanity's Last Exam leaderboard into `data/hle/`. Emits per-model accuracy (with 95% CI) and calibration error. |
 | `mmlu_pro` | TIGER-Lab leaderboard CSV | Converts the MMLU-Pro leaderboard (`TIGER-Lab/mmlu_pro_leaderboard_submission`) into `data/mmlu-pro/`. Emits per-model overall + 14 per-subject accuracies. |
+| `paperswithcode_drugbank` | Local Papers with Code PostgreSQL dump + reviewed YAML manifest | Manually converts only DrugBank score cells with reviewed model, metric-scale, split, and protocol semantics. Writes `data/paperswithcode-drugbank/`. The same cells also appear in `data/paperswithcode/` from the general adapter over the same dump, unreviewed; both records carry the PwC `pwc_evaluation_id` so the pair is joinable. |
 | `lexam` | LEXam project website | Converts the LEXam legal-reasoning leaderboard (open-question judge scores + 4-choice MCQ accuracy) into `data/lexam/`. |
 | `vectara_hallucination_leaderboard` | HuggingFace (`vectara/results`) | Converts the Vectara Hallucination Leaderboard result files, pinned to a source commit, into `data/vectara-hallucination-leaderboard/`. Emits 4 aggregate metrics plus per-category and per-text-complexity breakdowns (40 scores per model). |
 | `benchpress` | HuggingFace (`microsoft/benchpress-score-matrix`) | Converts the BenchPress score matrix into `data/benchpress/`. An aggregator: every cell keeps its own citation, and logs split by `evaluator_relationship`. See [`benchpress/README.md`](benchpress/README.md). |
 | `bountybench` | BountyBench run logs (local JSON tree) | Converts BountyBench cybersecurity agent logs into `data/bountybench/`. Emits one aggregate per (model, workflow, configuration) plus a per-bounty `*_samples.jsonl` sidecar with the full agent transcript. |
 | `paperswithcode` | Papers with Code PostgreSQL dumps | Converts PwC leaderboard entries into `data/paperswithcode/`. Metric bounds and direction are resolved against a vendored eval-card-registry snapshot; unknown metrics fail the run rather than getting invented bounds. Needs the `paperswithcode` extra. |
 | `wild` | HuggingFace (`kensho/WILD-raw`) | Converts the WILD-raw item-level eval responses (65 models × 27 benchmarks, run with Inspect AI) into `data/wild/`: aggregate accuracy per model×benchmark and per subtask, with optional per-item `_samples.jsonl` sidecars (`--include-instances`). See [`wild/README.md`](wild/README.md). |
+
+### Papers with Code DrugBank
+
+To run this manual adapter, provide a local custom-format PostgreSQL dump and a
+reviewed, non-empty YAML qualification manifest (schema version 2). It is not
+scheduled because
+neither input has a live fetch path, and the repository does not include a
+production manifest. The manifest must supply reviewed canonical model,
+metric, and benchmark IDs plus the registry commit against which they were
+reviewed. The adapter does not resolve or invent identities, and conversion is
+atomic: an anchor, hash, or schema mismatch aborts before any output is written.
+For split comparisons, each manifest entry must declare `transductive`,
+`inductive-s1`, or `inductive-s2`, with matching manifest-declared overlap
+labels. A
+canonical benchmark ID cannot be reused for conflicting protocols anywhere in
+the manifest, so the adapter cannot emit conflicting split scores under one
+benchmark key. The adapter preserves the scores and protocol evidence supplied
+by the reviewed manifest; it does not independently verify cited source content
+or train/test membership from the aggregate dump, and it does not compute a
+performance delta between splits.
+
+```bash
+uv run --extra paperswithcode python -m \
+  every_eval_ever.adapters.paperswithcode_drugbank.adapter \
+  --dump /path/to/paperswithcode.dump \
+  --overlay /path/to/reviewed-drugbank.yaml \
+  --output-dir /tmp/paperswithcode-drugbank/data/paperswithcode-drugbank
+```
+
+As of 2026-08-19, the archived Papers with Code DrugBank URL redirects away
+from its dataset record. Generated logs retain that URL as raw provenance,
+link `source_data` to DrugBank, and record the official Papers with Code archive
+in source metadata.
 
 ### Mercor Evaluation Exports
 

--- a/every_eval_ever/adapters/README.md
+++ b/every_eval_ever/adapters/README.md
@@ -80,7 +80,7 @@ re-hosting bytes that are already durably stored.
 | `global_mmlu_lite` | Kaggle API | Fetches Global MMLU Lite leaderboard results from Kaggle. |
 | `hfopenllm_v2` | HuggingFace Spaces API | Fetches the Open LLM Leaderboard v2 (4576+ models). The leaderboard is no longer maintained upstream, so this converts a frozen archive and is not scheduled. |
 | `helm` | HELM leaderboard | Converts HELM leaderboard data. Supports `--leaderboard_name` for Capabilities/Lite/Classic/Instruct/MMLU. |
-| `llm_stats` | LLM Stats API | Converts LLM Stats model, benchmark, and score API data into `data/llm-stats/`. |
+| `llm_stats` | LLM Stats API | Converts LLM Stats model, benchmark, and score API results into `data/llm-stats/`. |
 | `mercor_eval` | Mercor Evaluation Exports API | Fetches authenticated Mercor benchmark leaderboards and writes aggregate EEE records. |
 | `mt_bench` | LMSYS / FastChat | Converts MT-Bench GPT-4 single-answer judgments into `data/mt-bench/`. Emits overall, turn-1, and turn-2 means per model. |
 | `open_medical_llm` | HuggingFace (`openlifescienceai/results`) | Converts the Open Medical-LLM Leaderboard's lm-evaluation-harness results into `data/open-medical-llm/`. One record per model, one result per medical benchmark (9). See [`open_medical_llm/README.md`](open_medical_llm/README.md). |
@@ -90,7 +90,7 @@ re-hosting bytes that are already durably stored.
 | `terminal_bench_2` | tbench.ai | Fetches Terminal-Bench 2.0 agentic coding benchmark results. |
 | `hle` | Scale SEAL leaderboard | Converts the Scale SEAL Humanity's Last Exam leaderboard into `data/hle/`. Emits per-model accuracy (with 95% CI) and calibration error. |
 | `mmlu_pro` | TIGER-Lab leaderboard CSV | Converts the MMLU-Pro leaderboard (`TIGER-Lab/mmlu_pro_leaderboard_submission`) into `data/mmlu-pro/`. Emits per-model overall + 14 per-subject accuracies. |
-| `paperswithcode_drugbank` | Local Papers with Code PostgreSQL dump + reviewed YAML manifest | Manually converts only DrugBank score cells with reviewed model, metric-scale, split, and protocol semantics. Writes `data/paperswithcode-drugbank/`. The same cells also appear in `data/paperswithcode/` from the general adapter over the same dump, unreviewed; both records carry the PwC `pwc_evaluation_id` so the pair is joinable. |
+| `paperswithcode_drugbank` | Local Papers with Code PostgreSQL dump + reviewed YAML manifest | Manually converts DrugBank score cells with reviewed model, source-scale, split, and protocol semantics. The same source cell in `data/paperswithcode/` is matched by `(pwc_evaluation_id, metric_config.metric_name)`. |
 | `lexam` | LEXam project website | Converts the LEXam legal-reasoning leaderboard (open-question judge scores + 4-choice MCQ accuracy) into `data/lexam/`. |
 | `vectara_hallucination_leaderboard` | HuggingFace (`vectara/results`) | Converts the Vectara Hallucination Leaderboard result files, pinned to a source commit, into `data/vectara-hallucination-leaderboard/`. Emits 4 aggregate metrics plus per-category and per-text-complexity breakdowns (40 scores per model). |
 | `benchpress` | HuggingFace (`microsoft/benchpress-score-matrix`) | Converts the BenchPress score matrix into `data/benchpress/`. An aggregator: every cell keeps its own citation, and logs split by `evaluator_relationship`. See [`benchpress/README.md`](benchpress/README.md). |
@@ -102,21 +102,28 @@ re-hosting bytes that are already durably stored.
 
 To run this manual adapter, provide a local custom-format PostgreSQL dump and a
 reviewed, non-empty YAML qualification manifest (schema version 2). It is not
-scheduled because
-neither input has a live fetch path, and the repository does not include a
-production manifest. The manifest must supply reviewed canonical model,
-metric, and benchmark IDs plus the registry commit against which they were
-reviewed. The adapter does not resolve or invent identities, and conversion is
-atomic: an anchor, hash, or schema mismatch aborts before any output is written.
+scheduled because neither input has a live fetch path, and the repository does
+not include a production manifest. The manifest supplies reviewed model and
+benchmark identities, exact source-cell selectors, source-scale decisions,
+protocol semantics, provenance, and the registry revision used for review.
+Canonical metric fields are checked against the same vendored
+`eval-card-registry` snapshot as the general Papers with Code adapter, and
+observed metric ranges are derived from the source values being converted.
+Conversion is atomic: an anchor, hash, registry, or schema mismatch aborts before
+any output is written.
+
 For split comparisons, each manifest entry must declare `transductive`,
 `inductive-s1`, or `inductive-s2`, with matching manifest-declared overlap
-labels. A
-canonical benchmark ID cannot be reused for conflicting protocols anywhere in
-the manifest, so the adapter cannot emit conflicting split scores under one
-benchmark key. The adapter preserves the scores and protocol evidence supplied
-by the reviewed manifest; it does not independently verify cited source content
-or train/test membership from the aggregate dump, and it does not compute a
-performance delta between splits.
+labels. A canonical benchmark ID cannot be reused for conflicting protocols
+anywhere in the manifest, so the adapter cannot emit conflicting split scores
+under one benchmark key. Scores come from the pinned dump; the manifest supplies
+the source-cell selection and protocol evidence. The adapter does not
+independently verify cited source content or train/test membership from the
+aggregate dump, and it does not compute a performance delta between splits.
+
+The general Papers with Code adapter can emit the same PwC evaluation rows.
+`pwc_evaluation_id` identifies the shared row, while an exact metric-cell match
+uses `(pwc_evaluation_id, metric_config.metric_name)`.
 
 ```bash
 uv run --extra paperswithcode python -m \

--- a/every_eval_ever/adapters/catalog.py
+++ b/every_eval_ever/adapters/catalog.py
@@ -475,6 +475,18 @@ ADAPTERS: tuple[AdapterSpec, ...] = (
     # Registered but not schedulable. Each needs a local input file because it
     # has no live fetch path; automation would have nothing to hand it.
     AdapterSpec(
+        key='paperswithcode_drugbank',
+        module='every_eval_ever.adapters.paperswithcode_drugbank.adapter',
+        collections=('paperswithcode-drugbank',),
+        runnable=False,
+        unrunnable_reason=(
+            'requires local --dump and --overlay inputs. '
+            'No reviewed production manifest is checked in'
+        ),
+        with_packages=('pgdumplib',),
+        captures_raw=False,
+    ),
+    AdapterSpec(
         key='bfcl',
         module='every_eval_ever.adapters.bfcl.adapter',
         collections=('bfcl',),

--- a/every_eval_ever/adapters/paperswithcode_drugbank/__init__.py
+++ b/every_eval_ever/adapters/paperswithcode_drugbank/__init__.py
@@ -1,0 +1,6 @@
+"""Manual PwC DrugBank adapter for protocol-qualified source cells.
+
+The reviewed qualification manifest is the adapter's source-cell ledger;
+conversion fails atomically when any selected cell, anchor, or protocol binding
+does not match the pinned local dump.
+"""

--- a/every_eval_ever/adapters/paperswithcode_drugbank/adapter.py
+++ b/every_eval_ever/adapters/paperswithcode_drugbank/adapter.py
@@ -50,8 +50,8 @@ from pydantic import (
 )
 
 from every_eval_ever.adapters.paperswithcode.adapter import (
-    MetricResolver,
     build_metric_config as build_pwc_metric_config,
+    MetricResolver,
 )
 from every_eval_ever.eval_types import (
     EvalLibrary,
@@ -889,8 +889,7 @@ def build_logs(
     dump_file: str | None = None,
     resolver: MetricResolver | None = None,
 ) -> list[EvaluationLog]:
-    resolver = resolver or MetricResolver()
-    _validate_registry_revision(overlay, resolver)
+    resolver = validate_registry_contract(overlay, resolver)
     rows: dict[str, dict[str, Any]] = {}
     for row in evaluations:
         evaluation_id = str(row.get('id'))

--- a/every_eval_ever/adapters/paperswithcode_drugbank/adapter.py
+++ b/every_eval_ever/adapters/paperswithcode_drugbank/adapter.py
@@ -49,6 +49,8 @@ from pydantic import (
 from every_eval_ever.adapters.paperswithcode.adapter import MetricResolver
 from every_eval_ever.adapters.paperswithcode.adapter import (
     build_metric_config as build_pwc_metric_config,
+)
+from every_eval_ever.adapters.paperswithcode.adapter import (
     parse_metric_value as parse_pwc_metric_value,
 )
 from every_eval_ever.eval_types import (
@@ -817,7 +819,7 @@ def _build_result(
     if not canonical_metric.min_score <= score <= canonical_metric.max_score:
         raise ValueError(
             f'PwC evaluation {entry.pwc_evaluation_id} metric {metric.source_name!r} '
-            f'converts to {score}, outside canonical registry range '
+            f'converts to {score}, outside reviewed canonical range from the registry '
             f'[{canonical_metric.min_score}, {canonical_metric.max_score}]'
         )
 

--- a/every_eval_ever/adapters/paperswithcode_drugbank/adapter.py
+++ b/every_eval_ever/adapters/paperswithcode_drugbank/adapter.py
@@ -49,9 +49,9 @@ from pydantic import (
     model_validator,
 )
 
+from every_eval_ever.adapters.paperswithcode.adapter import MetricResolver
 from every_eval_ever.adapters.paperswithcode.adapter import (
     build_metric_config as build_pwc_metric_config,
-    MetricResolver,
 )
 from every_eval_ever.eval_types import (
     EvalLibrary,

--- a/every_eval_ever/adapters/paperswithcode_drugbank/adapter.py
+++ b/every_eval_ever/adapters/paperswithcode_drugbank/adapter.py
@@ -9,13 +9,10 @@ by ``adapters/paperswithcode`` before conversion. Protocol semantics and source
 scale remain explicit manifest decisions rather than inferences from labels or
 score distributions.
 
-Overlap with ``adapters/paperswithcode``: that adapter converts the same dump
-across every dataset on its scheduled run, so a DrugBank cell converted here is
-also present in ``data/paperswithcode/`` without the reviewed split and
-protocol semantics. Both records carry the cell's
-``additional_details.pwc_evaluation_id``, which is the PwC ``evaluations`` row
-id, so the two are joinable and a consumer reading both collections can tell
-they are one measurement rather than two.
+The general ``adapters/paperswithcode`` adapter can emit the same source cells
+without these reviewed protocol semantics. ``pwc_evaluation_id`` identifies the
+shared PwC evaluation row; an exact source-cell match across the two collections
+uses ``(pwc_evaluation_id, metric_config.metric_name)``.
 
 Run with the adapter extra installed::
 
@@ -52,6 +49,7 @@ from pydantic import (
 from every_eval_ever.adapters.paperswithcode.adapter import MetricResolver
 from every_eval_ever.adapters.paperswithcode.adapter import (
     build_metric_config as build_pwc_metric_config,
+    parse_metric_value as parse_pwc_metric_value,
 )
 from every_eval_ever.eval_types import (
     EvalLibrary,
@@ -495,10 +493,12 @@ def _validate_registry_revision(
 
 
 def _canonical_metric_config(
-    metric: OverlayMetric, resolver: MetricResolver
+    metric: OverlayMetric,
+    resolver: MetricResolver,
+    observed_range: tuple[float, float] | None = None,
 ) -> MetricConfig:
-    observed = (metric.min_score, metric.max_score)
-    resolved = resolver.resolve(metric.source_name, observed, 'drugbank')
+    metric_range = observed_range or (metric.min_score, metric.max_score)
+    resolved = resolver.resolve(metric.source_name, metric_range, 'drugbank')
     if not resolved.resolved:
         reason, candidates = resolver.unresolved_reason.get(
             metric.source_name, ('unknown', ())
@@ -516,7 +516,7 @@ def _canonical_metric_config(
             'direction in the vendored registry snapshot'
         )
     config = build_pwc_metric_config(
-        metric.source_name, resolved, observed, None
+        metric.source_name, resolved, metric_range, None
     )
     if config.score_type != ScoreType.continuous:
         raise ValueError(
@@ -652,13 +652,27 @@ def _metrics_object(row: dict[str, Any]) -> dict[str, Any]:
     return metrics
 
 
-def parse_metric_value(raw: Any) -> tuple[float, float | None, bool]:
-    """Split one reported cell into (value, reported dispersion, percent marker).
+def _observed_metric_ranges(
+    evaluations: Iterable[dict[str, Any]],
+) -> dict[str, tuple[float, float]]:
+    ranges: dict[str, list[float]] = {}
+    for row in evaluations:
+        try:
+            metrics = _metrics_object(row)
+        except ValueError:
+            continue
+        for name, raw_value in metrics.items():
+            value, _ = parse_pwc_metric_value(raw_value)
+            if value is None:
+                continue
+            bounds = ranges.setdefault(name, [value, value])
+            bounds[0] = min(bounds[0], value)
+            bounds[1] = max(bounds[1], value)
+    return {name: (bounds[0], bounds[1]) for name, bounds in ranges.items()}
 
-    The dispersion comes back as a number on the *source* scale, so the caller
-    has to apply the same scale factor it applies to the value. Returning it as
-    a string is what let an unscaled figure sit beside a rescaled score.
-    """
+
+def parse_metric_value(raw: Any) -> tuple[float, float | None, bool]:
+    """Split one reported cell into value, source-scale dispersion, and percent flag."""
     if raw is None or isinstance(raw, bool):
         raise ValueError('metric value must be a finite number')
     if isinstance(raw, (int, float)):
@@ -782,25 +796,28 @@ def _build_result(
     raw_value: Any,
     *,
     resolver: MetricResolver | None = None,
+    observed_range: tuple[float, float] | None = None,
 ) -> EvaluationResult:
     resolver = resolver or MetricResolver()
-    canonical_metric = _canonical_metric_config(metric, resolver)
     source_value, uncertainty, percent = parse_metric_value(raw_value)
+    canonical_metric = _canonical_metric_config(
+        metric,
+        resolver,
+        observed_range or (source_value, source_value),
+    )
     if percent and metric.source_scale != 'percent':
         raise ValueError(
             f'PwC evaluation {entry.pwc_evaluation_id} metric {metric.source_name!r} '
             'has a percent marker but the reviewed source_scale is not percent'
         )
     score = source_value * metric.scale_factor
-    # A dispersion is a spread in the score's units, so it takes the same factor.
-    # Left unscaled it read as wider than the metric's whole range.
     canonical_uncertainty = (
         None if uncertainty is None else uncertainty * metric.scale_factor
     )
     if not canonical_metric.min_score <= score <= canonical_metric.max_score:
         raise ValueError(
             f'PwC evaluation {entry.pwc_evaluation_id} metric {metric.source_name!r} '
-            f'converts to {score}, outside reviewed canonical range '
+            f'converts to {score}, outside canonical registry range '
             f'[{canonical_metric.min_score}, {canonical_metric.max_score}]'
         )
 
@@ -832,9 +849,6 @@ def _build_result(
             'protocol_evidence_locator': entry.evidence.source_locator,
             'protocol_review_note': entry.evidence.review_note,
             'raw_value': raw_value,
-            # Two keys, matching adapters/paperswithcode: the figure the source
-            # printed, and the same number on the scale `score` is on. A spread
-            # is in the score's units, so a rescale has to reach it too.
             'reported_uncertainty': uncertainty,
             'reported_uncertainty_canonical': (
                 canonical_uncertainty
@@ -898,6 +912,7 @@ def build_logs(
                 f'duplicate PwC evaluation id in source: {evaluation_id}'
             )
         rows[evaluation_id] = row
+    metric_ranges = _observed_metric_ranges(rows.values())
 
     groups: dict[str, _ModelGroup] = {}
     for entry in overlay.entries:
@@ -956,6 +971,7 @@ def build_logs(
                 metric,
                 metrics[metric.source_name],
                 resolver=resolver,
+                observed_range=metric_ranges.get(metric.source_name),
             )
             if result.evaluation_result_id is None:
                 raise ValueError('DrugBank result is missing its stable id')
@@ -1024,9 +1040,6 @@ def validate_output_dir(output_dir: Path) -> None:
 def export(logs: Iterable[EvaluationLog], output_dir: Path) -> list[Path]:
     outputs: list[EvaluationLogOutput] = []
     for log in logs:
-        # datastore_path_components owns this split: it takes the developer from
-        # the id's prefix, flattens deeper namespaces and rejects an unusable
-        # component, where splitting by hand raised on a flat id.
         _, developer, model_name = datastore_path_components(
             COLLECTION_NAME, log.model_info.id, log.model_info.developer
         )

--- a/every_eval_ever/adapters/paperswithcode_drugbank/adapter.py
+++ b/every_eval_ever/adapters/paperswithcode_drugbank/adapter.py
@@ -1,0 +1,1002 @@
+#!/usr/bin/env python3
+"""Convert reviewed Papers with Code DrugBank result cells to EEE.
+
+The adapter consumes a local PwC PostgreSQL dump and a YAML manifest that binds
+each selected score cell to reviewed model, metric, split, protocol, and
+provenance metadata. It checks the declared split against drug-entity overlap
+and does not infer semantics from labels or score distributions.
+
+Overlap with ``adapters/paperswithcode``: that adapter converts the same dump
+across every dataset on its scheduled run, so a DrugBank cell converted here is
+also present in ``data/paperswithcode/`` without the reviewed split and
+protocol semantics. Both records carry the cell's
+``additional_details.pwc_evaluation_id``, which is the PwC ``evaluations`` row
+id, so the two are joinable and a consumer reading both collections can tell
+they are one measurement rather than two.
+
+Run with the adapter extra installed::
+
+    uv run --extra paperswithcode python -m \
+      every_eval_ever.adapters.paperswithcode_drugbank.adapter \
+      --dump /path/to/paperswithcode.dump \
+      --overlay /path/to/reviewed-drugbank.yaml \
+      --output-dir /tmp/paperswithcode-drugbank/data/paperswithcode-drugbank
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Literal
+from urllib.parse import urlparse
+
+import yaml
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictInt,
+    StrictStr,
+    field_validator,
+    model_validator,
+)
+
+from every_eval_ever.eval_types import (
+    EvalLibrary,
+    EvaluationLog,
+    EvaluationResult,
+    EvaluatorRelationship,
+    MetricConfig,
+    ModelInfo,
+    ScoreDetails,
+    ScoreType,
+    SourceDataUrl,
+    SourceMetadata,
+)
+from every_eval_ever.helpers import (
+    SCHEMA_VERSION,
+    EvaluationLogOutput,
+    require_finite_number,
+    save_evaluation_logs,
+)
+from every_eval_ever.helpers.io import datastore_path_components
+
+SOURCE_NAME = 'Papers with Code DrugBank'
+SOURCE_ORGANIZATION = 'Papers with Code'
+SOURCE_ORGANIZATION_URL = 'https://github.com/paperswithcode'
+PWC_DATASET_ARCHIVE_URL = 'https://huggingface.co/datasets/pwc-archive/datasets'
+DRUGBANK_URL = 'https://go.drugbank.com'
+COLLECTION_NAME = 'paperswithcode-drugbank'
+DEFAULT_OUTPUT_DIR = f'/tmp/paperswithcode-drugbank/data/{COLLECTION_NAME}'
+
+_SHA256_RE = re.compile(r'^[0-9a-f]{64}$')
+_SAFE_SLUG_RE = re.compile(r'^[a-z0-9][a-z0-9._-]*$')
+_MODEL_COMPONENT_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9._-]*$')
+_REGISTRY_REVISION_RE = re.compile(r'^(?:[0-9a-f]{40}|[0-9a-f]{64})$')
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra='forbid', frozen=True)
+
+
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    pass
+
+
+def _construct_unique_mapping(loader, node, deep=False):
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise ValueError(f'overlay YAML contains duplicate key: {key!r}')
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def _sha256(value: str, field: str) -> str:
+    value = value.strip()
+    if not _SHA256_RE.fullmatch(value):
+        raise ValueError(f'{field} must be a lowercase 64-character SHA-256')
+    return value
+
+
+def _slug(value: str, field: str) -> str:
+    value = value.strip()
+    if not _SAFE_SLUG_RE.fullmatch(value):
+        raise ValueError(f'{field} must be a lowercase semantic slug')
+    return value
+
+
+def _canonical_sha256(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(',', ':'),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+
+
+class OverlayAnchors(_StrictModel):
+    paper_id: StrictStr | StrictInt | None
+    dataset_id: StrictStr | StrictInt
+    task_id: StrictStr | StrictInt
+    model_name: str
+    model_id: str
+    developer: str
+
+    @field_validator('model_name', 'model_id', 'developer')
+    @classmethod
+    def nonempty(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError('model identity anchors must be non-empty')
+        return value
+
+    @model_validator(mode='after')
+    def valid_model_id(self):
+        parts = self.model_id.split('/')
+        if len(parts) < 2 or any(
+            not _MODEL_COMPONENT_RE.fullmatch(p) for p in parts
+        ):
+            raise ValueError(
+                'model_id must contain at least two safe namespace/model components'
+            )
+        return self
+
+
+class ProtocolQualification(_StrictModel):
+    benchmark_id: str
+    split_id: Literal['transductive', 'inductive-s1', 'inductive-s2']
+    study_id: str
+    protocol_id: str
+    task_id: str
+    task_type: str
+    candidate_label_space: str
+    drug_entity_overlap: Literal['both-seen', 'one-unseen', 'both-unseen']
+    pair_overlap: str
+    relation_class_overlap: str
+    temporal_ordering: str
+    negative_sampling: str
+    split_preprocessing: str
+
+    @field_validator('benchmark_id', 'study_id', 'protocol_id', 'task_id')
+    @classmethod
+    def semantic_slug(cls, value: str, info) -> str:
+        return _slug(value, info.field_name)
+
+    @field_validator(
+        'task_type',
+        'candidate_label_space',
+        'pair_overlap',
+        'relation_class_overlap',
+        'temporal_ordering',
+        'negative_sampling',
+        'split_preprocessing',
+    )
+    @classmethod
+    def semantic_text(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError('protocol semantic fields must be non-empty')
+        return value
+
+    @model_validator(mode='after')
+    def split_matches_entity_overlap(self):
+        expected_overlap = {
+            'transductive': 'both-seen',
+            'inductive-s1': 'both-unseen',
+            'inductive-s2': 'one-unseen',
+        }[self.split_id]
+        if self.drug_entity_overlap != expected_overlap:
+            raise ValueError(
+                f'split_id {self.split_id!r} requires '
+                f'drug_entity_overlap {expected_overlap!r}'
+            )
+        return self
+
+    @property
+    def generalization_regime(self) -> Literal['transductive', 'inductive']:
+        return (
+            'transductive' if self.split_id == 'transductive' else 'inductive'
+        )
+
+    def semantic_sha256(self) -> str:
+        return _canonical_sha256(self.model_dump(mode='json'))
+
+
+class ProtocolEvidence(_StrictModel):
+    source_url: str
+    source_locator: str
+    review_note: str
+
+    @field_validator('source_url')
+    @classmethod
+    def absolute_url(cls, value: str) -> str:
+        value = value.strip()
+        parsed = urlparse(value)
+        if parsed.scheme not in {'http', 'https'} or not parsed.hostname:
+            raise ValueError('source_url must be an absolute HTTP(S) URL')
+        return value
+
+    @field_validator('source_locator', 'review_note')
+    @classmethod
+    def nonempty(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError(
+                'evidence locator and review note must be non-empty'
+            )
+        return value
+
+
+class OverlayMetric(_StrictModel):
+    source_name: str
+    metric_id: str
+    metric_name: str
+    metric_kind: str
+    metric_unit: str | None = None
+    lower_is_better: bool
+    min_score: float
+    max_score: float
+    source_scale: Literal['identity', 'percent'] = 'identity'
+
+    @field_validator('source_name', 'metric_name', 'metric_kind')
+    @classmethod
+    def nonempty(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError('metric text fields must be non-empty')
+        return value
+
+    @field_validator('metric_id')
+    @classmethod
+    def metric_slug(cls, value: str) -> str:
+        return _slug(value, 'metric_id')
+
+    @model_validator(mode='after')
+    def valid_bounds(self):
+        if not math.isfinite(self.min_score) or not math.isfinite(
+            self.max_score
+        ):
+            raise ValueError('metric bounds must be finite')
+        if self.max_score <= self.min_score:
+            raise ValueError('metric max_score must be greater than min_score')
+        if self.source_scale == 'percent':
+            if self.metric_unit != 'proportion':
+                raise ValueError(
+                    "percent source_scale requires canonical metric_unit 'proportion'"
+                )
+            if self.min_score != 0.0 or self.max_score != 1.0:
+                raise ValueError(
+                    'percent source_scale requires canonical bounds [0.0, 1.0]'
+                )
+        return self
+
+    @property
+    def scale_factor(self) -> float:
+        return 0.01 if self.source_scale == 'percent' else 1.0
+
+
+class ProtocolOverlayEntry(_StrictModel):
+    pwc_evaluation_id: StrictStr | StrictInt
+    anchors: OverlayAnchors
+    source_metrics_sha256: str
+    qualification: ProtocolQualification
+    evidence: ProtocolEvidence
+    metrics: list[OverlayMetric] = Field(min_length=1)
+
+    @field_validator('pwc_evaluation_id')
+    @classmethod
+    def evaluation_id_present(cls, value):
+        if value is None or (isinstance(value, str) and not value.strip()):
+            raise ValueError('pwc_evaluation_id must be non-empty')
+        return value
+
+    @field_validator('source_metrics_sha256')
+    @classmethod
+    def metrics_hash(cls, value: str) -> str:
+        return _sha256(value, 'source_metrics_sha256')
+
+    @model_validator(mode='after')
+    def unique_metric_names(self):
+        source_names = [metric.source_name for metric in self.metrics]
+        if len(source_names) != len(set(source_names)):
+            raise ValueError(
+                'metric source_name selectors must be unique within an entry'
+            )
+        metric_ids = [metric.metric_id for metric in self.metrics]
+        if len(metric_ids) != len(set(metric_ids)):
+            raise ValueError(
+                'canonical metric_id selectors must be unique within an entry'
+            )
+        return self
+
+
+class ProtocolOverlay(_StrictModel):
+    schema_version: Literal[2]
+    dump_sha256: str
+    registry_revision: str
+    retrieved_timestamp: str
+    entries: list[ProtocolOverlayEntry] = Field(min_length=1)
+
+    @field_validator('dump_sha256')
+    @classmethod
+    def dump_hash(cls, value: str) -> str:
+        return _sha256(value, 'dump_sha256')
+
+    @field_validator('registry_revision')
+    @classmethod
+    def registry_commit(cls, value: str) -> str:
+        value = value.strip()
+        if not _REGISTRY_REVISION_RE.fullmatch(value):
+            raise ValueError(
+                'registry_revision must be a 40- or 64-character commit SHA'
+            )
+        return value
+
+    @field_validator('retrieved_timestamp')
+    @classmethod
+    def unix_epoch(cls, value: str) -> str:
+        value = value.strip()
+        try:
+            parsed = float(value)
+        except ValueError as exc:
+            raise ValueError(
+                'retrieved_timestamp must be a Unix-epoch string'
+            ) from exc
+        if not math.isfinite(parsed) or parsed < 0:
+            raise ValueError(
+                'retrieved_timestamp must be a finite non-negative epoch'
+            )
+        return value
+
+    @model_validator(mode='after')
+    def consistent_entries(self):
+        seen: set[tuple[str, str]] = set()
+        seen_canonical_metrics: set[tuple[str, str, str]] = set()
+        model_by_evaluation: dict[str, str] = {}
+        developer_by_model: dict[str, str] = {}
+        protocol_by_benchmark: dict[str, str] = {}
+        for entry in self.entries:
+            evaluation_id = str(entry.pwc_evaluation_id)
+            model_id = entry.anchors.model_id
+            prior_model = model_by_evaluation.setdefault(
+                evaluation_id, model_id
+            )
+            if prior_model != model_id:
+                raise ValueError(
+                    f'PwC evaluation {evaluation_id} is assigned to multiple '
+                    f'canonical model ids: {prior_model!r} and {model_id!r}'
+                )
+            prior_developer = developer_by_model.setdefault(
+                model_id, entry.anchors.developer
+            )
+            if prior_developer != entry.anchors.developer:
+                raise ValueError(
+                    f'inconsistent reviewed developer for {model_id}'
+                )
+            benchmark_id = entry.qualification.benchmark_id
+            protocol_digest = entry.qualification.semantic_sha256()
+            prior_digest = protocol_by_benchmark.setdefault(
+                benchmark_id, protocol_digest
+            )
+            if prior_digest != protocol_digest:
+                raise ValueError(
+                    'canonical benchmark_id is reused for conflicting '
+                    f'protocol semantics: {benchmark_id!r}'
+                )
+            for metric in entry.metrics:
+                key = (evaluation_id, metric.source_name)
+                if key in seen:
+                    raise ValueError(
+                        f'PwC source score cell is selected more than once: {key}'
+                    )
+                seen.add(key)
+                metric_key = (
+                    evaluation_id,
+                    protocol_digest,
+                    metric.metric_id,
+                )
+                if metric_key in seen_canonical_metrics:
+                    raise ValueError(
+                        'canonical metric_id is selected more than once for '
+                        f'one source protocol: {metric.metric_id!r}'
+                    )
+                seen_canonical_metrics.add(metric_key)
+        return self
+
+
+@dataclass
+class _ModelGroup:
+    developer: str
+    result_ids: set[str] = field(default_factory=set)
+    model_names: set[str] = field(default_factory=set)
+    results: list[EvaluationResult] = field(default_factory=list)
+
+
+def stringify(value: Any) -> str:
+    if isinstance(value, bool):
+        return 'true' if value else 'false'
+    if value is None:
+        return 'null'
+    if isinstance(value, (dict, list)):
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(',', ':'),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    return str(value)
+
+
+def stringify_details(details: dict[str, Any]) -> dict[str, str]:
+    return {
+        key: stringify(value)
+        for key, value in details.items()
+        if value is not None
+    }
+
+
+def source_metrics_sha256(metrics: dict[str, Any]) -> str:
+    return _canonical_sha256(metrics)
+
+
+def file_sha256(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open('rb') as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_overlay(path: str | Path) -> tuple[ProtocolOverlay, str]:
+    raw = Path(path).read_bytes()
+    payload = yaml.load(raw, Loader=_UniqueKeySafeLoader)
+    if not isinstance(payload, dict):
+        raise ValueError('overlay YAML must decode to an object')
+    return ProtocolOverlay.model_validate(payload), hashlib.sha256(
+        raw
+    ).hexdigest()
+
+
+def load_dump(dump_path: str | Path):
+    import pgdumplib
+
+    return pgdumplib.load(str(dump_path))
+
+
+def _columns_for(dump, table: str) -> list[str]:
+    for entry in dump.entries:
+        if (
+            entry.desc != 'TABLE DATA'
+            or entry.namespace != 'public'
+            or entry.tag != table
+        ):
+            continue
+        copy_stmt = (entry.copy_stmt or '').strip()
+        prefix = f'COPY public.{table} ('
+        suffix = ') FROM stdin;'
+        if not copy_stmt.startswith(prefix) or not copy_stmt.endswith(suffix):
+            raise ValueError(f'cannot read column order for public.{table}')
+        column_list = copy_stmt[len(prefix) : -len(suffix)]
+        columns = [
+            column.strip().strip('"') for column in column_list.split(',')
+        ]
+        if not columns or any(not column for column in columns):
+            raise ValueError(f'public.{table} has an invalid COPY column list')
+        if len(columns) != len(set(columns)):
+            raise ValueError(
+                f'public.{table} COPY column list contains duplicates'
+            )
+        return columns
+    raise KeyError(f'table public.{table} not found in dump')
+
+
+def table_rows(dump, table: str) -> Iterator[dict[str, Any]]:
+    columns = _columns_for(dump, table)
+    for row in dump.table_data('public', table):
+        yield dict(zip(columns, row, strict=True))
+
+
+def load_source_context(
+    dump, overlay: ProtocolOverlay
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
+    wanted_evals = {str(entry.pwc_evaluation_id) for entry in overlay.entries}
+    evaluations: dict[str, dict[str, Any]] = {}
+    for row in table_rows(dump, 'evaluations'):
+        row_id = str(row.get('id'))
+        if row_id in wanted_evals:
+            if row_id in evaluations:
+                raise ValueError(
+                    f'duplicate PwC evaluation id in dump: {row_id}'
+                )
+            evaluations[row_id] = row
+    missing = sorted(wanted_evals - set(evaluations))
+    if missing:
+        raise ValueError(
+            f'overlay references missing PwC evaluations: {missing}'
+        )
+
+    wanted_datasets = {
+        str(entry.anchors.dataset_id) for entry in overlay.entries
+    }
+    datasets: dict[str, dict[str, Any]] = {}
+    for row in table_rows(dump, 'datasets'):
+        row_id = str(row.get('id'))
+        if row_id in wanted_datasets:
+            if row_id in datasets:
+                raise ValueError(f'duplicate PwC dataset id in dump: {row_id}')
+            datasets[row_id] = row
+    missing = sorted(wanted_datasets - set(datasets))
+    if missing:
+        raise ValueError(f'overlay references missing PwC datasets: {missing}')
+    return list(evaluations.values()), datasets
+
+
+def _metrics_object(row: dict[str, Any]) -> dict[str, Any]:
+    raw = row.get('metrics')
+    try:
+        if isinstance(raw, dict):
+            metrics = raw
+        elif raw:
+            metrics = json.loads(raw)
+        else:
+            metrics = {}
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f'PwC evaluation {row.get("id")} has invalid metrics JSON'
+        ) from exc
+    if not isinstance(metrics, dict) or any(
+        not isinstance(name, str) for name in metrics
+    ):
+        raise ValueError(
+            f'PwC evaluation {row.get("id")} metrics must be a string-keyed object'
+        )
+    return metrics
+
+
+def parse_metric_value(raw: Any) -> tuple[float, float | None, bool]:
+    """Split one reported cell into (value, reported dispersion, percent marker).
+
+    The dispersion comes back as a number on the *source* scale, so the caller
+    has to apply the same scale factor it applies to the value. Returning it as
+    a string is what let an unscaled figure sit beside a rescaled score.
+    """
+    if raw is None or isinstance(raw, bool):
+        raise ValueError('metric value must be a finite number')
+    if isinstance(raw, (int, float)):
+        value = float(raw)
+        if not math.isfinite(value):
+            raise ValueError('metric value must be finite')
+        return value, None, False
+    text = str(raw).strip()
+    if not text:
+        raise ValueError('metric value is empty')
+    uncertainty_text = None
+    for separator in ('±', '+/-', '+-'):
+        if separator in text:
+            text, _, uncertainty_text = text.partition(separator)
+            text = text.strip()
+            uncertainty_text = uncertainty_text.strip() or None
+            break
+    has_percent_marker = text.endswith('%')
+    text = text.removesuffix('%').strip()
+    if ',' in text:
+        raise ValueError(
+            f'metric value uses ambiguous comma formatting: {raw!r}'
+        )
+    try:
+        value = float(text)
+    except ValueError as exc:
+        raise ValueError(f'metric value is not numeric: {raw!r}') from exc
+    if not math.isfinite(value):
+        raise ValueError('metric value must be finite')
+    uncertainty = None
+    if uncertainty_text is not None:
+        uncertainty = require_finite_number(
+            uncertainty_text.removesuffix('%').strip(),
+            f'reported uncertainty in {raw!r}',
+        )
+        if uncertainty < 0:
+            raise ValueError(
+                f'reported uncertainty must not be negative: {raw!r}'
+            )
+    return value, uncertainty, has_percent_marker
+
+
+def _assert_anchor(
+    evaluation_id: str, field: str, expected: Any, actual: Any
+) -> None:
+    expected = None if expected is None else str(expected)
+    actual = None if actual is None else str(actual)
+    if expected != actual:
+        raise ValueError(
+            f'overlay anchor drift for PwC evaluation {evaluation_id}: '
+            f'{field} expected {expected!r}, got {actual!r}'
+        )
+
+
+def build_source_data(dataset: dict[str, Any]) -> SourceDataUrl:
+    return SourceDataUrl(
+        dataset_name='DrugBank',
+        source_type='url',
+        url=[DRUGBANK_URL],
+        additional_details=stringify_details(
+            {
+                'raw_dataset_id': dataset.get('id'),
+                'raw_dataset_url': dataset.get('url'),
+                'raw_dataset_homepage': dataset.get('homepage'),
+                'pwc_dataset_slug': dataset.get('slug'),
+            }
+        ),
+    )
+
+
+def build_source_metadata(
+    overlay: ProtocolOverlay, overlay_sha256: str, dump_file: str | None
+) -> SourceMetadata:
+    return SourceMetadata(
+        source_name=SOURCE_NAME,
+        source_type='documentation',
+        source_organization_name=SOURCE_ORGANIZATION,
+        source_organization_url=SOURCE_ORGANIZATION_URL,
+        evaluator_relationship=EvaluatorRelationship.third_party,
+        additional_details=stringify_details(
+            {
+                'source_role': 'aggregator',
+                'dump_sha256': overlay.dump_sha256,
+                'registry_revision': overlay.registry_revision,
+                'overlay_sha256': overlay_sha256,
+                'source_dump_file': dump_file,
+                'pwc_data_archive_url': PWC_DATASET_ARCHIVE_URL,
+                'qualification_policy': (
+                    'explicit source-cell manifest with no protocol inference '
+                    'from the DrugBank label or score values'
+                ),
+            }
+        ),
+    )
+
+
+def _metric_result_suffix(metric: OverlayMetric) -> str:
+    slug = (
+        re.sub(r'[^a-z0-9]+', '-', metric.source_name.lower()).strip('-')
+        or 'metric'
+    )
+    digest = _canonical_sha256(metric.model_dump(mode='json'))
+    return f'{slug}-{metric.metric_id}-{digest}'
+
+
+def _bundle_evaluation_id(dump_sha256: str, result_ids: Iterable[str]) -> str:
+    selected_result_ids = sorted(set(result_ids))
+    if not selected_result_ids:
+        raise ValueError(
+            'cannot build an evaluation id without selected metric results'
+        )
+    source_bundle_sha256 = _canonical_sha256(selected_result_ids)
+    return f'paperswithcode-drugbank/{dump_sha256}/{source_bundle_sha256}'
+
+
+def _build_result(
+    entry: ProtocolOverlayEntry,
+    row: dict[str, Any],
+    dataset: dict[str, Any],
+    metric: OverlayMetric,
+    raw_value: Any,
+) -> EvaluationResult:
+    source_value, uncertainty, percent = parse_metric_value(raw_value)
+    if percent and metric.source_scale != 'percent':
+        raise ValueError(
+            f'PwC evaluation {entry.pwc_evaluation_id} metric {metric.source_name!r} '
+            'has a percent marker but the reviewed source_scale is not percent'
+        )
+    score = source_value * metric.scale_factor
+    # A dispersion is a spread in the score's units, so it takes the same factor.
+    # Left unscaled it read as wider than the metric's whole range.
+    canonical_uncertainty = (
+        None if uncertainty is None else uncertainty * metric.scale_factor
+    )
+    if not metric.min_score <= score <= metric.max_score:
+        raise ValueError(
+            f'PwC evaluation {entry.pwc_evaluation_id} metric {metric.source_name!r} '
+            f'converts to {score}, outside reviewed canonical range '
+            f'[{metric.min_score}, {metric.max_score}]'
+        )
+
+    q = entry.qualification
+    protocol_digest = q.semantic_sha256()
+    details = stringify_details(
+        {
+            'pwc_evaluation_id': entry.pwc_evaluation_id,
+            'pwc_paper_id': entry.anchors.paper_id,
+            'pwc_dataset_id': entry.anchors.dataset_id,
+            'pwc_task_id': entry.anchors.task_id,
+            'pwc_model_name': entry.anchors.model_name,
+            'source_metrics_sha256': entry.source_metrics_sha256,
+            'protocol_semantic_sha256': protocol_digest,
+            'protocol_study_id': q.study_id,
+            'protocol_id': q.protocol_id,
+            'split_id': q.split_id,
+            'generalization_regime': q.generalization_regime,
+            'drug_entity_overlap': q.drug_entity_overlap,
+            'pair_overlap': q.pair_overlap,
+            'relation_class_overlap': q.relation_class_overlap,
+            'temporal_ordering': q.temporal_ordering,
+            'negative_sampling': q.negative_sampling,
+            'split_preprocessing': q.split_preprocessing,
+            'task_id': q.task_id,
+            'task_type': q.task_type,
+            'candidate_label_space': q.candidate_label_space,
+            'protocol_evidence_url': entry.evidence.source_url,
+            'protocol_evidence_locator': entry.evidence.source_locator,
+            'protocol_review_note': entry.evidence.review_note,
+            'raw_value': raw_value,
+            # Two keys, matching adapters/paperswithcode: the figure the source
+            # printed, and the same number on the scale `score` is on. A spread
+            # is in the score's units, so a rescale has to reach it too.
+            'reported_uncertainty': uncertainty,
+            'reported_uncertainty_canonical': (
+                canonical_uncertainty
+                if metric.scale_factor != 1.0
+                else None
+            ),
+            'reviewed_source_scale': metric.source_scale,
+            'applied_scale_factor': metric.scale_factor,
+        }
+    )
+    return EvaluationResult(
+        evaluation_result_id=(
+            f'paperswithcode-drugbank.{entry.pwc_evaluation_id}.'
+            f'{_metric_result_suffix(metric)}.{protocol_digest}'
+        ),
+        evaluation_name=q.benchmark_id,
+        source_data=build_source_data(dataset),
+        evaluation_timestamp=str(row.get('evaluated_on'))
+        if row.get('evaluated_on')
+        else None,
+        metric_config=MetricConfig(
+            evaluation_description=(
+                f'{metric.metric_name} for DrugBank protocol {q.protocol_id} '
+                f'({q.split_id}).'
+            ),
+            metric_id=metric.metric_id,
+            metric_name=metric.metric_name,
+            metric_kind=metric.metric_kind,
+            metric_unit=metric.metric_unit,
+            lower_is_better=metric.lower_is_better,
+            score_type=ScoreType.continuous,
+            min_score=metric.min_score,
+            max_score=metric.max_score,
+            additional_details={
+                'source_metric_name': metric.source_name,
+                'reviewed_source_scale': metric.source_scale,
+            },
+        ),
+        score_details=ScoreDetails(
+            score=score, uncertainty=None, details=details
+        ),
+    )
+
+
+def build_logs(
+    evaluations: Iterable[dict[str, Any]],
+    datasets_by_id: dict[str, dict[str, Any]],
+    overlay: ProtocolOverlay,
+    overlay_sha256: str,
+    *,
+    dump_file: str | None = None,
+) -> list[EvaluationLog]:
+    rows: dict[str, dict[str, Any]] = {}
+    for row in evaluations:
+        evaluation_id = str(row.get('id'))
+        if evaluation_id in rows:
+            raise ValueError(
+                f'duplicate PwC evaluation id in source: {evaluation_id}'
+            )
+        rows[evaluation_id] = row
+
+    groups: dict[str, _ModelGroup] = {}
+    for entry in overlay.entries:
+        evaluation_id = str(entry.pwc_evaluation_id)
+        row = rows.get(evaluation_id)
+        if row is None:
+            raise ValueError(
+                f'overlay references missing PwC evaluation {evaluation_id}'
+            )
+        for anchor_field in ('paper_id', 'dataset_id', 'task_id', 'model_name'):
+            _assert_anchor(
+                evaluation_id,
+                anchor_field,
+                getattr(entry.anchors, anchor_field),
+                row.get(anchor_field),
+            )
+
+        dataset = datasets_by_id.get(str(entry.anchors.dataset_id))
+        if dataset is None:
+            raise ValueError(
+                f'overlay references missing PwC dataset {entry.anchors.dataset_id!r}'
+            )
+        labels = {
+            str(dataset[field]).strip().casefold()
+            for field in ('name', 'slug')
+            if dataset.get(field)
+        }
+        if labels != {'drugbank'}:
+            raise ValueError(
+                f'overlay entry {evaluation_id} does not target DrugBank'
+            )
+
+        metrics = _metrics_object(row)
+        actual_hash = source_metrics_sha256(metrics)
+        if actual_hash != entry.source_metrics_sha256:
+            raise ValueError(
+                f'PwC evaluation {evaluation_id} metrics payload drift: expected '
+                f'{entry.source_metrics_sha256}, got {actual_hash}'
+            )
+
+        model_id = entry.anchors.model_id
+        group = groups.setdefault(
+            model_id, _ModelGroup(entry.anchors.developer)
+        )
+        group.model_names.add(entry.anchors.model_name)
+        for metric in entry.metrics:
+            if metric.source_name not in metrics:
+                raise ValueError(
+                    f'PwC evaluation {evaluation_id} is missing selected metric '
+                    f'{metric.source_name!r}'
+                )
+            result = _build_result(
+                entry,
+                row,
+                dataset,
+                metric,
+                metrics[metric.source_name],
+            )
+            if result.evaluation_result_id is None:
+                raise ValueError('DrugBank result is missing its stable id')
+            if result.evaluation_result_id in group.result_ids:
+                raise ValueError(
+                    'duplicate DrugBank evaluation_result_id: '
+                    f'{result.evaluation_result_id}'
+                )
+            group.result_ids.add(result.evaluation_result_id)
+            group.results.append(result)
+
+    logs: list[EvaluationLog] = []
+    for model_id, group in sorted(groups.items()):
+        raw_model_names = sorted(group.model_names)
+        log = EvaluationLog(
+            schema_version=SCHEMA_VERSION,
+            evaluation_id=_bundle_evaluation_id(
+                overlay.dump_sha256,
+                group.result_ids,
+            ),
+            retrieved_timestamp=overlay.retrieved_timestamp,
+            source_metadata=build_source_metadata(
+                overlay, overlay_sha256, dump_file
+            ),
+            eval_library=EvalLibrary(name='unknown', version='unknown'),
+            model_info=ModelInfo(
+                name=raw_model_names[0],
+                id=model_id,
+                developer=group.developer,
+                additional_details={
+                    'raw_model_name': raw_model_names[0],
+                    'raw_model_names': json.dumps(
+                        raw_model_names,
+                        ensure_ascii=False,
+                        separators=(',', ':'),
+                    ),
+                    'identity_source': 'protocol_qualification_manifest',
+                },
+            ),
+            evaluation_results=sorted(
+                group.results,
+                key=lambda result: result.evaluation_result_id or '',
+            ),
+        )
+        logs.append(log)
+    if not logs:
+        raise ValueError(
+            'DrugBank qualification manifest selected zero source score cells'
+        )
+    return logs
+
+
+def validate_output_dir(output_dir: Path) -> None:
+    if output_dir.name != COLLECTION_NAME or output_dir.parent.name != 'data':
+        raise ValueError(
+            f'--output-dir must end with data/{COLLECTION_NAME}: {output_dir}'
+        )
+    if not output_dir.exists():
+        return
+    if not output_dir.is_dir():
+        raise ValueError(f'output path must be a directory: {output_dir}')
+    if any(output_dir.iterdir()):
+        raise ValueError(f'output directory must be empty: {output_dir}')
+
+
+def export(logs: Iterable[EvaluationLog], output_dir: Path) -> list[Path]:
+    outputs: list[EvaluationLogOutput] = []
+    for log in logs:
+        # datastore_path_components owns this split: it takes the developer from
+        # the id's prefix, flattens deeper namespaces and rejects an unusable
+        # component, where splitting by hand raised on a flat id.
+        _, developer, model_name = datastore_path_components(
+            COLLECTION_NAME, log.model_info.id, log.model_info.developer
+        )
+        outputs.append(
+            EvaluationLogOutput(
+                eval_log=log,
+                base_dir=output_dir,
+                developer=developer,
+                model_name=model_name,
+            )
+        )
+    return save_evaluation_logs(outputs)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            'Convert explicitly qualified PwC DrugBank transductive, '
+            'inductive-S1, and inductive-S2 results.'
+        )
+    )
+    parser.add_argument(
+        '--dump',
+        type=Path,
+        required=True,
+        help='Local PwC PostgreSQL custom-format dump.',
+    )
+    parser.add_argument(
+        '--overlay',
+        type=Path,
+        required=True,
+        help='External YAML manifest binding exact PwC cells to DrugBank protocol semantics.',
+    )
+    parser.add_argument(
+        '--output-dir',
+        type=Path,
+        default=Path(DEFAULT_OUTPUT_DIR),
+        help=f'Output collection directory (default: {DEFAULT_OUTPUT_DIR}).',
+    )
+    return parser.parse_args(argv)
+
+
+def run(args: argparse.Namespace) -> int:
+    overlay, overlay_sha256 = load_overlay(args.overlay)
+    actual_dump_sha256 = file_sha256(args.dump)
+    if actual_dump_sha256 != overlay.dump_sha256:
+        raise ValueError(
+            'PwC dump SHA-256 does not match the qualification manifest: '
+            f'expected {overlay.dump_sha256}, got {actual_dump_sha256}'
+        )
+    evaluations, datasets = load_source_context(load_dump(args.dump), overlay)
+    logs = build_logs(
+        evaluations, datasets, overlay, overlay_sha256, dump_file=args.dump.name
+    )
+    validate_output_dir(args.output_dir)
+    paths = export(logs, args.output_dir)
+    for path in paths:
+        print(path)
+    return len(paths)
+
+
+if __name__ == '__main__':
+    written = run(parse_args())
+    print(f'Wrote {written} Papers with Code DrugBank model log(s).')

--- a/every_eval_ever/adapters/paperswithcode_drugbank/adapter.py
+++ b/every_eval_ever/adapters/paperswithcode_drugbank/adapter.py
@@ -2,9 +2,12 @@
 """Convert reviewed Papers with Code DrugBank result cells to EEE.
 
 The adapter consumes a local PwC PostgreSQL dump and a YAML manifest that binds
-each selected score cell to reviewed model, metric, split, protocol, and
-provenance metadata. It checks the declared split against drug-entity overlap
-and does not infer semantics from labels or score distributions.
+each selected score cell to reviewed model, source-scale, split, protocol, and
+provenance metadata. Canonical metric fields in that manifest are assertions:
+the CLI verifies them against the same vendored eval-card-registry snapshot used
+by ``adapters/paperswithcode`` before conversion. Protocol semantics and source
+scale remain explicit manifest decisions rather than inferences from labels or
+score distributions.
 
 Overlap with ``adapters/paperswithcode``: that adapter converts the same dump
 across every dataset on its scheduled run, so a DrugBank cell converted here is
@@ -46,6 +49,10 @@ from pydantic import (
     model_validator,
 )
 
+from every_eval_ever.adapters.paperswithcode.adapter import (
+    MetricResolver,
+    build_metric_config as build_pwc_metric_config,
+)
 from every_eval_ever.eval_types import (
     EvalLibrary,
     EvaluationLog,
@@ -473,6 +480,82 @@ def load_overlay(path: str | Path) -> tuple[ProtocolOverlay, str]:
     ).hexdigest()
 
 
+def _validate_registry_revision(
+    overlay: ProtocolOverlay, resolver: MetricResolver
+) -> None:
+    registry_revision = resolver.registry_revision
+    if not registry_revision:
+        raise ValueError('vendored PwC registry snapshot has no revision')
+    if overlay.registry_revision != registry_revision:
+        raise ValueError(
+            'qualification manifest registry_revision does not match the '
+            'vendored PwC registry snapshot: '
+            f'declared {overlay.registry_revision}, vendored {registry_revision}'
+        )
+
+
+def _canonical_metric_config(
+    metric: OverlayMetric, resolver: MetricResolver
+) -> MetricConfig:
+    observed = (metric.min_score, metric.max_score)
+    resolved = resolver.resolve(metric.source_name, observed, 'drugbank')
+    if not resolved.resolved:
+        reason, candidates = resolver.unresolved_reason.get(
+            metric.source_name, ('unknown', ())
+        )
+        candidate_text = (
+            f'; candidates={list(candidates)!r}' if candidates else ''
+        )
+        raise ValueError(
+            f'PwC metric {metric.source_name!r} is not resolvable in the '
+            f'vendored registry snapshot ({reason}{candidate_text})'
+        )
+    if resolved.detail.get('direction_source') == 'unknown':
+        raise ValueError(
+            f'PwC metric {metric.source_name!r} has no determinate canonical '
+            'direction in the vendored registry snapshot'
+        )
+    config = build_pwc_metric_config(
+        metric.source_name, resolved, observed, None
+    )
+    if config.score_type != ScoreType.continuous:
+        raise ValueError(
+            f'PwC metric {metric.source_name!r} has unsupported canonical '
+            f'score_type {config.score_type.value!r}; DrugBank requires '
+            "'continuous'"
+        )
+    return config
+
+
+def validate_registry_contract(
+    overlay: ProtocolOverlay, resolver: MetricResolver | None = None
+) -> MetricResolver:
+    """Verify every manifest metric assertion against the shared PwC snapshot."""
+    resolver = resolver or MetricResolver()
+    _validate_registry_revision(overlay, resolver)
+    for entry in overlay.entries:
+        for metric in entry.metrics:
+            canonical = _canonical_metric_config(metric, resolver)
+            for field_name in (
+                'metric_id',
+                'metric_name',
+                'metric_kind',
+                'metric_unit',
+                'lower_is_better',
+                'min_score',
+                'max_score',
+            ):
+                declared = getattr(metric, field_name)
+                expected = getattr(canonical, field_name)
+                if declared != expected:
+                    raise ValueError(
+                        f'PwC metric {metric.source_name!r} registry contract '
+                        f'mismatch for {field_name}: manifest declares '
+                        f'{declared!r}, vendored registry requires {expected!r}'
+                    )
+    return resolver
+
+
 def load_dump(dump_path: str | Path):
     import pgdumplib
 
@@ -697,7 +780,11 @@ def _build_result(
     dataset: dict[str, Any],
     metric: OverlayMetric,
     raw_value: Any,
+    *,
+    resolver: MetricResolver | None = None,
 ) -> EvaluationResult:
+    resolver = resolver or MetricResolver()
+    canonical_metric = _canonical_metric_config(metric, resolver)
     source_value, uncertainty, percent = parse_metric_value(raw_value)
     if percent and metric.source_scale != 'percent':
         raise ValueError(
@@ -710,11 +797,11 @@ def _build_result(
     canonical_uncertainty = (
         None if uncertainty is None else uncertainty * metric.scale_factor
     )
-    if not metric.min_score <= score <= metric.max_score:
+    if not canonical_metric.min_score <= score <= canonical_metric.max_score:
         raise ValueError(
             f'PwC evaluation {entry.pwc_evaluation_id} metric {metric.source_name!r} '
             f'converts to {score}, outside reviewed canonical range '
-            f'[{metric.min_score}, {metric.max_score}]'
+            f'[{canonical_metric.min_score}, {canonical_metric.max_score}]'
         )
 
     q = entry.qualification
@@ -770,18 +857,19 @@ def _build_result(
         else None,
         metric_config=MetricConfig(
             evaluation_description=(
-                f'{metric.metric_name} for DrugBank protocol {q.protocol_id} '
-                f'({q.split_id}).'
+                f'{canonical_metric.metric_name} for DrugBank protocol '
+                f'{q.protocol_id} ({q.split_id}).'
             ),
-            metric_id=metric.metric_id,
-            metric_name=metric.metric_name,
-            metric_kind=metric.metric_kind,
-            metric_unit=metric.metric_unit,
-            lower_is_better=metric.lower_is_better,
-            score_type=ScoreType.continuous,
-            min_score=metric.min_score,
-            max_score=metric.max_score,
+            metric_id=canonical_metric.metric_id,
+            metric_name=canonical_metric.metric_name,
+            metric_kind=canonical_metric.metric_kind,
+            metric_unit=canonical_metric.metric_unit,
+            lower_is_better=canonical_metric.lower_is_better,
+            score_type=canonical_metric.score_type,
+            min_score=canonical_metric.min_score,
+            max_score=canonical_metric.max_score,
             additional_details={
+                **(canonical_metric.additional_details or {}),
                 'source_metric_name': metric.source_name,
                 'reviewed_source_scale': metric.source_scale,
             },
@@ -799,7 +887,10 @@ def build_logs(
     overlay_sha256: str,
     *,
     dump_file: str | None = None,
+    resolver: MetricResolver | None = None,
 ) -> list[EvaluationLog]:
+    resolver = resolver or MetricResolver()
+    _validate_registry_revision(overlay, resolver)
     rows: dict[str, dict[str, Any]] = {}
     for row in evaluations:
         evaluation_id = str(row.get('id'))
@@ -865,6 +956,7 @@ def build_logs(
                 dataset,
                 metric,
                 metrics[metric.source_name],
+                resolver=resolver,
             )
             if result.evaluation_result_id is None:
                 raise ValueError('DrugBank result is missing its stable id')
@@ -980,6 +1072,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def run(args: argparse.Namespace) -> int:
     overlay, overlay_sha256 = load_overlay(args.overlay)
+    resolver = validate_registry_contract(overlay)
     actual_dump_sha256 = file_sha256(args.dump)
     if actual_dump_sha256 != overlay.dump_sha256:
         raise ValueError(
@@ -988,7 +1081,12 @@ def run(args: argparse.Namespace) -> int:
         )
     evaluations, datasets = load_source_context(load_dump(args.dump), overlay)
     logs = build_logs(
-        evaluations, datasets, overlay, overlay_sha256, dump_file=args.dump.name
+        evaluations,
+        datasets,
+        overlay,
+        overlay_sha256,
+        dump_file=args.dump.name,
+        resolver=resolver,
     )
     validate_output_dir(args.output_dir)
     paths = export(logs, args.output_dir)

--- a/tests/test_adapter_catalog.py
+++ b/tests/test_adapter_catalog.py
@@ -78,6 +78,16 @@ def test_registered_module_imports(spec: catalog.AdapterSpec) -> None:
     importlib.import_module(spec.module)
 
 
+@pytest.mark.parametrize('spec', catalog.ADAPTERS, ids=lambda spec: spec.key)
+def test_dependency_probes_are_module_names(spec: catalog.AdapterSpec) -> None:
+    for module_name in spec.with_packages:
+        assert all(part.isidentifier() for part in module_name.split('.')), (
+            f'{spec.key}: with_packages entries are passed to importlib.find_spec; '
+            'use a dotted module name, not a requirement specifier: '
+            f'{module_name!r}'
+        )
+
+
 @pytest.mark.parametrize('spec', RUNNABLE, ids=lambda spec: spec.key)
 def test_runnable_adapter_accepts_its_registered_arguments(
     spec: catalog.AdapterSpec, tmp_path: Path

--- a/tests/test_paperswithcode_drugbank_adapter.py
+++ b/tests/test_paperswithcode_drugbank_adapter.py
@@ -548,7 +548,7 @@ def test_result_id_binds_protocol_semantics_for_the_same_source_cell() -> None:
 
 
 def test_aggregate_id_binds_protocol_and_metric_selection() -> None:
-    metrics = {'AUROC': '99.49', 'AUPR': '88.00'}
+    metrics = {'AUROC': '99.49', 'Accuracy': '88.00'}
     row = _source_row(metrics)
     dataset = _datasets()
 
@@ -570,7 +570,12 @@ def test_aggregate_id_binds_protocol_and_metric_selection() -> None:
     expanded_payload = deepcopy(base_payload)
     expanded_metric = deepcopy(expanded_payload['entries'][0]['metrics'][0])
     expanded_metric.update(
-        {'source_name': 'AUPR', 'metric_id': 'aupr', 'metric_name': 'AUPR'}
+        {
+            'source_name': 'Accuracy',
+            'metric_id': 'accuracy',
+            'metric_name': 'Accuracy',
+            'metric_kind': 'accuracy',
+        }
     )
     expanded_payload['entries'][0]['metrics'].append(expanded_metric)
     expanded_overlay = adapter.ProtocolOverlay.model_validate(expanded_payload)
@@ -579,7 +584,7 @@ def test_aggregate_id_binds_protocol_and_metric_selection() -> None:
     )[0]
 
     changed_metric_payload = deepcopy(base_payload)
-    changed_metric_payload['entries'][0]['metrics'][0]['metric_id'] = 'accuracy'
+    changed_metric_payload['entries'][0]['metrics'] = [expanded_metric]
     changed_metric = adapter.ProtocolOverlay.model_validate(
         changed_metric_payload
     )

--- a/tests/test_paperswithcode_drugbank_adapter.py
+++ b/tests/test_paperswithcode_drugbank_adapter.py
@@ -1,0 +1,1428 @@
+"""Offline tests for the standalone Papers with Code DrugBank adapter."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import yaml
+
+from every_eval_ever.adapters.paperswithcode_drugbank import adapter
+
+DUMP_SHA = 'a' * 64
+OVERLAY_SHA = 'b' * 64
+REGISTRY_REVISION = 'c' * 40
+RETRIEVED_TS = '1784160000.0'
+
+
+def _overlay_payload(
+    metrics: dict[str, object],
+    *,
+    overlap: str = 'one-unseen',
+    source_scale: str = 'percent',
+) -> dict[str, object]:
+    protocol_id = {
+        'both-seen': 'pair-held-out',
+        'one-unseen': 'one-unseen-drug',
+        'both-unseen': 'two-unseen-drugs',
+    }[overlap]
+    split_id = {
+        'both-seen': 'transductive',
+        'one-unseen': 'inductive-s2',
+        'both-unseen': 'inductive-s1',
+    }[overlap]
+    regime = 'transductive' if overlap == 'both-seen' else 'inductive'
+    return {
+        'schema_version': 2,
+        'dump_sha256': DUMP_SHA,
+        'registry_revision': REGISTRY_REVISION,
+        'retrieved_timestamp': RETRIEVED_TS,
+        'entries': [
+            {
+                'pwc_evaluation_id': 'eval-1',
+                'anchors': {
+                    'paper_id': 'paper-1',
+                    'dataset_id': 'drugbank-id',
+                    'task_id': 'ddi-task',
+                    'model_name': 'Method Alpha',
+                    'model_id': 'example-org/method-alpha',
+                    'developer': 'example-org',
+                },
+                'source_metrics_sha256': adapter.source_metrics_sha256(metrics),
+                'qualification': {
+                    'benchmark_id': (
+                        'paperswithcode-drugbank.alpha-study.'
+                        f'ddi-event-multiclass.{regime}.{protocol_id}'
+                    ),
+                    'split_id': split_id,
+                    'study_id': 'alpha-study',
+                    'protocol_id': protocol_id,
+                    'task_id': 'ddi-event-multiclass',
+                    'task_type': 'ddi-event-multiclass',
+                    'candidate_label_space': 'reported-relation-labels',
+                    'drug_entity_overlap': overlap,
+                    'pair_overlap': 'none',
+                    'relation_class_overlap': 'shared',
+                    'temporal_ordering': 'not-reported',
+                    'negative_sampling': 'paper-defined',
+                    'split_preprocessing': 'paper-defined',
+                },
+                'evidence': {
+                    'source_url': 'https://example.org/paper',
+                    'source_locator': 'Table 1 / split definition',
+                    'review_note': 'Synthetic fixture with explicit split semantics.',
+                },
+                'metrics': [
+                    {
+                        'source_name': 'AUROC',
+                        'metric_id': 'auroc',
+                        'metric_name': 'AUROC',
+                        'metric_kind': 'roc_auc',
+                        'metric_unit': 'proportion',
+                        'lower_is_better': False,
+                        'min_score': 0.0,
+                        'max_score': 1.0,
+                        'source_scale': source_scale,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _overlay(
+    metrics: dict[str, object],
+    *,
+    overlap: str = 'one-unseen',
+    source_scale: str = 'percent',
+) -> adapter.ProtocolOverlay:
+    return adapter.ProtocolOverlay.model_validate(
+        _overlay_payload(metrics, overlap=overlap, source_scale=source_scale)
+    )
+
+
+def _overlay_entry(
+    metrics: dict[str, object],
+    *,
+    overlap: str,
+    evaluation_id: str,
+    paper_id: str,
+    model_name: str,
+    model_id: str = 'example-org/method-alpha',
+    developer: str = 'example-org',
+    source_scale: str = 'percent',
+) -> dict[str, object]:
+    entry = _overlay_payload(
+        metrics, overlap=overlap, source_scale=source_scale
+    )['entries'][0]
+    entry['pwc_evaluation_id'] = evaluation_id
+    entry['anchors']['paper_id'] = paper_id
+    entry['anchors']['model_name'] = model_name
+    entry['anchors']['model_id'] = model_id
+    entry['anchors']['developer'] = developer
+    return entry
+
+
+def _source_row(
+    metrics: dict[str, object],
+    *,
+    evaluation_id: str = 'eval-1',
+    paper_id: str = 'paper-1',
+    model_name: str = 'Method Alpha',
+) -> dict[str, object]:
+    return {
+        'id': evaluation_id,
+        'paper_id': paper_id,
+        'dataset_id': 'drugbank-id',
+        'task_id': 'ddi-task',
+        'model_name': model_name,
+        'evaluated_on': '2024-03-25',
+        'metrics': json.dumps(metrics),
+    }
+
+
+def _source_rows(metrics: dict[str, object]) -> list[dict[str, object]]:
+    return [_source_row(metrics)]
+
+
+def _datasets() -> dict[str, dict[str, object]]:
+    return {
+        'drugbank-id': {
+            'id': 'drugbank-id',
+            'name': 'DrugBank',
+            'slug': 'drugbank',
+            'url': 'https://paperswithcode.com/dataset/drugbank',
+            'homepage': 'https://go.drugbank.com',
+        }
+    }
+
+
+def test_split_identity_preserves_generalization_regime() -> None:
+    metrics = {'AUROC': '99.49'}
+
+    transductive = _overlay(metrics, overlap='both-seen')
+    assert transductive.entries[0].qualification.generalization_regime == (
+        'transductive'
+    )
+    assert transductive.entries[0].qualification.split_id == 'transductive'
+    assert '.transductive.' in (
+        transductive.entries[0].qualification.benchmark_id
+    )
+
+    for overlap in ('one-unseen', 'both-unseen'):
+        inductive = _overlay(metrics, overlap=overlap)
+        assert inductive.entries[0].qualification.generalization_regime == (
+            'inductive'
+        )
+        assert inductive.entries[0].qualification.split_id == (
+            'inductive-s2' if overlap == 'one-unseen' else 'inductive-s1'
+        )
+        assert '.inductive.' in inductive.entries[0].qualification.benchmark_id
+
+
+@pytest.mark.parametrize(
+    ('split_id', 'drug_entity_overlap'),
+    [
+        ('transductive', 'both-seen'),
+        ('inductive-s1', 'both-unseen'),
+        ('inductive-s2', 'one-unseen'),
+    ],
+)
+def test_split_identity_matches_the_drugbank_protocol_table(
+    split_id: str, drug_entity_overlap: str
+) -> None:
+    payload = _overlay_payload({'AUROC': '99.49'}, overlap='both-seen')
+    qualification = payload['entries'][0]['qualification']
+    qualification.update(
+        {
+            'split_id': split_id,
+            'drug_entity_overlap': drug_entity_overlap,
+        }
+    )
+
+    validated = adapter.ProtocolQualification.model_validate(qualification)
+
+    assert validated.split_id == split_id
+    assert validated.drug_entity_overlap == drug_entity_overlap
+    assert validated.generalization_regime == (
+        'transductive' if split_id == 'transductive' else 'inductive'
+    )
+
+
+def test_split_id_must_match_entity_overlap() -> None:
+    payload = _overlay_payload({'AUROC': '99.49'}, overlap='both-seen')
+    payload['entries'][0]['qualification']['split_id'] = 'inductive-s1'
+
+    with pytest.raises(ValueError, match='requires drug_entity_overlap'):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+
+def test_split_qualified_results_preserve_paired_performance() -> None:
+    alpha_transductive = {'AUROC': '99.49'}
+    alpha_inductive = {'AUROC': '70.92'}
+    beta_transductive = {'AUROC': '80.00'}
+    beta_inductive = {'AUROC': '90.00'}
+    gamma_transductive = {'AUROC': '81.00'}
+    gamma_inductive_s1 = {'AUROC': '52.00'}
+    gamma_inductive_s2 = {'AUROC': '63.00'}
+    entries = [
+        _overlay_entry(
+            alpha_transductive,
+            overlap='both-seen',
+            evaluation_id='eval-1',
+            paper_id='paper-1',
+            model_name='Method Alpha',
+        ),
+        _overlay_entry(
+            alpha_inductive,
+            overlap='one-unseen',
+            evaluation_id='eval-2',
+            paper_id='paper-2',
+            model_name='Method Alpha v2',
+        ),
+        _overlay_entry(
+            beta_transductive,
+            overlap='both-seen',
+            evaluation_id='eval-3',
+            paper_id='paper-3',
+            model_name='Method Beta',
+            model_id='example-org/method-beta',
+        ),
+        _overlay_entry(
+            gamma_transductive,
+            overlap='both-seen',
+            evaluation_id='eval-5',
+            paper_id='paper-5',
+            model_name='Method Gamma',
+            model_id='example-org/method-gamma',
+        ),
+        _overlay_entry(
+            gamma_inductive_s1,
+            overlap='both-unseen',
+            evaluation_id='eval-6',
+            paper_id='paper-6',
+            model_name='Method Gamma S1',
+            model_id='example-org/method-gamma',
+        ),
+        _overlay_entry(
+            gamma_inductive_s2,
+            overlap='one-unseen',
+            evaluation_id='eval-7',
+            paper_id='paper-7',
+            model_name='Method Gamma S2',
+            model_id='example-org/method-gamma',
+        ),
+        _overlay_entry(
+            beta_inductive,
+            overlap='both-unseen',
+            evaluation_id='eval-4',
+            paper_id='paper-4',
+            model_name='Method Beta v2',
+            model_id='example-org/method-beta',
+        ),
+    ]
+    payload = _overlay_payload(alpha_transductive, overlap='both-seen')
+    payload['entries'] = entries
+    overlay = adapter.ProtocolOverlay.model_validate(payload)
+    rows = [
+        _source_row(
+            alpha_transductive,
+            evaluation_id='eval-1',
+            paper_id='paper-1',
+            model_name='Method Alpha',
+        ),
+        _source_row(
+            alpha_inductive,
+            evaluation_id='eval-2',
+            paper_id='paper-2',
+            model_name='Method Alpha v2',
+        ),
+        _source_row(
+            beta_transductive,
+            evaluation_id='eval-3',
+            paper_id='paper-3',
+            model_name='Method Beta',
+        ),
+        _source_row(
+            beta_inductive,
+            evaluation_id='eval-4',
+            paper_id='paper-4',
+            model_name='Method Beta v2',
+        ),
+        _source_row(
+            gamma_transductive,
+            evaluation_id='eval-5',
+            paper_id='paper-5',
+            model_name='Method Gamma',
+        ),
+        _source_row(
+            gamma_inductive_s1,
+            evaluation_id='eval-6',
+            paper_id='paper-6',
+            model_name='Method Gamma S1',
+        ),
+        _source_row(
+            gamma_inductive_s2,
+            evaluation_id='eval-7',
+            paper_id='paper-7',
+            model_name='Method Gamma S2',
+        ),
+    ]
+
+    logs = adapter.build_logs(rows, _datasets(), overlay, OVERLAY_SHA)
+    by_model = {log.model_info.id: log for log in logs}
+    expected_scores = {
+        'eval-1': 0.9949,
+        'eval-2': 0.7092,
+        'eval-3': 0.8,
+        'eval-4': 0.9,
+        'eval-5': 0.81,
+        'eval-6': 0.52,
+        'eval-7': 0.63,
+    }
+    entries_by_evaluation_id = {
+        str(entry.pwc_evaluation_id): entry for entry in overlay.entries
+    }
+
+    def results_by_split(model_id: str) -> dict[str, object]:
+        return {
+            result.score_details.details['split_id']: result
+            for result in by_model[model_id].evaluation_results
+        }
+
+    alpha = results_by_split('example-org/method-alpha')
+    beta = results_by_split('example-org/method-beta')
+    assert (
+        alpha['transductive'].score_details.score
+        > alpha['inductive-s2'].score_details.score
+    )
+    assert (
+        beta['transductive'].score_details.score
+        < beta['inductive-s1'].score_details.score
+    )
+    gamma = results_by_split('example-org/method-gamma')
+    assert set(gamma) == {'transductive', 'inductive-s1', 'inductive-s2'}
+    assert (
+        gamma['transductive'].score_details.score
+        > gamma['inductive-s2'].score_details.score
+        > gamma['inductive-s1'].score_details.score
+    )
+    assert len({result.evaluation_name for result in gamma.values()}) == 3
+
+    all_results = [result for log in logs for result in log.evaluation_results]
+    assert len({result.evaluation_result_id for result in all_results}) == 7
+    for result in all_results:
+        details = result.score_details.details
+        entry = entries_by_evaluation_id[details['pwc_evaluation_id']]
+        qualification = entry.qualification
+        assert result.evaluation_name == qualification.benchmark_id
+        assert result.score_details.score == pytest.approx(
+            expected_scores[details['pwc_evaluation_id']]
+        )
+        assert details['split_id'] == qualification.split_id
+        assert (
+            details['drug_entity_overlap'] == qualification.drug_entity_overlap
+        )
+        assert details['generalization_regime'] == (
+            'transductive'
+            if details['split_id'] == 'transductive'
+            else 'inductive'
+        )
+        assert (
+            details['protocol_semantic_sha256'] in result.evaluation_result_id
+        )
+        assert details['protocol_semantic_sha256'] == (
+            qualification.semantic_sha256()
+        )
+
+
+def test_benchmark_id_cannot_hide_conflicting_split_protocols() -> None:
+    first = _overlay_entry(
+        {'AUROC': '99.49'},
+        overlap='both-seen',
+        evaluation_id='eval-1',
+        paper_id='paper-1',
+        model_name='Method Alpha',
+    )
+    second = _overlay_entry(
+        {'AUROC': '70.92'},
+        overlap='one-unseen',
+        evaluation_id='eval-2',
+        paper_id='paper-2',
+        model_name='Method Alpha v2',
+    )
+    second['qualification']['benchmark_id'] = first['qualification'][
+        'benchmark_id'
+    ]
+    payload = _overlay_payload({'AUROC': '99.49'}, overlap='both-seen')
+    payload['entries'] = [first, second]
+
+    with pytest.raises(ValueError, match='reused for conflicting protocol'):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+
+def test_benchmark_id_protocol_is_consistent_across_models() -> None:
+    first = _overlay_entry(
+        {'AUROC': '99.49'},
+        overlap='both-seen',
+        evaluation_id='eval-1',
+        paper_id='paper-1',
+        model_name='Method Alpha',
+    )
+    second = _overlay_entry(
+        {'AUROC': '70.92'},
+        overlap='one-unseen',
+        evaluation_id='eval-2',
+        paper_id='paper-2',
+        model_name='Method Beta',
+        model_id='example-org/method-beta',
+    )
+    second['qualification']['benchmark_id'] = first['qualification'][
+        'benchmark_id'
+    ]
+    payload = _overlay_payload({'AUROC': '99.49'}, overlap='both-seen')
+    payload['entries'] = [first, second]
+
+    with pytest.raises(ValueError, match='reused for conflicting protocol'):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+
+def test_benchmark_id_protocol_is_consistent_across_metrics() -> None:
+    first = _overlay_entry(
+        {'AUROC': '99.49'},
+        overlap='both-seen',
+        evaluation_id='eval-1',
+        paper_id='paper-1',
+        model_name='Method Alpha',
+    )
+    second = _overlay_entry(
+        {'AUPR': '70.92'},
+        overlap='one-unseen',
+        evaluation_id='eval-2',
+        paper_id='paper-2',
+        model_name='Method Alpha v2',
+    )
+    second['qualification']['benchmark_id'] = first['qualification'][
+        'benchmark_id'
+    ]
+    second['metrics'][0].update(
+        {'source_name': 'AUPR', 'metric_id': 'aupr', 'metric_name': 'AUPR'}
+    )
+    payload = _overlay_payload({'AUROC': '99.49'}, overlap='both-seen')
+    payload['entries'] = [first, second]
+
+    with pytest.raises(ValueError, match='reused for conflicting protocol'):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+
+def test_duplicate_canonical_metric_ids_are_rejected() -> None:
+    metrics = {'AUROC': '99.49', 'AUPR': '88.00'}
+    payload = _overlay_payload(metrics)
+    duplicate = deepcopy(payload['entries'][0]['metrics'][0])
+    duplicate['source_name'] = 'AUPR'
+    payload['entries'][0]['metrics'].append(duplicate)
+
+    with pytest.raises(ValueError, match='canonical metric_id selectors'):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+
+def test_duplicate_canonical_metric_ids_across_entries_are_rejected() -> None:
+    first = _overlay_entry(
+        {'AUROC': '99.49'},
+        overlap='both-seen',
+        evaluation_id='eval-1',
+        paper_id='paper-1',
+        model_name='Method Alpha',
+    )
+    second = _overlay_entry(
+        {'AUPR': '88.00'},
+        overlap='both-seen',
+        evaluation_id='eval-1',
+        paper_id='paper-1',
+        model_name='Method Alpha',
+    )
+    second['metrics'][0].update(
+        {'source_name': 'AUPR', 'metric_id': 'auroc', 'metric_name': 'AUROC'}
+    )
+    payload = _overlay_payload({'AUROC': '99.49'}, overlap='both-seen')
+    payload['entries'] = [first, second]
+
+    with pytest.raises(ValueError, match='selected more than once'):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+
+def test_result_id_binds_protocol_semantics_for_the_same_source_cell() -> None:
+    metrics = {'AUROC': '99.49'}
+    overlay = _overlay(metrics, overlap='both-seen')
+    entry = overlay.entries[0]
+    row = _source_row(metrics)
+    dataset = _datasets()['drugbank-id']
+    metric = entry.metrics[0]
+    baseline = adapter._build_result(
+        entry, row, dataset, metric, metrics['AUROC']
+    )
+    changed_qualification = entry.qualification.model_copy(
+        update={'protocol_id': 'alternate-protocol'}
+    )
+    changed_entry = entry.model_copy(
+        update={'qualification': changed_qualification}
+    )
+    changed = adapter._build_result(
+        changed_entry, row, dataset, metric, metrics['AUROC']
+    )
+
+    assert baseline.evaluation_name == changed.evaluation_name
+    assert baseline.evaluation_result_id != changed.evaluation_result_id
+    assert baseline.score_details.score == changed.score_details.score
+    assert (
+        baseline.score_details.details['protocol_semantic_sha256']
+        != (changed.score_details.details['protocol_semantic_sha256'])
+    )
+
+
+def test_aggregate_id_binds_protocol_and_metric_selection() -> None:
+    metrics = {'AUROC': '99.49', 'AUPR': '88.00'}
+    row = _source_row(metrics)
+    dataset = _datasets()
+
+    base_payload = _overlay_payload(metrics, overlap='both-seen')
+    base_overlay = adapter.ProtocolOverlay.model_validate(base_payload)
+    base_log = adapter.build_logs([row], dataset, base_overlay, OVERLAY_SHA)[0]
+
+    changed_protocol_payload = deepcopy(base_payload)
+    changed_protocol_payload['entries'][0]['qualification']['protocol_id'] = (
+        'alternate-protocol'
+    )
+    changed_protocol = adapter.ProtocolOverlay.model_validate(
+        changed_protocol_payload
+    )
+    changed_protocol_log = adapter.build_logs(
+        [row], dataset, changed_protocol, OVERLAY_SHA
+    )[0]
+
+    expanded_payload = deepcopy(base_payload)
+    expanded_metric = deepcopy(expanded_payload['entries'][0]['metrics'][0])
+    expanded_metric.update(
+        {'source_name': 'AUPR', 'metric_id': 'aupr', 'metric_name': 'AUPR'}
+    )
+    expanded_payload['entries'][0]['metrics'].append(expanded_metric)
+    expanded_overlay = adapter.ProtocolOverlay.model_validate(expanded_payload)
+    expanded_log = adapter.build_logs(
+        [row], dataset, expanded_overlay, OVERLAY_SHA
+    )[0]
+
+    changed_metric_payload = deepcopy(base_payload)
+    changed_metric_payload['entries'][0]['metrics'][0]['metric_id'] = 'accuracy'
+    changed_metric = adapter.ProtocolOverlay.model_validate(
+        changed_metric_payload
+    )
+    changed_metric_log = adapter.build_logs(
+        [row], dataset, changed_metric, OVERLAY_SHA
+    )[0]
+
+    assert base_log.evaluation_id != changed_protocol_log.evaluation_id
+    assert base_log.evaluation_id != expanded_log.evaluation_id
+    assert base_log.evaluation_id != changed_metric_log.evaluation_id
+
+
+def test_metric_result_suffix_uses_full_metric_digest() -> None:
+    overlay = _overlay({'AUROC': '99.49'})
+    metric = overlay.entries[0].metrics[0]
+    first = metric.model_copy(update={'source_name': 'AUROC@]@&'})
+    second = metric.model_copy(update={'source_name': 'AUROC&${'})
+
+    assert adapter._metric_result_suffix(
+        first
+    ) != adapter._metric_result_suffix(second)
+
+
+def test_explicit_percent_scale_converts_without_distribution_inference() -> (
+    None
+):
+    metrics = {'AUROC': '99.49'}
+    overlay = _overlay(metrics)
+    logs = adapter.build_logs(
+        _source_rows(metrics),
+        _datasets(),
+        overlay,
+        OVERLAY_SHA,
+        dump_file='paperswithcode.dump',
+    )
+
+    [log] = logs
+    assert log.model_info.id == 'example-org/method-alpha'
+    assert log.model_info.developer == 'example-org'
+    assert log.source_metadata.source_type.value == 'documentation'
+    assert log.source_metadata.source_name == adapter.SOURCE_NAME
+    assert log.source_metadata.additional_details['registry_revision'] == (
+        REGISTRY_REVISION
+    )
+
+    score = log.evaluation_results[0]
+    qualification = overlay.entries[0].qualification
+    assert score.evaluation_name == qualification.benchmark_id
+    assert score.score_details.details['protocol_semantic_sha256'] == (
+        qualification.semantic_sha256()
+    )
+    assert score.score_details.score == pytest.approx(0.9949)
+    assert score.metric_config.metric_id == 'auroc'
+    assert score.metric_config.metric_unit == 'proportion'
+    assert score.score_details.details['raw_value'] == '99.49'
+    assert score.score_details.details['reviewed_source_scale'] == 'percent'
+    assert score.score_details.details['applied_scale_factor'] == '0.01'
+    assert score.score_details.details['generalization_regime'] == 'inductive'
+    assert score.source_data.dataset_name == 'DrugBank'
+    assert (
+        'https://paperswithcode.com/dataset/drugbank'
+        not in score.source_data.url
+    )
+    assert score.source_data.url == [adapter.DRUGBANK_URL]
+    assert score.source_data.additional_details['raw_dataset_url'] == (
+        'https://paperswithcode.com/dataset/drugbank'
+    )
+    assert log.source_metadata.additional_details['pwc_data_archive_url'] == (
+        adapter.PWC_DATASET_ARCHIVE_URL
+    )
+
+
+def test_reported_uncertainty_lands_on_the_same_scale_as_the_score() -> None:
+    """A dispersion is a spread in the score's units, so it takes the factor too.
+
+    Left unscaled, a percent-scale cell published `score=0.912` beside
+    `reported_uncertainty=1.4` — a spread wider than the metric's whole range.
+    """
+    metrics = {'AUROC': '99.49 ± 0.31'}
+    logs = adapter.build_logs(
+        _source_rows(metrics), _datasets(), _overlay(metrics), OVERLAY_SHA
+    )
+
+    details = logs[0].evaluation_results[0].score_details.details
+    assert logs[0].evaluation_results[0].score_details.score == pytest.approx(
+        0.9949
+    )
+    # Two keys, like adapters/paperswithcode: what the source printed, and the
+    # same number on the scale `score` is on.
+    assert details['reported_uncertainty'] == '0.31'
+    assert float(details['reported_uncertainty_canonical']) == pytest.approx(
+        0.0031
+    )
+    assert details['raw_value'] == '99.49 ± 0.31'
+
+
+def test_an_identity_scale_uncertainty_is_carried_through_unchanged() -> None:
+    metrics = {'AUROC': '0.9949 +/- 0.0031'}
+    logs = adapter.build_logs(
+        _source_rows(metrics),
+        _datasets(),
+        _overlay(metrics, source_scale='identity'),
+        OVERLAY_SHA,
+    )
+
+    details = logs[0].evaluation_results[0].score_details.details
+    assert details['reported_uncertainty'] == '0.0031'
+    # Nothing was rescaled, so repeating the figure would only invite drift.
+    assert 'reported_uncertainty_canonical' not in details
+
+
+def test_a_cell_with_no_uncertainty_records_none() -> None:
+    metrics = {'AUROC': '99.49'}
+    logs = adapter.build_logs(
+        _source_rows(metrics), _datasets(), _overlay(metrics), OVERLAY_SHA
+    )
+
+    details = logs[0].evaluation_results[0].score_details.details
+    assert 'reported_uncertainty' not in details
+
+
+@pytest.mark.parametrize(
+    'raw_value', ['99.49 ± abc', '99.49 ± -0.3', '99.49 ± inf']
+)
+def test_an_unusable_uncertainty_fails_rather_than_reaching_a_record(
+    raw_value: str,
+) -> None:
+    metrics = {'AUROC': raw_value}
+    with pytest.raises(ValueError):
+        adapter.build_logs(
+            _source_rows(metrics), _datasets(), _overlay(metrics), OVERLAY_SHA
+        )
+
+
+def test_wrong_explicit_scale_fails_closed_instead_of_guessing() -> None:
+    metrics = {'AUROC': '99.49'}
+    with pytest.raises(ValueError, match='outside reviewed canonical range'):
+        adapter.build_logs(
+            _source_rows(metrics),
+            _datasets(),
+            _overlay(metrics, source_scale='identity'),
+            OVERLAY_SHA,
+        )
+
+
+def test_percent_marker_must_agree_with_manifest_scale() -> None:
+    metrics = {'AUROC': '99.49%'}
+    with pytest.raises(ValueError, match='percent marker'):
+        adapter.build_logs(
+            _source_rows(metrics),
+            _datasets(),
+            _overlay(metrics, source_scale='identity'),
+            OVERLAY_SHA,
+        )
+
+
+@pytest.mark.parametrize('raw_value', ['1,000', '0,5'])
+def test_metric_parser_rejects_ambiguous_comma_formatting(
+    raw_value: str,
+) -> None:
+    with pytest.raises(ValueError, match='ambiguous comma formatting'):
+        adapter.parse_metric_value(raw_value)
+
+
+def test_source_data_uses_only_trusted_drugbank_url() -> None:
+    source = adapter.build_source_data(
+        {
+            'id': 'drugbank-id',
+            'name': 'DrugBank',
+            'slug': 'drugbank',
+            'url': 'https://go.drugbank.com@evil.example/',
+            'homepage': 'http://localhost/private',
+            'paper_url': 'https://example.org/paper-not-dataset',
+        }
+    )
+
+    assert source.url == [adapter.DRUGBANK_URL]
+    assert source.additional_details['raw_dataset_url'] == (
+        'https://go.drugbank.com@evil.example/'
+    )
+    assert source.additional_details['raw_dataset_homepage'] == (
+        'http://localhost/private'
+    )
+
+
+def test_metrics_payload_and_source_anchors_are_drift_guards() -> None:
+    metrics = {'AUROC': '99.49'}
+    overlay = _overlay(metrics)
+
+    with pytest.raises(ValueError, match='metrics payload drift'):
+        adapter.build_logs(
+            _source_rows({'AUROC': '99.50'}),
+            _datasets(),
+            overlay,
+            OVERLAY_SHA,
+        )
+
+    wrong_anchor = _source_rows(metrics)
+    wrong_anchor[0]['paper_id'] = 'other-paper'
+    with pytest.raises(ValueError, match='anchor drift'):
+        adapter.build_logs(wrong_anchor, _datasets(), overlay, OVERLAY_SHA)
+
+
+@pytest.mark.parametrize(
+    ('name', 'slug'),
+    [('Other', 'other'), ('Other', 'drugbank'), ('DrugBank', 'other')],
+)
+def test_non_drugbank_or_conflicting_dataset_is_rejected(
+    name: str, slug: str
+) -> None:
+    metrics = {'AUROC': '99.49'}
+    bad_datasets = _datasets()
+    bad_datasets['drugbank-id'] = {
+        'id': 'drugbank-id',
+        'name': name,
+        'slug': slug,
+    }
+    with pytest.raises(ValueError, match='does not target DrugBank'):
+        adapter.build_logs(
+            _source_rows(metrics),
+            bad_datasets,
+            _overlay(metrics),
+            OVERLAY_SHA,
+        )
+
+
+def test_overlay_rejects_duplicate_cells_and_invalid_model_mappings() -> None:
+    metrics = {'AUROC': '99.49'}
+    payload = _overlay_payload(metrics)
+    duplicate = deepcopy(payload['entries'][0])
+    payload['entries'].append(duplicate)
+    with pytest.raises(ValueError, match='selected more than once'):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+    payload = _overlay_payload(metrics)
+    payload['entries'][0]['anchors']['model_id'] = 'missing-model-namespace'
+    with pytest.raises(ValueError, match='at least two'):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+    payload = _overlay_payload(metrics)
+    conflicting_model = deepcopy(payload['entries'][0])
+    conflicting_model['anchors']['model_id'] = 'other-org/method-alpha'
+    conflicting_model['anchors']['developer'] = 'other-company'
+    payload['entries'].append(conflicting_model)
+    with pytest.raises(ValueError, match='multiple canonical model ids'):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+
+def test_model_ids_allow_nested_namespaces_and_independent_developers(
+    tmp_path,
+) -> None:
+    metrics = {'AUROC': '99.49'}
+    payload = _overlay_payload(metrics)
+    payload['entries'][0]['anchors']['model_id'] = (
+        'example-org/azure/method-alpha'
+    )
+    payload['entries'][0]['anchors']['developer'] = 'example-company'
+    logs = adapter.build_logs(
+        _source_rows(metrics),
+        _datasets(),
+        adapter.ProtocolOverlay.model_validate(payload),
+        OVERLAY_SHA,
+    )
+
+    [log] = logs
+    assert log.model_info.id == 'example-org/azure/method-alpha'
+    assert log.model_info.developer == 'example-company'
+
+    output_dir = tmp_path / 'data' / 'paperswithcode-drugbank'
+    [path] = adapter.export(logs, output_dir)
+    assert path.parent == output_dir / 'example-org' / 'azure_method-alpha'
+
+
+def test_aliases_with_conflicting_developers_are_rejected() -> None:
+    metrics = {'AUROC': '99.49'}
+    payload = _overlay_payload(metrics)
+    second_entry = deepcopy(payload['entries'][0])
+    second_entry['pwc_evaluation_id'] = 'eval-2'
+    second_entry['anchors']['paper_id'] = 'paper-2'
+    second_entry['anchors']['model_name'] = 'Method Alpha v1'
+    second_entry['anchors']['developer'] = 'other-company'
+    payload['entries'].append(second_entry)
+
+    rows = _source_rows(metrics)
+    second_row = dict(rows[0])
+    second_row.update(
+        id='eval-2', paper_id='paper-2', model_name='Method Alpha v1'
+    )
+    rows.append(second_row)
+
+    with pytest.raises(ValueError, match='inconsistent reviewed developer'):
+        adapter.build_logs(
+            rows,
+            _datasets(),
+            adapter.ProtocolOverlay.model_validate(payload),
+            OVERLAY_SHA,
+        )
+
+
+def test_evaluation_id_is_stable_across_review_note_edits() -> None:
+    metrics = {'AUROC': '99.49'}
+    first = adapter.build_logs(
+        _source_rows(metrics),
+        _datasets(),
+        _overlay(metrics),
+        OVERLAY_SHA,
+    )
+    after_review_note_edit = adapter.build_logs(
+        _source_rows(metrics),
+        _datasets(),
+        _overlay(metrics),
+        'c' * 64,
+    )
+
+    evaluation_id = first[0].evaluation_id
+    assert evaluation_id == after_review_note_edit[0].evaluation_id
+    result_ids = [
+        result.evaluation_result_id for result in first[0].evaluation_results
+    ]
+    assert None not in result_ids
+    assert evaluation_id == adapter._bundle_evaluation_id(DUMP_SHA, result_ids)
+
+
+def test_model_ids_that_collided_under_underscore_flattening_remain_distinct() -> (
+    None
+):
+    metrics = {'AUROC': '99.49'}
+    payload = _overlay_payload(metrics)
+    first_entry = payload['entries'][0]
+    first_entry['anchors']['model_id'] = 'foo_bar/baz'
+    first_entry['anchors']['developer'] = 'foo_bar'
+
+    second_entry = deepcopy(first_entry)
+    second_entry['pwc_evaluation_id'] = 'eval-2'
+    second_entry['anchors']['paper_id'] = 'paper-2'
+    second_entry['anchors']['model_name'] = 'Method Beta'
+    second_entry['anchors']['model_id'] = 'foo/bar_baz'
+    second_entry['anchors']['developer'] = 'foo'
+    payload['entries'].append(second_entry)
+
+    rows = _source_rows(metrics)
+    second_row = dict(rows[0])
+    second_row.update(id='eval-2', paper_id='paper-2', model_name='Method Beta')
+    rows.append(second_row)
+
+    logs = adapter.build_logs(
+        rows,
+        _datasets(),
+        adapter.ProtocolOverlay.model_validate(payload),
+        OVERLAY_SHA,
+    )
+
+    assert {log.model_info.id for log in logs} == {
+        'foo_bar/baz',
+        'foo/bar_baz',
+    }
+    assert len({log.evaluation_id for log in logs}) == 2
+
+
+def test_source_model_aliases_consolidate_under_canonical_model_id() -> None:
+    metrics = {'AUROC': '99.49'}
+    payload = _overlay_payload(metrics)
+    second_entry = deepcopy(payload['entries'][0])
+    second_entry['pwc_evaluation_id'] = 'eval-2'
+    second_entry['anchors']['paper_id'] = 'paper-2'
+    second_entry['anchors']['model_name'] = 'Method Alpha v1'
+    payload['entries'].append(second_entry)
+
+    rows = _source_rows(metrics)
+    second_row = dict(rows[0])
+    second_row.update(
+        id='eval-2', paper_id='paper-2', model_name='Method Alpha v1'
+    )
+    rows.append(second_row)
+
+    logs = adapter.build_logs(
+        rows,
+        _datasets(),
+        adapter.ProtocolOverlay.model_validate(payload),
+        OVERLAY_SHA,
+    )
+
+    [log] = logs
+    assert log.model_info.id == 'example-org/method-alpha'
+    assert json.loads(log.model_info.additional_details['raw_model_names']) == [
+        'Method Alpha',
+        'Method Alpha v1',
+    ]
+    names_by_source_id = {
+        result.score_details.details[
+            'pwc_evaluation_id'
+        ]: result.score_details.details['pwc_model_name']
+        for result in log.evaluation_results
+    }
+    assert names_by_source_id == {
+        'eval-1': 'Method Alpha',
+        'eval-2': 'Method Alpha v1',
+    }
+    assert len(log.evaluation_results) == 2
+
+
+@pytest.mark.parametrize(
+    ('field', 'replacement', 'companion_updates'),
+    [
+        ('study_id', 'beta-study', {}),
+        ('protocol_id', 'alternate-protocol', {}),
+        ('task_id', 'ddi-binary', {}),
+        ('task_type', 'ddi-binary', {}),
+        ('candidate_label_space', 'binary-interaction', {}),
+        (
+            'drug_entity_overlap',
+            'both-unseen',
+            {'split_id': 'inductive-s1'},
+        ),
+        ('split_id', 'inductive-s1', {'drug_entity_overlap': 'both-unseen'}),
+        ('pair_overlap', 'partial', {}),
+        ('relation_class_overlap', 'disjoint', {}),
+        ('temporal_ordering', 'chronological', {}),
+        ('negative_sampling', 'uniform', {}),
+        ('split_preprocessing', 'deduplicated-before-split', {}),
+    ],
+)
+def test_protocol_digest_binds_every_semantic_field_without_rekeying_benchmark(
+    field: str, replacement: str, companion_updates: dict[str, str]
+) -> None:
+    payload = _overlay_payload({'AUROC': '99.49'})
+    qualification = payload['entries'][0]['qualification']
+    baseline = adapter.ProtocolQualification.model_validate(qualification)
+    changed = adapter.ProtocolQualification.model_validate(
+        {**qualification, field: replacement, **companion_updates}
+    )
+
+    assert changed.semantic_sha256() != baseline.semantic_sha256()
+    assert changed.benchmark_id == baseline.benchmark_id
+
+
+@pytest.mark.parametrize(
+    ('updates', 'message'),
+    [
+        (
+            {'metric_unit': 'percent', 'min_score': 0.0, 'max_score': 100.0},
+            'canonical metric_unit',
+        ),
+        (
+            {'metric_unit': 'proportion', 'min_score': 0.0, 'max_score': 100.0},
+            'canonical bounds',
+        ),
+    ],
+)
+def test_percent_conversion_rejects_contradictory_output_metadata(
+    updates: dict[str, object], message: str
+) -> None:
+    payload = _overlay_payload({'AUROC': '99.49'})
+    payload['entries'][0]['metrics'][0].update(updates)
+
+    with pytest.raises(ValueError, match=message):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+
+def test_overlay_requires_entries_and_unix_retrieval_time() -> None:
+    with pytest.raises(ValueError):
+        adapter.ProtocolOverlay.model_validate(
+            {
+                'schema_version': 2,
+                'dump_sha256': DUMP_SHA,
+                'registry_revision': REGISTRY_REVISION,
+                'retrieved_timestamp': RETRIEVED_TS,
+                'entries': [],
+            }
+        )
+
+    old_payload = _overlay_payload({'AUROC': '99.49'})
+    old_payload['schema_version'] = 1
+    with pytest.raises(ValueError, match='schema_version'):
+        adapter.ProtocolOverlay.model_validate(old_payload)
+
+    payload = _overlay_payload({'AUROC': '99.49'})
+    payload['retrieved_timestamp'] = 'not-an-epoch'
+    with pytest.raises(ValueError, match='Unix-epoch'):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+    payload = _overlay_payload({'AUROC': '99.49'})
+    payload['registry_revision'] = 'main'
+    with pytest.raises(ValueError, match='commit SHA'):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    'yaml_text',
+    [
+        'schema_version: 2\nschema_version: 2\n',
+        'entries:\n  - pwc_evaluation_id: eval-1\n'
+        '    pwc_evaluation_id: eval-2\n',
+        'entries:\n  - qualification:\n'
+        '      split_id: transductive\n'
+        '      split_id: inductive-s1\n',
+        'entries:\n  - metrics:\n'
+        '      - source_name: AUROC\n'
+        '        source_name: AUPR\n',
+    ],
+)
+def test_overlay_yaml_rejects_duplicate_keys(tmp_path, yaml_text: str) -> None:
+    path = tmp_path / 'overlay.yaml'
+    path.write_text(yaml_text, encoding='utf-8')
+
+    with pytest.raises(ValueError, match='duplicate key'):
+        adapter.load_overlay(path)
+
+
+@pytest.mark.parametrize(
+    ('field', 'invalid_id'),
+    [
+        ('pwc_evaluation_id', True),
+        ('pwc_evaluation_id', 1.0),
+        ('paper_id', True),
+        ('dataset_id', 1.0),
+        ('task_id', True),
+    ],
+)
+def test_overlay_source_ids_reject_coercive_types(
+    field: str, invalid_id: object
+) -> None:
+    payload = _overlay_payload({'AUROC': '99.49'})
+    if field == 'pwc_evaluation_id':
+        payload['entries'][0][field] = invalid_id
+    else:
+        payload['entries'][0]['anchors'][field] = invalid_id
+
+    with pytest.raises(ValueError, match=field):
+        adapter.ProtocolOverlay.model_validate(payload)
+
+
+def test_output_directory_must_be_fixed_collection_and_empty(tmp_path) -> None:
+    with pytest.raises(ValueError, match='must end with'):
+        adapter.validate_output_dir(tmp_path / 'out')
+
+    output = tmp_path / 'data' / adapter.COLLECTION_NAME
+    output.mkdir(parents=True)
+    (output / 'old.json').write_text('{}', encoding='utf-8')
+    with pytest.raises(ValueError, match='must be empty'):
+        adapter.validate_output_dir(output)
+
+    output_file = tmp_path / 'other' / 'data' / adapter.COLLECTION_NAME
+    output_file.parent.mkdir(parents=True)
+    output_file.write_text('', encoding='utf-8')
+    with pytest.raises(ValueError, match='must be a directory'):
+        adapter.validate_output_dir(output_file)
+
+
+@dataclass
+class _DumpEntry:
+    desc: str
+    tag: str
+    namespace: str
+    copy_stmt: str
+
+
+class _FakeDump:
+    def __init__(
+        self, evaluation: dict[str, object], dataset: dict[str, object]
+    ):
+        self.entries = [
+            _DumpEntry(
+                'TABLE DATA',
+                'evaluations',
+                'public',
+                'COPY public.evaluations '
+                '(id, paper_id, dataset_id, task_id, model_name, '
+                'evaluated_on, metrics) FROM stdin;',
+            ),
+            _DumpEntry(
+                'TABLE DATA',
+                'datasets',
+                'public',
+                'COPY public.datasets '
+                '(id, name, slug, url, homepage) FROM stdin;',
+            ),
+        ]
+        self._rows = {
+            'evaluations': [
+                tuple(
+                    evaluation[key]
+                    for key in (
+                        'id',
+                        'paper_id',
+                        'dataset_id',
+                        'task_id',
+                        'model_name',
+                        'evaluated_on',
+                        'metrics',
+                    )
+                )
+            ],
+            'datasets': [
+                tuple(
+                    dataset.get(key)
+                    for key in ('id', 'name', 'slug', 'url', 'homepage')
+                )
+            ],
+        }
+
+    def table_data(self, schema: str, table: str):
+        assert schema == 'public'
+        return iter(self._rows[table])
+
+
+def test_source_context_reads_only_manifest_selected_rows() -> None:
+    metrics = {'AUROC': '99.49'}
+    overlay = _overlay(metrics)
+    evaluation = _source_rows(metrics)[0]
+    dataset = _datasets()['drugbank-id']
+    dump = _FakeDump(evaluation, dataset)
+
+    evaluations, datasets = adapter.load_source_context(dump, overlay)
+    assert [row['id'] for row in evaluations] == ['eval-1']
+    assert set(datasets) == {'drugbank-id'}
+
+
+def test_dump_row_width_must_match_copy_columns() -> None:
+    metrics = {'AUROC': '99.49'}
+    dump = _FakeDump(_source_rows(metrics)[0], _datasets()['drugbank-id'])
+    dump._rows['evaluations'][0] = dump._rows['evaluations'][0][:-1]
+
+    with pytest.raises(ValueError):
+        list(adapter.table_rows(dump, 'evaluations'))
+
+
+def test_dump_copy_target_must_match_selected_table() -> None:
+    metrics = {'AUROC': '99.49'}
+    dump = _FakeDump(_source_rows(metrics)[0], _datasets()['drugbank-id'])
+    dump.entries[0].copy_stmt = dump.entries[0].copy_stmt.replace(
+        'public.evaluations', 'public.datasets'
+    )
+
+    with pytest.raises(ValueError, match='cannot read column order'):
+        list(adapter.table_rows(dump, 'evaluations'))
+
+
+def test_late_source_mismatch_leaves_no_output(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first_metrics = {'AUROC': '99.49'}
+    second_metrics = {'AUROC': '70.92'}
+    first_row = _source_row(first_metrics)
+    second_row = _source_row(
+        second_metrics,
+        evaluation_id='eval-2',
+        paper_id='paper-2',
+        model_name='Method Alpha v2',
+    )
+    dump = _FakeDump(first_row, _datasets()['drugbank-id'])
+    dump._rows['evaluations'].append(
+        tuple(
+            second_row[key]
+            for key in (
+                'id',
+                'paper_id',
+                'dataset_id',
+                'task_id',
+                'model_name',
+                'evaluated_on',
+                'metrics',
+            )
+        )
+    )
+    first_entry = _overlay_entry(
+        first_metrics,
+        overlap='both-seen',
+        evaluation_id='eval-1',
+        paper_id='paper-1',
+        model_name='Method Alpha',
+    )
+    second_entry = _overlay_entry(
+        second_metrics,
+        overlap='one-unseen',
+        evaluation_id='eval-2',
+        paper_id='paper-2',
+        model_name='Method Alpha v2',
+    )
+    second_entry['source_metrics_sha256'] = 'd' * 64
+    payload = _overlay_payload(first_metrics, overlap='both-seen')
+    payload['entries'] = [first_entry, second_entry]
+    overlay_path = tmp_path / 'overlay.yaml'
+    overlay_path.write_text(
+        yaml.safe_dump(payload, sort_keys=False), encoding='utf-8'
+    )
+    output_dir = tmp_path / 'data' / adapter.COLLECTION_NAME
+    dump_path = tmp_path / 'paperswithcode.dump'
+    monkeypatch.setattr(adapter, 'file_sha256', lambda path: DUMP_SHA)
+    monkeypatch.setattr(adapter, 'load_dump', lambda path: dump)
+
+    with pytest.raises(ValueError, match='metrics payload drift'):
+        adapter.run(
+            adapter.parse_args(
+                [
+                    '--dump',
+                    str(dump_path),
+                    '--overlay',
+                    str(overlay_path),
+                    '--output-dir',
+                    str(output_dir),
+                ]
+            )
+        )
+
+    assert not output_dir.exists()
+
+
+def test_real_pgdumplib_dump_runs_through_cli_path(tmp_path) -> None:
+    pgdumplib = pytest.importorskip(
+        'pgdumplib',
+        reason='manual adapter dependency is not in the core environment',
+    )
+    metrics = {'AUROC': '99.49'}
+    dump_path = tmp_path / 'paperswithcode.dump'
+    dump = pgdumplib.new('paperswithcode', 'UTF8', appear_as='15.0')
+
+    evaluations = dump.add_entry(
+        'TABLE',
+        namespace='public',
+        tag='evaluations',
+        owner='postgres',
+        defn="""CREATE TABLE public.evaluations (
+        id text,
+        paper_id text,
+        dataset_id text,
+        task_id text,
+        model_name text,
+        evaluated_on text,
+        metrics jsonb
+        );""",
+    )
+    with dump.table_data_writer(
+        evaluations,
+        (
+            'id',
+            'paper_id',
+            'dataset_id',
+            'task_id',
+            'model_name',
+            'evaluated_on',
+            'metrics',
+        ),
+    ) as writer:
+        writer.append(
+            'eval-1',
+            'paper-1',
+            'drugbank-id',
+            'ddi-task',
+            'Method Alpha',
+            '2024-03-25',
+            json.dumps(metrics, separators=(',', ':')),
+        )
+
+    datasets = dump.add_entry(
+        'TABLE',
+        namespace='public',
+        tag='datasets',
+        owner='postgres',
+        defn="""CREATE TABLE public.datasets (
+        id text,
+        name text,
+        slug text,
+        url text,
+        homepage text
+        );""",
+    )
+    with dump.table_data_writer(
+        datasets, ('id', 'name', 'slug', 'url', 'homepage')
+    ) as writer:
+        writer.append(
+            'drugbank-id',
+            'DrugBank',
+            'drugbank',
+            'https://paperswithcode.com/dataset/drugbank',
+            'https://go.drugbank.com',
+        )
+    dump.save(dump_path)
+
+    overlay_payload = _overlay_payload(metrics)
+    overlay_payload['dump_sha256'] = adapter.file_sha256(dump_path)
+    overlay_path = tmp_path / 'overlay.yaml'
+    overlay_path.write_text(
+        yaml.safe_dump(overlay_payload, sort_keys=False), encoding='utf-8'
+    )
+    output_dir = tmp_path / 'data' / 'paperswithcode-drugbank'
+
+    written = adapter.run(
+        adapter.parse_args(
+            [
+                '--dump',
+                str(dump_path),
+                '--overlay',
+                str(overlay_path),
+                '--output-dir',
+                str(output_dir),
+            ]
+        )
+    )
+
+    output_files = list(output_dir.glob('example-org/method-alpha/*.json'))
+    assert written == 1
+    assert len(output_files) == 1
+    record = json.loads(output_files[0].read_text(encoding='utf-8'))
+    assert record['evaluation_results'][0]['score_details'][
+        'score'
+    ] == pytest.approx(0.9949)
+    assert record['source_metadata']['source_organization_url'] == (
+        'https://github.com/paperswithcode'
+    )
+
+    validation = subprocess.run(
+        [
+            sys.executable,
+            '-m',
+            'every_eval_ever',
+            'validate',
+            str(output_files[0]),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert '0 warnings' in validation.stdout
+
+
+def test_cli_requires_local_dump_and_external_manifest(tmp_path) -> None:
+    dump = tmp_path / 'pwc.dump'
+    manifest = tmp_path / 'overlay.yaml'
+    output_dir = tmp_path / 'data' / adapter.COLLECTION_NAME
+    args = adapter.parse_args(
+        [
+            '--dump',
+            str(dump),
+            '--overlay',
+            str(manifest),
+            '--output-dir',
+            str(output_dir),
+        ]
+    )
+    assert args.dump == dump
+    assert args.overlay == manifest
+    assert args.output_dir == output_dir
+
+    default_args = adapter.parse_args(
+        ['--dump', str(dump), '--overlay', str(manifest)]
+    )
+    assert default_args.output_dir == Path(adapter.DEFAULT_OUTPUT_DIR)

--- a/tests/test_paperswithcode_drugbank_adapter.py
+++ b/tests/test_paperswithcode_drugbank_adapter.py
@@ -12,11 +12,13 @@ from pathlib import Path
 import pytest
 import yaml
 
+from every_eval_ever.adapters.paperswithcode import adapter as pwc_adapter
 from every_eval_ever.adapters.paperswithcode_drugbank import adapter
 
 DUMP_SHA = 'a' * 64
 OVERLAY_SHA = 'b' * 64
-REGISTRY_REVISION = 'c' * 40
+REGISTRY_REVISION = pwc_adapter.MetricResolver().registry_revision
+assert REGISTRY_REVISION is not None
 RETRIEVED_TS = '1784160000.0'
 
 
@@ -82,7 +84,7 @@ def _overlay_payload(
                         'source_name': 'AUROC',
                         'metric_id': 'auroc',
                         'metric_name': 'AUROC',
-                        'metric_kind': 'roc_auc',
+                        'metric_kind': 'auroc',
                         'metric_unit': 'proportion',
                         'lower_is_better': False,
                         'min_score': 0.0,

--- a/tests/test_paperswithcode_drugbank_registry_contract.py
+++ b/tests/test_paperswithcode_drugbank_registry_contract.py
@@ -187,10 +187,9 @@ def test_auroc_output_matches_generic_pwc_canonical_contract() -> None:
     )
     [result] = log.evaluation_results
 
-    resolved = RESOLVER.resolve('AUROC', (0.0, 1.0), 'drugbank')
-    generic = pwc_adapter.build_metric_config(
-        'AUROC', resolved, (0.0, 1.0), None
-    )
+    observed = (99.49, 99.49)
+    resolved = RESOLVER.resolve('AUROC', observed, 'drugbank')
+    generic = pwc_adapter.build_metric_config('AUROC', resolved, observed, None)
 
     assert result.metric_config.metric_id == generic.metric_id
     assert result.metric_config.metric_name == generic.metric_name
@@ -203,9 +202,29 @@ def test_auroc_output_matches_generic_pwc_canonical_contract() -> None:
     assert result.metric_config.additional_details['bound_registry_revision'] == (
         REGISTRY_REVISION
     )
+    assert result.metric_config.additional_details['observed_min'] == '99.49'
+    assert result.metric_config.additional_details['observed_max'] == '99.49'
     assert result.score_details.score == pytest.approx(0.9949)
     assert result.score_details.details['reviewed_source_scale'] == 'percent'
     assert result.score_details.details['applied_scale_factor'] == '0.01'
+
+
+def test_observed_range_is_derived_from_source_rows() -> None:
+    overlay = _overlay(source_scale='percent')
+    selected = _row(percent=True)
+    other = dict(selected)
+    other['id'] = 'eval-2'
+    other['metrics'] = json.dumps({'AUROC': '75.0'})
+
+    [log] = adapter.build_logs(
+        [selected, other], _datasets(), overlay, OVERLAY_SHA
+    )
+    [result] = log.evaluation_results
+
+    assert result.metric_config.additional_details['observed_min'] == '75.0'
+    assert result.metric_config.additional_details['observed_max'] == '99.49'
+    assert result.metric_config.min_score == 0.0
+    assert result.metric_config.max_score == 1.0
 
 
 def test_cli_contract_gate_runs_before_dump_access(

--- a/tests/test_paperswithcode_drugbank_registry_contract.py
+++ b/tests/test_paperswithcode_drugbank_registry_contract.py
@@ -1,0 +1,240 @@
+"""Registry-contract regressions for the PwC DrugBank adapter."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+
+import pytest
+import yaml
+
+from every_eval_ever.adapters.paperswithcode import adapter as pwc_adapter
+from every_eval_ever.adapters.paperswithcode_drugbank import adapter
+
+DUMP_SHA = 'a' * 64
+OVERLAY_SHA = 'b' * 64
+RETRIEVED_TS = '1784160000.0'
+RESOLVER = pwc_adapter.MetricResolver()
+REGISTRY_REVISION = RESOLVER.registry_revision
+assert REGISTRY_REVISION is not None
+
+
+def _payload(*, source_scale: str = 'identity') -> dict[str, object]:
+    return {
+        'schema_version': 2,
+        'dump_sha256': DUMP_SHA,
+        'registry_revision': REGISTRY_REVISION,
+        'retrieved_timestamp': RETRIEVED_TS,
+        'entries': [
+            {
+                'pwc_evaluation_id': 'eval-1',
+                'anchors': {
+                    'paper_id': 'paper-1',
+                    'dataset_id': 'drugbank-id',
+                    'task_id': 'ddi-task',
+                    'model_name': 'Method Alpha',
+                    'model_id': 'example-org/method-alpha',
+                    'developer': 'example-org',
+                },
+                'source_metrics_sha256': adapter.source_metrics_sha256(
+                    {'AUROC': '99.49' if source_scale == 'percent' else '0.9949'}
+                ),
+                'qualification': {
+                    'benchmark_id': (
+                        'paperswithcode-drugbank.alpha-study.'
+                        'ddi-event-multiclass.inductive.one-unseen-drug'
+                    ),
+                    'split_id': 'inductive-s2',
+                    'study_id': 'alpha-study',
+                    'protocol_id': 'one-unseen-drug',
+                    'task_id': 'ddi-event-multiclass',
+                    'task_type': 'ddi-event-multiclass',
+                    'candidate_label_space': 'reported-relation-labels',
+                    'drug_entity_overlap': 'one-unseen',
+                    'pair_overlap': 'none',
+                    'relation_class_overlap': 'shared',
+                    'temporal_ordering': 'not-reported',
+                    'negative_sampling': 'paper-defined',
+                    'split_preprocessing': 'paper-defined',
+                },
+                'evidence': {
+                    'source_url': 'https://example.org/paper',
+                    'source_locator': 'Table 1',
+                    'review_note': 'Synthetic registry-contract fixture.',
+                },
+                'metrics': [
+                    {
+                        'source_name': 'AUROC',
+                        'metric_id': 'auroc',
+                        'metric_name': 'AUROC',
+                        'metric_kind': 'auroc',
+                        'metric_unit': 'proportion',
+                        'lower_is_better': False,
+                        'min_score': 0.0,
+                        'max_score': 1.0,
+                        'source_scale': source_scale,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _overlay(*, source_scale: str = 'identity') -> adapter.ProtocolOverlay:
+    return adapter.ProtocolOverlay.model_validate(
+        _payload(source_scale=source_scale)
+    )
+
+
+def _row(*, percent: bool = False) -> dict[str, object]:
+    metrics = {'AUROC': '99.49' if percent else '0.9949'}
+    return {
+        'id': 'eval-1',
+        'paper_id': 'paper-1',
+        'dataset_id': 'drugbank-id',
+        'task_id': 'ddi-task',
+        'model_name': 'Method Alpha',
+        'evaluated_on': '2024-03-25',
+        'metrics': json.dumps(metrics),
+    }
+
+
+def _datasets() -> dict[str, dict[str, object]]:
+    return {
+        'drugbank-id': {
+            'id': 'drugbank-id',
+            'name': 'DrugBank',
+            'slug': 'drugbank',
+            'url': 'https://paperswithcode.com/dataset/drugbank',
+            'homepage': 'https://go.drugbank.com',
+        }
+    }
+
+
+def test_manifest_revision_must_equal_vendored_snapshot() -> None:
+    payload = _payload()
+    payload['registry_revision'] = 'd' * 40
+    overlay = adapter.ProtocolOverlay.model_validate(payload)
+
+    with pytest.raises(ValueError, match='registry_revision does not match'):
+        adapter.validate_registry_contract(overlay)
+
+    with pytest.raises(ValueError, match='registry_revision does not match'):
+        adapter.build_logs([_row()], _datasets(), overlay, OVERLAY_SHA)
+
+
+@pytest.mark.parametrize(
+    ('field_name', 'replacement'),
+    [
+        ('metric_id', 'accuracy'),
+        ('metric_name', 'Area Under ROC'),
+        ('metric_kind', 'roc_auc'),
+        ('metric_unit', 'percent'),
+        ('lower_is_better', True),
+        ('min_score', -1.0),
+        ('max_score', 2.0),
+    ],
+)
+def test_manifest_canonical_fields_are_registry_assertions(
+    field_name: str, replacement: object
+) -> None:
+    payload = _payload()
+    payload['entries'][0]['metrics'][0][field_name] = replacement
+    overlay = adapter.ProtocolOverlay.model_validate(payload)
+
+    with pytest.raises(ValueError, match=rf'mismatch for {field_name}'):
+        adapter.validate_registry_contract(overlay)
+
+
+def test_unknown_source_metric_fails_closed() -> None:
+    payload = _payload()
+    metric = payload['entries'][0]['metrics'][0]
+    metric.update(
+        {
+            'source_name': 'Definitely Not A Registry Metric',
+            'metric_id': 'unknown-metric',
+            'metric_name': 'Definitely Not A Registry Metric',
+            'metric_kind': 'unknown-metric',
+        }
+    )
+    overlay = adapter.ProtocolOverlay.model_validate(payload)
+
+    with pytest.raises(ValueError, match='not resolvable'):
+        adapter.validate_registry_contract(overlay)
+
+
+def test_ambiguous_normalized_source_metric_fails_closed() -> None:
+    payload = _payload()
+    metric = payload['entries'][0]['metrics'][0]
+    metric.update(
+        {
+            'source_name': 'clipiqa',
+            'metric_id': 'clip-iqa',
+            'metric_name': 'clipiqa',
+            'metric_kind': 'clip-iqa',
+        }
+    )
+    overlay = adapter.ProtocolOverlay.model_validate(payload)
+
+    with pytest.raises(ValueError, match='ambiguous_normalized'):
+        adapter.validate_registry_contract(overlay)
+
+
+def test_auroc_output_matches_generic_pwc_canonical_contract() -> None:
+    overlay = _overlay(source_scale='percent')
+    [log] = adapter.build_logs(
+        [_row(percent=True)], _datasets(), overlay, OVERLAY_SHA
+    )
+    [result] = log.evaluation_results
+
+    resolved = RESOLVER.resolve('AUROC', (0.0, 1.0), 'drugbank')
+    generic = pwc_adapter.build_metric_config(
+        'AUROC', resolved, (0.0, 1.0), None
+    )
+
+    assert result.metric_config.metric_id == generic.metric_id
+    assert result.metric_config.metric_name == generic.metric_name
+    assert result.metric_config.metric_kind == generic.metric_kind
+    assert result.metric_config.metric_unit == generic.metric_unit
+    assert result.metric_config.lower_is_better == generic.lower_is_better
+    assert result.metric_config.score_type == generic.score_type
+    assert result.metric_config.min_score == generic.min_score
+    assert result.metric_config.max_score == generic.max_score
+    assert result.metric_config.additional_details['bound_registry_revision'] == (
+        REGISTRY_REVISION
+    )
+    assert result.score_details.score == pytest.approx(0.9949)
+    assert result.score_details.details['reviewed_source_scale'] == 'percent'
+    assert result.score_details.details['applied_scale_factor'] == '0.01'
+
+
+def test_cli_contract_gate_runs_before_dump_access(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = deepcopy(_payload())
+    payload['entries'][0]['metrics'][0]['metric_kind'] = 'roc_auc'
+    overlay_path = tmp_path / 'overlay.yaml'
+    overlay_path.write_text(
+        yaml.safe_dump(payload, sort_keys=False), encoding='utf-8'
+    )
+    dump_path = tmp_path / 'paperswithcode.dump'
+    output_dir = tmp_path / 'data' / adapter.COLLECTION_NAME
+
+    def unexpected_dump_access(_path):
+        raise AssertionError('registry contract must fail before dump access')
+
+    monkeypatch.setattr(adapter, 'file_sha256', unexpected_dump_access)
+
+    with pytest.raises(ValueError, match='mismatch for metric_kind'):
+        adapter.run(
+            adapter.parse_args(
+                [
+                    '--dump',
+                    str(dump_path),
+                    '--overlay',
+                    str(overlay_path),
+                    '--output-dir',
+                    str(output_dir),
+                ]
+            )
+        )


### PR DESCRIPTION
## Summary

This PR adds a manual-only adapter that converts selected DrugBank leaderboard cells from a local Papers With Code custom-format PostgreSQL dump into EEE aggregate evaluation logs.

A reviewed YAML qualification manifest identifies the exact source cells to convert and supplies reviewed model and benchmark identities, source-scale decisions, split and protocol semantics, provenance, and the registry revision used during review. Canonical metric metadata — including metric identity, kind, unit, direction, and canonical bounds — is resolved and checked against the same vendored `eval-card-registry` snapshot used by the general Papers With Code adapter. Observed metric ranges are derived from the source values being converted rather than from the manifest.

The manifest distinguishes `transductive` (both drugs seen), `inductive-s1` (both drugs unseen), and `inductive-s2` (one drug unseen), following the split convention described by the [[DSN-DDI primary source](https://academic.oup.com/bib/article/24/1/bbac597/6966537)](https://academic.oup.com/bib/article/24/1/bbac597/6966537). Scores themselves come from the pinned Papers With Code dump; the manifest supplies source-cell selection and protocol evidence.

## Design and safety

The adapter parses the dump strictly and fails closed on dump-hash drift, missing or ambiguous anchors, malformed scores, incompatible source scales, registry-revision drift, unknown or ambiguous registry metrics, duplicate YAML keys, duplicate metric selections, conflicting benchmark protocols, coercive source IDs, or invalid output paths.

Conversion is atomic: the reviewed selection is treated as one qualified bundle, and no output is published unless the complete bundle passes registry, schema, and path validation.

Aggregate and result identities include the selected metric results, canonical metric configuration, and protocol semantics. Output records include `split_id`, the generalization regime, entity-overlap evidence, and the protocol digest. DrugBank remains the trusted `source_data` value, while the raw Papers With Code URL and archive URL are retained as provenance metadata.

Papers With Code `±` values are preserved without coercing an unspecified dispersion type into a typed standard-error field. When score rescaling applies, the source-reported dispersion and its canonical-scale value remain distinguishable.

## Relationship to the general Papers With Code adapter

The general Papers With Code adapter can emit the same underlying evaluation rows. `pwc_evaluation_id` identifies the shared PwC evaluation row, while an exact source-cell match uses:

`(pwc_evaluation_id, metric_config.metric_name)`

This PR makes that overlap explicit and joinable without attempting to solve global cross-collection deduplication. Broader deduplication policy remains part of #256 rather than expanding the scope of this adapter.

## Scope and follow-up

No production qualification manifest or generated datastore records are included. The adapter remains `runnable=False` because it requires local inputs and has no live fetch path.

The adapter converts the source cells selected by the reviewed manifest; it does not independently verify the cited paper content or reconstruct train/test membership from the aggregate Papers With Code dump, and it does not compute performance deltas between splits.

## Verification

* The GitHub Actions `Tests` workflow passes on the current PR head across Ruff, core/full, and locked/loose configurations.
* Registry-contract tests cover the pinned registry revision, canonical metric parity with the general Papers With Code adapter, fail-closed handling of unknown or ambiguous metrics, and source-derived observed ranges.
* Integration coverage exercises a real `pgdumplib` custom-format dump through the adapter CLI path.
* Source-scale mismatches fail closed instead of being guessed.
* No dependency or lockfile changes are included.