### PR TITLE
Retry a commit the Hub refused while another adapter job held the lock

### DIFF
--- a/every_eval_ever/cron/README.md
+++ b/every_eval_ever/cron/README.md
@@ -178,8 +178,17 @@ a run are per run. `state/<adapter>.json` carries `last_raw_prefix`, the whole
 path, since a date no longer names one directory.
 
 A run makes two commits here, one either side of publishing to the datastore,
-each guarded by the commit the previous one left, so two overlapping runs
-collide loudly instead of one silently overwriting the other.
+each guarded by the commit the previous one left, so two overlapping runs of
+one adapter collide loudly instead of one silently overwriting the other.
+
+Adapters of one matrix racing each other is a different thing, and ordinary:
+every job commits to this branch and to the datastore's, and the Hub takes one
+commit per repository at a time. A refused commit is retried with backoff —
+rebased onto the new head when the head moved, and after a wait when the head
+had not moved because the winning commit was still in flight. A datastore
+batch is retried only where the datastore's own file listing proves it absent,
+so a retry cannot publish a second copy. Anything that is not a lost race
+fails the job immediately.
 
 The first carries the raw snapshot and `state/<adapter>.inflight`: the
 fingerprint and datastore paths of every record this run is about to publish.

--- a/every_eval_ever/cron/store.py
+++ b/every_eval_ever/cron/store.py
@@ -51,6 +51,9 @@ changes a repository's visibility.
 from __future__ import annotations
 
 import json
+import random
+import re
+import time
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
@@ -67,9 +70,70 @@ MANIFEST_NAME = 'manifest.jsonl'
 RUN_REPORT_NAME = 'run.json'
 #: Payloads identical to the previous run are referenced, not re-uploaded.
 UNCHANGED_MARKER = 'same_as'
-#: How many times a state commit re-reads the head and tries again when
-#: another adapter's job moved the branch first.
-COMMIT_ATTEMPTS = 5
+#: How many times a commit is attempted before the race is called a failure.
+#: A daily matrix runs several adapter jobs at once and every one of them
+#: commits to the same branch, so losing the race is ordinary rather than
+#: exceptional.
+COMMIT_ATTEMPTS = 8
+#: Backoff between commit attempts. The Hub holds a per-repository commit
+#: lock for the length of one commit, so the wait needed is seconds, and the
+#: jitter matters more than the ceiling: four jobs that back off in lockstep
+#: collide again on every attempt.
+COMMIT_RETRY_BASE_SECONDS = 1.0
+COMMIT_RETRY_MAX_SECONDS = 30.0
+#: Statuses the Hub refuses a commit with when it lost a race: 412 when the
+#: parent sent is no longer the head, 409 while another commit to the same
+#: repository is still in flight.
+_CONFLICT_STATUSES = frozenset({409, 412})
+#: The sentence the Hub returns with a 409 when another commit to the same
+#: repository is still in flight.
+_COMMIT_IN_PROGRESS = 'commit operation is in progress'
+#: Hub errors lead with the status, which is how a conflict is recognised
+#: when the exception carries no response to read it from.
+_STATUS_PREFIX = re.compile(r'\s*(409|412)\b')
+
+
+def is_commit_conflict(exc: BaseException) -> bool:
+    """Return whether the Hub refused this commit because of a race.
+
+    A race resolves two ways and each has its own status. The branch head
+    moved under us (412), answered by rebasing onto the new head; or another
+    commit to the same repository is still in flight (409), answered by
+    waiting, since the Hub serialises commits per repository and rejects the
+    loser before the head has moved at all. Both are retryable, and anything
+    else — a permission or transport error — is not.
+    """
+    status = getattr(getattr(exc, 'response', None), 'status_code', None)
+    if status in _CONFLICT_STATUSES:
+        return True
+    text = str(exc)
+    if _COMMIT_IN_PROGRESS in text.lower():
+        return True
+    return _STATUS_PREFIX.match(text) is not None
+
+
+def commit_retry_delay(attempt: int) -> float:
+    """Return the seconds to wait before retry ``attempt`` (1 is the first).
+
+    Exponential with full-width jitter over the top half of each window, so
+    concurrent jobs separate instead of retrying together.
+    """
+    window = min(
+        COMMIT_RETRY_BASE_SECONDS * 2 ** (attempt - 1),
+        COMMIT_RETRY_MAX_SECONDS,
+    )
+    return random.uniform(window / 2, window)
+
+
+def wait_before_retry(attempt: int) -> None:
+    """Wait out the backoff window before commit retry ``attempt``.
+
+    The one place either commit path sleeps, so a test replaces this rather
+    than the clock.
+    """
+    time.sleep(commit_retry_delay(attempt))
+
+
 #: :attr:`InflightBatch.destination` for records committed straight to the
 #: datastore's default branch.
 DIRECT_DESTINATION = 'datastore'
