### PR TITLE
Skip a scheduled run when source, schema and adapter are all unchanged

### DIFF
--- a/every_eval_ever/adapters/README.md
+++ b/every_eval_ever/adapters/README.md
@@ -37,6 +37,24 @@ An adapter that automation runs must therefore:
 `bfcl`, `cocoabench` and `sciarena` are registered as `runnable=False`: they need a
 local input file and have no live fetch path.
 
+### Skipping a run whose source has not changed
+
+Many sources go days or weeks without a new result, so re-scraping them produces
+byte-identical records the de-duplication ledger then drops. An adapter can let the
+scheduler skip that work entirely by answering `--emit-source-version`: it prints one
+line naming the current upstream state — a pinned commit, a dump version, a content
+hash — and exits `0` without converting anything. The runner folds that line together
+with the schema version and a digest of the adapter's own package into a *freshness
+token*, and skips the run (green, status `skipped_source_unchanged`) only when all
+three match the last completed run. A change to any one — the source, the schema, or
+the adapter code — forces a real run, as does `--force-full`.
+
+The behaviour is on by default (`skip_if_unchanged=True` in the catalog); an adapter
+that does not implement the flag simply runs every time, as before. Set
+`skip_if_unchanged=False` for an adapter whose source version cannot be reported
+cheaply or reliably. The probe runs in-process for the digest, so an adapter must
+stay importable without side effects and print the version before any network work.
+
 ## Raw source snapshots
 
 [`helpers/raw_capture.py`](../helpers/raw_capture.py) keeps the bytes an adapter

--- a/every_eval_ever/adapters/catalog.py
+++ b/every_eval_ever/adapters/catalog.py
@@ -92,6 +92,14 @@ class AdapterSpec:
     #: an outage is expected, and take it back once the source is stable,
     #: so a real regression goes red again.
     allow_source_outage: bool = False
+    #: Whether a run may be skipped when the adapter reports its upstream
+    #: source, the schema, and its own code are all unchanged since the last
+    #: completed run. On by default: an adapter opts in by answering
+    #: ``--emit-source-version`` with its current source version, and one that
+    #: does not implement the flag simply runs every time as before. Set
+    #: ``False`` to force an adapter to always run, e.g. when its source
+    #: version cannot be reported cheaply or reliably.
+    skip_if_unchanged: bool = True
     notes: str = ''
 
     def __post_init__(self) -> None:

--- a/every_eval_ever/adapters/vectara_hallucination_leaderboard/adapter.py
+++ b/every_eval_ever/adapters/vectara_hallucination_leaderboard/adapter.py
@@ -579,11 +579,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         help="Write the fetched raw source rows to this path.",
     )
+    parser.add_argument(
+        "--emit-source-version",
+        action="store_true",
+        help=(
+            "Print the pinned source commit and exit, so the scheduler can "
+            "skip a run whose source has not changed."
+        ),
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    if args.emit_source_version:
+        # The whole leaderboard is pinned to one commit, so the commit is the
+        # source version. Nothing here fetches, so the scheduler's probe costs
+        # nothing.
+        print(SOURCE_COMMIT)
+        return 0
     retrieved_timestamp = str(time.time())
 
     print("=" * 60)

--- a/every_eval_ever/cron/__main__.py
+++ b/every_eval_ever/cron/__main__.py
@@ -508,6 +508,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             run_date=run_date,
             known_fingerprints=state.known_fingerprints,
             force_full=args.force_full,
+            previous_freshness_token=state.freshness_token,
             run_url=run_url,
         )
         for note in (inflight_note, pending_note):