@@ -504,12 +568,19 @@ class RawStore:
         records with no fingerprints, so the next run would publish them
         again under fresh paths.
 
+        A race resolves one of two ways, and both are retried here. The head
+        moved, in which case the next attempt rebases onto it; or the Hub's
+        per-repository commit lock was held by a commit still in flight, in
+        which case the head has not moved yet and the next attempt waits and
+        keeps the same parent. An unmoved head is therefore not evidence
+        against a race.
+
         Retrying is safe rather than a lost update because a job only ever
         writes files it owns: ``state/<adapter>.*`` and this adapter's raw
         snapshot directory. The workflow's per-adapter concurrency group is
         what guarantees no second job is writing the same ones. A failure
-        that is not a moved head is re-raised untouched, so a permission or
-        transport error still fails the job.
+        that is not a conflict is re-raised untouched, so a permission or
+        transport error still fails the job immediately.
 
         Visibility is confirmed here rather than trusted from startup, because
         the adapter has been running in between and a repository's visibility
@@ -519,7 +590,7 @@ class RawStore:
             return None
         self._require_private()
         parent = parent_commit
-        for remaining in reversed(range(COMMIT_ATTEMPTS)):
+        for attempt in range(1, COMMIT_ATTEMPTS + 1):
             try:
                 return self.api.create_commit(
                     repo_id=self.repo_id,
@@ -530,20 +601,24 @@ class RawStore:
                     parent_commit=parent,
                 )
             except Exception as exc:  # noqa: BLE001 - re-raised with context
-                moved = self._moved_head(parent) if remaining else None
-                if moved is None:
+                last = attempt == COMMIT_ATTEMPTS
+                if last or not is_commit_conflict(exc):
                     raise StoreError(
                         f'could not write to {self.repo_id}: '
                         f'{type(exc).__name__}: {exc}'
                     ) from exc
-                parent = moved
+                moved = self._moved_head(parent)
+                if moved is not None:
+                    parent = moved
+                wait_before_retry(attempt)
         return None
 
     def _moved_head(self, parent: str | None) -> str | None:
         """Return the branch head if it moved under us, else ``None``.
 
-        A commit that was rejected while the head is exactly where we left it
-        was not a race, so there is nothing to retry against.
+        ``None`` also covers a head that could not be read and a commit sent
+        without a parent, so the caller keeps the parent it has rather than
+        treating an unanswered question as a moved branch.
         """
         if parent is None:
             return None
@@ -678,6 +753,8 @@ def state_operations(state: AdapterState) -> list[CommitOperationAdd]:
 
 __all__ = [
     'COMMIT_ATTEMPTS',
+    'COMMIT_RETRY_BASE_SECONDS',
+    'COMMIT_RETRY_MAX_SECONDS',
     'DEFAULT_RAW_REPO',
     'DIRECT_DESTINATION',
     'MANIFEST_NAME',
@@ -689,13 +766,16 @@ __all__ = [
     'InflightBatch',
     'RawStore',
     'StoreError',
+    'commit_retry_delay',
     'fingerprints_path',
     'inflight_operation',
     'inflight_path',
+    'is_commit_conflict',
     'pending_fingerprints_path',
     'plan_raw_upload',
     'raw_prefix',
     'run_report_operation',
     'state_operations',
     'state_path',
+    'wait_before_retry',
 ]

--- a/every_eval_ever/cron/submit.py
+++ b/every_eval_ever/cron/submit.py
@@ -22,6 +22,10 @@ from typing import Any, Sequence
 
 from huggingface_hub import CommitOperationAdd
 
+# Imported as a module, not by name: the retry helpers are replaced in tests
+# and both commit paths have to see the replacement.
+from every_eval_ever.cron import store
+
 DEFAULT_DATASTORE_REPO = 'evaleval/EEE_datastore'
 #: Machine-readable line the retired flow wrote into a pull request body to
 #: identify its adapter. Still how a leftover pull request is recognised.
@@ -238,7 +242,9 @@ class DatastoreSubmitter:
 
         A commit that errored after the Hub accepted it is adopted rather
         than repeated: the datastore's file listing arbitrates, and a batch
-        proven present counts as committed and the upload carries on.
+        proven present counts as committed and the upload carries on. A batch
+        the same listing proves absent, rejected because another adapter job
+        held the Hub's commit lock, is retried after a backoff.
 
         A failure after something landed raises
         :class:`PartialSubmissionError` carrying what did, so the caller can
@@ -249,45 +255,60 @@ class DatastoreSubmitter:
         total = len(batches)
         for index, batch in enumerate(batches, start=1):
             suffix = f' ({index}/{total})' if total > 1 else ''
-            try:
-                self.api.create_commit(
-                    repo_id=self.repo_id,
-                    repo_type='dataset',
-                    operations=list(batch),
-                    commit_message=f'{message}{suffix}',
-                    commit_description=description,
-                )
-            except Exception as exc:  # noqa: BLE001 - re-raised with context
-                landed = self._landed_anyway(batch)
-                if landed:
-                    # The Hub accepted the commit and only the reply was
-                    # lost, so this batch is in the datastore and the upload
-                    # carries on. Stopping here instead would end a run
-                    # whose every batch landed as a failure nothing retries,
-                    # because its records are all accounted for.
-                    committed.extend(landed)
-                    continue
-                unresolved: list[str] = []
-                if landed is None:
-                    unresolved = [
-                        operation.path_in_repo for operation in batch
-                    ]
-                    hint = (
-                        ' Whether the failing batch landed could not be '
-                        'checked either; if the error was a timeout whose '
-                        'commit went through, a retry would duplicate its '
-                        f'records, so inspect {self.repo_url} before '
-                        're-running.'
+            for attempt in range(1, store.COMMIT_ATTEMPTS + 1):
+                try:
+                    self.api.create_commit(
+                        repo_id=self.repo_id,
+                        repo_type='dataset',
+                        operations=list(batch),
+                        commit_message=f'{message}{suffix}',
+                        commit_description=description,
                     )
-                else:
-                    hint = ''
-                raise PartialSubmissionError(
-                    f'could not commit records to {self.repo_id}: '
-                    f'{type(exc).__name__}: {exc}.{hint}',
-                    committed_paths=committed,
-                    unresolved_paths=unresolved,
-                ) from exc
-            committed.extend(operation.path_in_repo for operation in batch)
+                except Exception as exc:  # noqa: BLE001 - re-raised w/ context
+                    landed = self._landed_anyway(batch)
+                    if landed:
+                        # The Hub accepted the commit and only the reply was
+                        # lost, so this batch is in the datastore and the
+                        # upload carries on. Stopping here instead would end
+                        # a run whose every batch landed as a failure nothing
+                        # retries, because its records are all accounted for.
+                        committed.extend(landed)
+                        break
+                    if (
+                        landed is not None
+                        and attempt < store.COMMIT_ATTEMPTS
+                        and store.is_commit_conflict(exc)
+                    ):
+                        # Every adapter job of a matrix publishes to this one
+                        # branch, so the Hub's per-repository commit lock is
+                        # contended. Retried only where the datastore proved
+                        # the batch absent, so a retry cannot duplicate it.
+                        store.wait_before_retry(attempt)
+                        continue
+                    unresolved: list[str] = []
+                    if landed is None:
+                        unresolved = [
+                            operation.path_in_repo for operation in batch
+                        ]
+                        hint = (
+                            ' Whether the failing batch landed could not be '
+                            'checked either; if the error was a timeout whose '
+                            'commit went through, a retry would duplicate its '
+                            f'records, so inspect {self.repo_url} before '
+                            're-running.'
+                        )
+                    else:
+                        hint = ''
+                    raise PartialSubmissionError(
+                        f'could not commit records to {self.repo_id}: '
+                        f'{type(exc).__name__}: {exc}.{hint}',
+                        committed_paths=committed,
+                        unresolved_paths=unresolved,
+                    ) from exc
+                committed.extend(
+                    operation.path_in_repo for operation in batch
+                )
+                break
         return Submission(committed_paths=tuple(committed))
 
     def _landed_anyway(

--- a/tests/test_cron_store_and_submit.py
+++ b/tests/test_cron_store_and_submit.py
@@ -35,6 +35,34 @@ def _repo_not_found(repo_id: object) -> RepositoryNotFoundError:
     )
     return RepositoryNotFoundError(f'{repo_id} not found', response=response)
 
+@pytest.fixture(autouse=True)
+def retry_waits(monkeypatch) -> list[int]:
+    """Record the commit backoff instead of waiting it out.
+
+    Every commit path here retries a lost race, so without this the module
+    spends the real backoff — a minute per test that exhausts its attempts.
+    Tests that care assert on the recorded attempt numbers.
+    """
+    waits: list[int] = []
+    monkeypatch.setattr(store, 'wait_before_retry', waits.append)
+    return waits
+
+
+def _conflict(status: int, message: str) -> Exception:
+    """Build the Hub's refusal of a commit that lost a race.
+
+    ``huggingface_hub>=1.0`` attaches the httpx response its errors came
+    from, and the status on it is what distinguishes a moved head from a
+    held commit lock.
+    """
+    response = httpx.Response(
+        status, request=httpx.Request('POST', 'https://huggingface.co')
+    )
+    error = RuntimeError(message)
+    error.response = response
+    return error
+
+
 RUN_DATE = date(2026, 8, 10)
 YESTERDAY = date(2026, 8, 9)
 #: Where today's snapshot goes, and where yesterday's went. Both carry a run
@@ -638,7 +666,9 @@ def test_two_adapters_from_one_head_both_record_their_state() -> None:
     assert hub.files['state/mt_bench.fingerprints'].split() == ['b']
 
 
-def test_a_rejected_commit_that_is_not_a_race_still_fails() -> None:
+def test_a_rejected_commit_that_is_not_a_race_still_fails(
+    retry_waits,
+) -> None:
     """A permission or transport error must not be retried into silence."""
     hub = FakeHub(sha='headsha')
     raw_store = store.RawStore(hub)
@@ -651,6 +681,81 @@ def test_a_rejected_commit_that_is_not_a_race_still_fails() -> None:
             message='hle',
             parent_commit=state.parent_commit,
         )
+
+    assert retry_waits == []
+
+
+def test_a_held_commit_lock_is_waited_out_not_reported(retry_waits) -> None:
+    """The head has not moved, and it is still a race.
+
+    Four adapter jobs of one matrix commit to this branch at once and the Hub
+    serialises them, so the losers are refused with 409 before the winner's
+    commit has moved the head at all. Reading an unmoved head as evidence
+    against a race fails the job for the one reason a retry would fix.
+    """
+    hub = FakeHub(sha='headsha')
+    raw_store = store.RawStore(hub)
+    state = raw_store.read_state('hle')
+    state.fingerprints.add('a')
+    held = _conflict(
+        409,
+        '409 Client Error: Conflict for url: .../commit/main\n\nAnother '
+        'commit operation is in progress for this repository. Please try '
+        'again later.',
+    )
+    attempts: list[dict] = []
+    real_create_commit = hub.create_commit
+
+    def hold_the_lock_once(**kwargs):
+        attempts.append(kwargs)
+        if len(attempts) == 1:
+            raise held
+        return real_create_commit(**kwargs)
+
+    hub.create_commit = hold_the_lock_once
+
+    raw_store.commit(
+        store.state_operations(state),
+        message='hle',
+        parent_commit=state.parent_commit,
+    )
+
+    assert hub.files['state/hle.fingerprints'].split() == ['a']
+    assert retry_waits == [1], 'one wait, before the second attempt'
+
+
+def test_a_lock_that_never_clears_fails_after_its_attempts(
+    retry_waits,
+) -> None:
+    """A retry budget, so a permanently locked repository is still reported."""
+    hub = FakeHub(sha='headsha')
+    raw_store = store.RawStore(hub)
+    state = raw_store.read_state('hle')
+    hub.commit_error = _conflict(409, '409 Client Error: Conflict')
+
+    with pytest.raises(store.StoreError, match='could not write'):
+        raw_store.commit(
+            store.state_operations(state),
+            message='hle',
+            parent_commit=state.parent_commit,
+        )
+
+    assert retry_waits == list(range(1, store.COMMIT_ATTEMPTS))
+
+
+def test_the_backoff_grows_and_separates_concurrent_jobs() -> None:
+    """Lockstep retries collide again; each window is entered at random."""
+    windows = [
+        {store.commit_retry_delay(attempt) for _ in range(50)}
+        for attempt in (1, 2, 3)
+    ]
+
+    assert all(len(window) > 1 for window in windows), 'no jitter'
+    assert max(windows[0]) <= min(windows[1])
+    assert max(windows[1]) <= min(windows[2])
+    assert (
+        store.commit_retry_delay(99) <= store.COMMIT_RETRY_MAX_SECONDS
+    ), 'the window has a ceiling'
 
 
 def test_a_reference_survives_a_run_of_unchanged_days(tmp_path) -> None:
@@ -1157,6 +1262,68 @@ def test_an_unanswerable_batch_is_reported_as_unresolved(tmp_path) -> None:
         'inspect https://huggingface.co/datasets/evaleval/EEE_datastore '
         'before re-running'
     ) in str(caught.value)