@@ -629,6 +630,16 @@ def _finish(
 
         state.last_run_date = outcome.run_date.isoformat()
         state.last_status = outcome.status
+        # Remember the token only when the run actually settled the source:
+        # a completed or partial conversion, or a skip that already matched it.
+        # A failure keeps the previous good token, so the next run compares
+        # against the last state that truly published rather than forgetting it.
+        if outcome.freshness_token is not None and outcome.status in (
+            'completed',
+            'partial',
+            'skipped_source_unchanged',
+        ):
+            state.freshness_token = outcome.freshness_token
         # Only advance the snapshot pointer when a snapshot was actually
         # written. Pointing it at a directory holding nothing but a run report
         # would make the next run find no manifest and re-upload everything.
@@ -757,7 +768,10 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument(
         '--force-full',
         action='store_true',
-        help='Publish every record, ignoring the de-duplication ledger.',
+        help=(
+            'Convert and publish everything, ignoring both the freshness '
+            'skip and the de-duplication ledger.'
+        ),
     )
     run_parser.add_argument(
         '--datastore-repo',

--- a/every_eval_ever/cron/runner.py
+++ b/every_eval_ever/cron/runner.py
@@ -18,6 +18,7 @@ a report of what happened; ``store`` and ``submit`` do the rest.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import importlib.util
 import io
 import json
@@ -33,6 +34,7 @@ from typing import Any, Literal
 
 from every_eval_ever.adapters.catalog import ADAPTERS as _ALL_ADAPTERS
 from every_eval_ever.adapters.catalog import AdapterSpec
+from every_eval_ever.converters import SCHEMA_VERSION
 from every_eval_ever.cron.provenance import stamp_cron_provenance
 from every_eval_ever.helpers.raw_capture import CAPTURE_DIR_ENV
 from every_eval_ever.helpers.raw_capture import MANIFEST_NAME as RAW_MANIFEST
@@ -45,8 +47,21 @@ Status = Literal[
     'skipped_missing_credential',
     'skipped_missing_dependency',
     'skipped_source_unavailable',
+    'skipped_source_unchanged',
     'failed',
 ]
+
+#: The flag an adapter answers to report its current upstream source version
+#: instead of converting. A participating adapter prints one line and exits 0;
+#: an adapter that does not implement it exits non-zero, which the runner reads
+#: as "no version" and runs the adapter as usual.
+SOURCE_VERSION_FLAG = '--emit-source-version'
+
+#: How long the source-version probe may take. It should print a constant or
+#: read one revision, so this is a backstop against an adapter that does real
+#: work on the flag rather than a budget; a probe that overruns it is treated
+#: as no version and the adapter runs.
+PROBE_TIMEOUT_SECONDS = 120
 
 #: The exit code (``EX_TEMPFAIL``) an adapter uses to say its upstream
 #: source is down, as opposed to crashing on it. Honoured only when the
@@ -171,6 +186,10 @@ class RunOutcome:
     skipped_unchanged: list[StagedRecord] = field(default_factory=list)
     coverage: dict[str, Any] | None = None
     messages: list[str] = field(default_factory=list)
+    #: The freshness token this run computed, or ``None`` if the adapter could
+    #: not report a source version. The caller persists it after a completed
+    #: or partial run so the next run has something to compare against.
+    freshness_token: str | None = None
 
     #: Statuses that make the scheduled job red. A missing credential is one
     #: of them: an adapter is only in today's matrix because the catalog says
@@ -365,6 +384,93 @@ def _as_text(value: str | bytes | None) -> str:
     if isinstance(value, bytes):
         return value.decode('utf-8', errors='replace')
     return value
+
+
+def adapter_code_digest(spec: AdapterSpec) -> str | None:
+    """Return a hex digest of the adapter package's own source.
+
+    Covers every ``.py`` the package ships, not just ``adapter.py``, so a
+    change in a helper the adapter imports counts too. It does not reach the
+    shared converters the adapter calls into; the schema half of the token
+    covers a schema change, and a maintainer touching shared code can force a
+    full refresh once. Returns ``None`` when the package cannot be located,
+    which the caller treats as no token, i.e. run.
+    """
+    try:
+        found = importlib.util.find_spec(spec.module)
+    except (ImportError, ValueError):
+        return None
+    if found is None or not found.origin:
+        return None
+    package_dir = Path(found.origin).parent
+    digest = hashlib.sha256()
+    for path in sorted(package_dir.rglob('*.py')):
+        digest.update(path.relative_to(package_dir).as_posix().encode('utf-8'))
+        digest.update(b'\0')
+        digest.update(path.read_bytes())
+        digest.update(b'\0')
+    return digest.hexdigest()
+
+
+def probe_source_version(
+    spec: AdapterSpec,
+    *,
+    raw_dir: Path,
+    base_env: dict[str, str] | None = None,
+    cwd: Path | None = None,
+    executable: str | None = None,
+) -> str | None:
+    """Ask the adapter for its current source version, or ``None``.
+
+    Runs the adapter with :data:`SOURCE_VERSION_FLAG`, which a participating
+    adapter answers by printing one line and exiting 0 without converting. An
+    adapter that does not implement the flag exits non-zero, and that, a
+    timeout, or empty output all read as "no version": the run then proceeds
+    exactly as it would without the feature.
+    """
+    argv = [
+        executable or sys.executable,
+        '-m',
+        spec.module,
+        SOURCE_VERSION_FLAG,
+    ]
+    try:
+        completed = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            encoding='utf-8',
+            errors='replace',
+            timeout=min(spec.timeout_minutes * 60, PROBE_TIMEOUT_SECONDS),
+            cwd=None if cwd is None else str(cwd),
+            env=adapter_environment(spec, raw_dir=raw_dir, base_env=base_env),
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if completed.returncode != 0:
+        return None
+    lines = [
+        line.strip() for line in completed.stdout.splitlines() if line.strip()
+    ]
+    return lines[-1] if lines else None
+
+
+def freshness_token(
+    source_version: str | None, spec: AdapterSpec
+) -> str | None:
+    """Fold the source version, schema, and adapter code into one token.
+
+    All three must be unchanged for a run to be skipped, so any one of them
+    moving produces a different token and forces a run. Returns ``None`` when
+    the source version is unknown or the adapter code cannot be digested, so an
+    adapter that cannot be pinned to a version is never skipped.
+    """
+    if source_version is None:
+        return None
+    code = adapter_code_digest(spec)
+    if code is None:
+        return None
+    return f'source={source_version}|schema={SCHEMA_VERSION}|adapter={code}'
 
 
 def discover_records(
@@ -705,6 +811,7 @@ def run(
     run_date: date,
     known_fingerprints: set[str] | None = None,
     force_full: bool = False,
+    previous_freshness_token: str | None = None,
     run_url: str | None = None,
     base_env: dict[str, str] | None = None,
     cwd: Path | None = None,
@@ -754,6 +861,32 @@ def run(
             f'not run: install {", ".join(unavailable)} to run this adapter'
         )
         return outcome
+
+    if spec.skip_if_unchanged:
+        # Ask the source what it is before scraping it. The token is computed
+        # even when this run will not skip (a cold start, or --force-full), so
+        # the next run has the current value to compare against.
+        source_version = probe_source_version(
+            spec,
+            raw_dir=raw_dir,
+            base_env=env,
+            cwd=cwd,
+            executable=executable,
+        )
+        outcome.freshness_token = freshness_token(source_version, spec)
+        if (
+            not force_full
+            and previous_freshness_token is not None
+            and outcome.freshness_token is not None
+            and outcome.freshness_token == previous_freshness_token
+        ):
+            outcome.status = 'skipped_source_unchanged'
+            outcome.messages.append(
+                'not run: upstream source, schema and adapter are all '
+                f'unchanged since the last run (source {source_version!r}). '
+                'Pass --force-full to convert anyway.'
+            )
+            return outcome
 
     outcome.process = run_adapter(
         spec,

--- a/every_eval_ever/cron/store.py
+++ b/every_eval_ever/cron/store.py
@@ -105,6 +105,12 @@ class AdapterState:
     #: from :attr:`last_raw_date`, since a date no longer names one directory.
     last_raw_prefix: str | None = None
     last_status: str | None = None
+    #: The freshness token the last completed run computed: source version,
+    #: schema version, and adapter code folded together. The next run skips
+    #: only when it recomputes exactly this, so a change in any of the three
+    #: forces a real run. ``None`` until an adapter that reports a source
+    #: version has completed once.
+    freshness_token: str | None = None
     #: Records that were merged into the datastore. Kept forever.
     fingerprints: set[str] = field(default_factory=set)
     #: Records committed to :attr:`pull_request_number` but not merged yet.
@@ -129,6 +135,7 @@ class AdapterState:
                     'last_raw_date': self.last_raw_date,
                     'last_raw_prefix': self.last_raw_prefix,
                     'last_status': self.last_status,
+                    'freshness_token': self.freshness_token,
                     'fingerprint_count': len(self.fingerprints),
                     'pending_fingerprint_count': len(self.pending_fingerprints),
                 },
@@ -423,6 +430,7 @@ class RawStore:
                     f'{RAW_DIR}/{adapter}/{state.last_raw_date}'
                 )
             state.last_status = payload.get('last_status')
+            state.freshness_token = payload.get('freshness_token')
 
         ledger = self._download_text(fingerprints_path(adapter))
         if ledger is not None:

--- a/tests/test_cron_runner.py
+++ b/tests/test_cron_runner.py
@@ -53,12 +53,22 @@ BEHAVIOUR = json.loads((HERE / 'behaviour.json').read_text('utf-8'))
 
 def parse_args(argv=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('--output-dir', type=Path, required=True)
+    parser.add_argument('--output-dir', type=Path)
+    parser.add_argument('--emit-source-version', action='store_true')
     return parser.parse_args(argv)
 
 
 def main(argv=None):
     args = parse_args(argv)
+    if args.emit_source_version:
+        # A test that set a source_version answers the probe with it; one that
+        # did not stands in for an adapter that cannot report a version, which
+        # the runner reads from the non-zero exit.
+        version = BEHAVIOUR.get('source_version')
+        if version is None:
+            return 2
+        print(version)
+        return 0
     staging = args.output_dir.parent.parent
     for capture in BEHAVIOUR.get('captures', []):
         from every_eval_ever.helpers import raw_capture
@@ -187,6 +197,10 @@ def pipeline(tmp_path, monkeypatch):
     (package / 'adapter.py').write_text(
         textwrap.dedent(STAND_IN), encoding='utf-8'
     )
+    # The runner digests the adapter's own source in-process for the freshness
+    # token, so the stand-in has to be importable here as a real adapter would
+    # be, not only in the subprocess it hands PYTHONPATH.
+    monkeypatch.syspath_prepend(str(tmp_path))
     runs = 0
 
     def go(files, *, run_kwargs=None, env=None, spec_kwargs=None, **behaviour):
@@ -579,6 +593,127 @@ def test_force_full_republishes_a_known_record(pipeline) -> None:
     assert len(outcome.uploaded) == 1
     assert outcome.skipped_unchanged == []
     assert any('bypassed' in message for message in outcome.messages)
+
+
+# --- freshness skip ------------------------------------------------------
+
+
+def test_an_unchanged_source_skips_the_run_without_converting(pipeline) -> None:
+    record = record_without_samples()
+    files = {f'demo-org/demo-model/{UUID_A}.json': record}
+
+    first = pipeline(files, source_version='v1')
+    assert first.status == 'completed'
+    assert first.freshness_token is not None
+
+    second = pipeline(
+        files,
+        source_version='v1',
+        run_kwargs={'previous_freshness_token': first.freshness_token},
+    )
+
+    assert second.status == 'skipped_source_unchanged'
+    assert second.ok  # a green day, not a failure
+    assert second.uploaded == []
+    assert second.records == []  # the adapter never ran
+    assert not list(second.upload_dir.rglob('*.json'))
+    assert any('unchanged' in message for message in second.messages)
+
+
+def test_a_changed_source_is_not_skipped(pipeline) -> None:
+    record = record_without_samples()
+    files = {f'demo-org/demo-model/{UUID_A}.json': record}
+
+    first = pipeline(files, source_version='v1')
+    second = pipeline(
+        files,
+        source_version='v2',
+        run_kwargs={'previous_freshness_token': first.freshness_token},
+    )
+
+    assert second.status == 'completed'
+    assert second.freshness_token != first.freshness_token
+    assert len(second.uploaded) == 1
+
+
+def test_force_full_converts_even_when_the_source_is_unchanged(
+    pipeline,
+) -> None:
+    record = record_without_samples()
+    files = {f'demo-org/demo-model/{UUID_A}.json': record}
+
+    first = pipeline(files, source_version='v1')
+    second = pipeline(
+        files,
+        source_version='v1',
+        run_kwargs={
+            'previous_freshness_token': first.freshness_token,
+            'force_full': True,
+        },
+    )
+
+    assert second.status == 'completed'
+    assert len(second.uploaded) == 1
+
+
+def test_an_adapter_that_reports_no_version_is_never_skipped(pipeline) -> None:
+    record = record_without_samples()
+    files = {f'demo-org/demo-model/{UUID_A}.json': record}
+
+    # No source_version: the stand-in exits non-zero on the probe, so the run
+    # cannot be pinned and must go ahead even against a stored token.
+    outcome = pipeline(
+        files,
+        run_kwargs={'previous_freshness_token': 'source=whatever|x'},
+    )
+
+    assert outcome.status == 'completed'
+    assert outcome.freshness_token is None
+    assert len(outcome.uploaded) == 1
+
+
+def test_disabling_skip_if_unchanged_always_runs(pipeline) -> None:
+    record = record_without_samples()
+    files = {f'demo-org/demo-model/{UUID_A}.json': record}
+
+    first = pipeline(files, source_version='v1')
+    second = pipeline(
+        files,
+        source_version='v1',
+        spec_kwargs={'skip_if_unchanged': False},
+        run_kwargs={'previous_freshness_token': first.freshness_token},
+    )
+
+    assert second.status == 'completed'
+    # The probe is not even attempted when the catalog turns the feature off.
+    assert second.freshness_token is None
+    assert len(second.uploaded) == 1
+
+
+def test_the_adapter_code_is_part_of_the_token(tmp_path) -> None:
+    package = tmp_path / 'digest_pkg'
+    package.mkdir()
+    (package / '__init__.py').write_text('', encoding='utf-8')
+    (package / 'adapter.py').write_text('VERSION = 1\n', encoding='utf-8')
+    spec = AdapterSpec(
+        key='digest',
+        module='digest_pkg.adapter',
+        collections=(COLLECTION,),
+    )
+
+    import sys as _sys
+
+    _sys.path.insert(0, str(tmp_path))
+    try:
+        before = runner.freshness_token('v1', spec)
+        (package / 'adapter.py').write_text('VERSION = 2\n', encoding='utf-8')
+        # find_spec caches nothing here; the digest reads the file fresh.
+        after = runner.freshness_token('v1', spec)
+    finally:
+        _sys.path.remove(str(tmp_path))
+
+    assert before is not None and after is not None
+    assert before != after  # same source version, changed adapter code
 
 
 # --- refusals ------------------------------------------------------------

--- a/tests/test_cron_store_and_submit.py
+++ b/tests/test_cron_store_and_submit.py
@@ -328,6 +328,7 @@ def test_state_round_trips_through_the_store() -> None:
         last_raw_date='2026-08-09',
         last_raw_prefix='raw/hle/2026-08-09/run-1-1',
         last_status='completed',
+        freshness_token='source=abc123|schema=0.3.0|adapter=deadbeef',
         fingerprints={'bbb', 'aaa'},
         pending_fingerprints={'ccc'},
     )
@@ -342,6 +343,9 @@ def test_state_round_trips_through_the_store() -> None:
     assert reloaded.exists
     assert reloaded.pull_request_number == 7
     assert reloaded.last_status == 'completed'
+    assert reloaded.freshness_token == (
+        'source=abc123|schema=0.3.0|adapter=deadbeef'
+    )
     assert reloaded.last_raw_prefix == 'raw/hle/2026-08-09/run-1-1'
     assert reloaded.fingerprints == {'aaa', 'bbb'}
     # Pending fingerprints survive apart from the durable ones, because the

--- a/tests/test_vectara_hallucination_leaderboard_adapter.py
+++ b/tests/test_vectara_hallucination_leaderboard_adapter.py
@@ -162,6 +162,15 @@ def test_unbounded_length_metric_declares_infinite_upper_bound(
     )
 
 
+def test_emit_source_version_prints_the_pinned_commit(capsys):
+    exit_code = adapter.main(['--emit-source-version'])
+
+    assert exit_code == 0
+    # One line, the pinned commit, nothing fetched — this is what the
+    # scheduler compares to decide whether a run can be skipped.
+    assert capsys.readouterr().out.strip() == adapter.SOURCE_COMMIT
+
+
 def test_private_corpus_is_distinguished_from_public_result_files(
     source_rows, tmp_path: Path
 ):


### PR DESCRIPTION
## What

Lets the daily ingestion runner skip an adapter whose upstream source has not
changed since the last completed run, instead of re-scraping it to produce
byte-identical records the de-duplication ledger then drops.

An adapter opts in by answering a new `--emit-source-version` flag: it prints
one line naming its current upstream state — a pinned commit, a dump version, a
content hash — and exits `0` without converting. The runner folds that line
together with the schema version and a digest of the adapter's own package into
a **freshness token**, and skips the run (green, status
`skipped_source_unchanged`) only when all three match the token stored from the
last completed run. A change to the source, the schema, or the adapter code, or
`--force-full`, forces a real run.

## Design

- **On by default** (`skip_if_unchanged=True` in the catalog). An adapter that
  does not implement `--emit-source-version` reports no version, so it is never
  skipped and runs exactly as before. `skip_if_unchanged=False` forces an
  adapter to always run.
- **Three components, all must match.** The token is
  `source=<probe>|schema=<SCHEMA_VERSION>|adapter=<sha256 of package .py files>`.
  The adapter digest covers the package's own source (not the shared converters);
  a schema bump or a shared-code change that should invalidate everything is a
  one-time `--force-full`.
- **Never skip-forever.** A probe error, timeout, empty output, missing stored
  token, or `--force-full` all fall through to a real run. The token is only
  *stored* after a `completed`/`partial` run (or a matching skip), so a failed
  run keeps the last good token rather than pinning a broken state.
- The probe reuses the runner's existing subprocess/env machinery and runs
  in-process for the digest, so a participating adapter must stay importable
  without side effects and print the version before any network work.

## Rollout

Wired into the **vectara_hallucination_leaderboard** adapter first: it is pinned
to a `SOURCE_COMMIT`, so the commit *is* its source version and the probe costs
no network. Other adapters can adopt the flag incrementally (HF-sha adapters,
etc.); until they do, they run unchanged.

## Tests

- `tests/test_cron_runner.py` — unchanged source skips without converting;
  changed source runs; `--force-full` overrides; an adapter reporting no version
  is never skipped; `skip_if_unchanged=False` always runs; the adapter code is
  part of the token.
- `tests/test_cron_store_and_submit.py` — `freshness_token` round-trips through
  the state store.
- `tests/test_vectara_hallucination_leaderboard_adapter.py` — the probe prints
  the pinned commit and exits 0.

Full suite green (766 passed, 20 skipped); ruff clean.