+
+
+def test_a_contended_datastore_commit_is_retried_not_torn(
+    tmp_path, retry_waits
+) -> None:
+    """The dangerous half of the same race: a lock conflict mid-publication.
+
+    Adapter jobs publish to one branch, so the Hub refuses the losers here
+    too. Reporting it as a partial submission strands the run between the
+    snapshot commit and the ledger commit, which is the one state a re-run
+    cannot reason about cheaply.
+    """
+    tree = _upload_tree(tmp_path, 7)
+    hub = FakeHub()
+    sub = submit.DatastoreSubmitter(hub, batch_size=3)
+
+    real_create_commit = hub.create_commit
+    refusals: list[int] = []
+
+    def hold_the_lock_on_the_second_batch(**kwargs):
+        if len(hub.commits) == 1 and len(refusals) < 2:
+            refusals.append(1)
+            raise _conflict(409, '409 Client Error: Conflict')
+        return real_create_commit(**kwargs)
+
+    hub.create_commit = hold_the_lock_on_the_second_batch
+
+    result = sub.publish(
+        operations=submit.upload_operations(tree),
+        description='body',
+        message='hle 2026-08-10',
+    )
+
+    assert len(result.committed_paths) == 7
+    assert len(set(result.committed_paths)) == 7, 'no batch published twice'
+    assert retry_waits == [1, 2]
+
+
+def test_a_conflict_the_datastore_cannot_arbitrate_is_not_retried(
+    tmp_path, retry_waits
+) -> None:
+    """A retry is safe only because the listing proved the batch absent.
+
+    With the listing unreadable, whether the records landed is exactly the
+    open question, and sending them again would publish a second copy under
+    fresh UUID paths.
+    """
+    tree = _upload_tree(tmp_path, 3)
+    hub = FakeHub()
+    sub = submit.DatastoreSubmitter(hub, batch_size=3)
+    hub.commit_error = _conflict(409, '409 Client Error: Conflict')
+    hub.list_files_error = ConnectionError('network is unreachable')
+
+    with pytest.raises(submit.PartialSubmissionError) as caught:
+        sub.publish(
+            operations=submit.upload_operations(tree),
+            description='body',
+            message='hle 2026-08-10',
+        )
+
+    assert retry_waits == []
+    assert len(caught.value.unresolved_paths) == 3
 
 
 # --- what happened to the last pull request -------------------------------


### PR DESCRIPTION
## What / source

The scheduled ingestion has failed on every run from 2026-08-19 to 2026-08-24 —
a different adapter each night, none of them for an adapter reason. Runs
[32213938319](https://github.com/evaleval/every_eval_ever/actions/runs/32213938319)
through
[32688554201](https://github.com/evaleval/every_eval_ever/actions/runs/32688554201);
2026-08-18 is the last green one.

All of them are this:

```
error: could not write to evaleval/EEE_raw: HfHubHTTPError: 409 Client Error:
Conflict for url: https://huggingface.co/api/datasets/evaleval/EEE_raw/commit/main

Another commit operation is in progress for this repository. Please try again later.
```

Four jobs of one matrix commit to one branch of the raw store and the Hub takes
one commit per repository at a time, so losing the race is ordinary.
`store.commit` already retried — but only where `_moved_head` saw the branch sha
change, on the stated reasoning that "a commit that was rejected while the head
is exactly where we left it was not a race, so there is nothing to retry
against."

That reasoning holds for a 412 parent mismatch and inverts for a held commit
lock: the winner's commit has not landed, so the head has *not* moved, so the
loser reads a pure race as a hard error and raises without a single retry.
`global_mmlu_lite` on the 24th started its ingest step at 04:03:14.4 and failed
at 04:03:17.9, before scraping anything.

The same race sits in `submit.publish`, which is the dangerous one — it is
mid-publication, and `cron/README.md` already describes at length what a torn
commit series costs: records in the datastore with nothing in the ledger naming
them, republished next run under fresh UUID paths.

## Design

- `is_commit_conflict` recognises both races — 409 while another commit is in
  flight, 412 when the parent sent is no longer the head. Anything else (403,
  transport) still fails the job immediately, so nothing is retried into
  silence.
- `commit` retries either: rebasing onto the new head where it moved, keeping
  the parent and waiting where it did not. `commit_retry_delay` is exponential
  with jitter over the top half of each window, because four jobs backing off
  in lockstep collide again on every attempt. `COMMIT_ATTEMPTS` 5 → 8, ceiling
  30 s, worst case ≈90 s against the job's 15-minute buffer.
- `submit.publish` retries a conflicting batch **only where
  `_landed_anyway` proves it absent**, reusing the existing arbiter, so a retry
  cannot publish a second copy. A conflict the datastore cannot arbitrate is
  still reported as unresolved and left in flight for the next run to settle.
- `wait_before_retry` is the single place either path sleeps, so a test
  replaces it rather than the clock.

Not addressed here, and worth deciding separately: whether every adapter job
should be writing to one branch of one repository at all, when the raw store's
layout is already partitioned per adapter.

## Review lane

- [x] **Fast** — no conflicts, scoped to the two cron commit paths and their
      tests, verified by me, well under ~1000 lines
- [ ] **Needs a human**

No overlap with #261, which touches `store.py` only to add
`AdapterState.freshness_token`.

## Checklist

- [x] full `uv run pytest tests` green: **815 passed, 20 skipped**
- [x] `uv run ruff check every_eval_ever tests` clean; `ruff format --check`
      clean on every file this touches
- [x] 5 new tests: a held lock is waited out; a lock that never clears still
      fails after its budget; the backoff grows and is jittered; a contended
      datastore commit publishes each batch exactly once; a conflict the file
      listing cannot arbitrate is not retried
- [x] `cron/README.md` updated — its "two overlapping runs collide loudly" text
      described two runs of *one* adapter and did not cover adapters racing
      each other

Nothing here converts source rows, so the validate, adapter-report, registry
and coverage items do not apply.

## Decisions & coverage

- **Decision / where:** what counts as a retryable conflict
  **Chose / instead of:** classify by status (409/412), with the Hub's
  "commit operation is in progress" sentence and a leading-status match as
  fallbacks for an error carrying no response — instead of matching the message
  alone, which breaks when the Hub rewords it, or retrying every failure,
  which would retry a 403 eight times before reporting it
  **Confidence:** high
  **General?** no

- **Decision / where:** `submit.publish` retry condition
  **Chose / instead of:** retry only where the datastore's file listing proves
  the batch absent, instead of trusting that a 409 means nothing landed. One
  extra listing call buys the guarantee that a retry cannot duplicate records,
  and it reuses the arbiter already there for the ambiguous-timeout case
  **Confidence:** high
  **General?** yes — same rule for any future retry on this path

- **Decision / where:** attempt budget and backoff shape
  **Chose / instead of:** 8 attempts with jitter over the top half of each
  window (≈90 s worst case) instead of more attempts or a longer ceiling. The
  Hub's lock is held for the length of one commit, so seconds is the right
  order; the jitter matters more than the ceiling
  **Confidence:** medium — if a busier matrix still loses, the budget is the
  knob, and `max-parallel` is the other one
  **General?** no

- **Decision / where:** test timing
  **Chose / instead of:** an autouse fixture recording the backoff instead of
  sleeping it, rather than shrinking the constants under test.
  `test_a_rejected_write_is_reported_not_swallowed` simulates a permanent 412
  and now exhausts the budget, so without this the module would spend a real
  minute; it drops from 61 s to 0.3 s
  **Confidence:** high
  **General?** yes

**Coverage:** not a conversion change — no source rows read, no records
emitted, no adapter behaviour changed.

**Operator asked about policy calls?** None. No new id, no dropped data, no
metric or re-hosting decision.
