### PR TITLE
Commit raw store state against the live head, not a pinned parent

### DIFF
--- a/every_eval_ever/cron/__main__.py
+++ b/every_eval_ever/cron/__main__.py
@@ -541,7 +541,6 @@ def _finish(
     committed_paths: tuple[str, ...] = ()
     publish_failure: submit.PartialSubmissionError | None = None
     raw_manifest: list[dict] = []
-    parent_commit = state.parent_commit
 
     if raw_store is not None:
         # The snapshot and the intention to publish, before the publishing.
@@ -581,14 +580,12 @@ def _finish(
                 )
             )
         )
-        result = raw_store.commit(
+        raw_store.commit(
             operations,
             message=(
                 f'cron: {spec.key} {outcome.run_date.isoformat()} (snapshot)'
             ),
-            parent_commit=parent_commit,
         )
-        parent_commit = getattr(result, 'oid', None) or parent_commit
 
     if dry_run:
         notes.append('dry run: nothing was published')
@@ -666,7 +663,6 @@ def _finish(
                 f'cron: {spec.key} {outcome.run_date.isoformat()} '
                 f'({outcome.status})'
             ),
-            parent_commit=parent_commit,
         )
 
     _report(outcome, spec=spec, published=len(landed), dry_run=dry_run)

--- a/every_eval_ever/cron/store.py
+++ b/every_eval_ever/cron/store.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import json
 import random
 import re
+import sys
 import time
 from dataclasses import dataclass, field
 from datetime import date
@@ -81,9 +82,11 @@ COMMIT_ATTEMPTS = 8
 #: collide again on every attempt.
 COMMIT_RETRY_BASE_SECONDS = 1.0
 COMMIT_RETRY_MAX_SECONDS = 30.0
-#: Statuses the Hub refuses a commit with when it lost a race: 412 when the
-#: parent sent is no longer the head, 409 while another commit to the same
-#: repository is still in flight.
+#: Statuses the Hub refuses a commit with when it lost a race. A commit here
+#: sends no parent, so the head moving under it is not an error and 412 is not
+#: expected; it stays in the set so that a Hub which ever returned one would be
+#: waited out rather than failing the job. 409 is the live case: another commit
+#: to the same repository is still holding the per-repository lock.
 _CONFLICT_STATUSES = frozenset({409, 412})
 #: The sentence the Hub returns with a 409 when another commit to the same
 #: repository is still in flight.
@@ -96,12 +99,12 @@ _STATUS_PREFIX = re.compile(r'\s*(409|412)\b')
 def is_commit_conflict(exc: BaseException) -> bool:
     """Return whether the Hub refused this commit because of a race.
 
-    A race resolves two ways and each has its own status. The branch head
-    moved under us (412), answered by rebasing onto the new head; or another
+    A commit here sends no parent, so it lands on whatever the head is and
+    the only race left is the Hub's per-repository commit lock: another
     commit to the same repository is still in flight (409), answered by
-    waiting, since the Hub serialises commits per repository and rejects the
-    loser before the head has moved at all. Both are retryable, and anything
-    else — a permission or transport error — is not.
+    waiting for the lock to clear. A 412 is not expected without a parent,
+    but is still treated as retryable so a Hub that returned one would be
+    waited out. Anything else — a permission or transport error — is not.
     """
     status = getattr(getattr(exc, 'response', None), 'status_code', None)
     if status in _CONFLICT_STATUSES:
@@ -175,9 +178,6 @@ class AdapterState:
     #: Promoted into :attr:`fingerprints` when that pull request merges,
     #: dropped when it is closed without merging.
     pending_fingerprints: set[str] = field(default_factory=set)
-    #: Commit the state was read at, so a concurrent write is rejected
-    #: instead of silently overwriting a newer one.
-    parent_commit: str | None = None
     #: ``False`` when no state file existed yet, which is a cold start rather
     #: than "this adapter has published nothing".
     exists: bool = False
@@ -444,21 +444,9 @@ class RawStore:
             ) from exc
         return Path(local).read_text(encoding='utf-8')
 
-    def head_commit(self) -> str | None:
-        """Return the revision the store is currently at, if resolvable."""
-        try:
-            info = self.api.dataset_info(self.repo_id, revision=self.revision)
-        except Exception as exc:  # noqa: BLE001 - re-raised with context
-            raise StoreError(
-                f'could not resolve {self.repo_id}@{self.revision}: '
-                f'{type(exc).__name__}: {exc}'
-            ) from exc
-        return getattr(info, 'sha', None)
-
     def read_state(self, adapter: str) -> AdapterState:
         """Load one adapter's ledger, distinguishing absent from unreadable."""
         state = AdapterState(adapter=adapter)
-        state.parent_commit = self.head_commit()
 
         raw = self._download_text(state_path(adapter))
         if raw is not None:
@@ -557,30 +545,29 @@ class RawStore:
         operations: list[CommitOperationAdd],
         *,
         message: str,
-        parent_commit: str | None,
     ) -> Any:
-        """Commit to the store, retrying when another adapter got there first.
+        """Commit to the store, waiting out the Hub's per-repository lock.
 
-        Every adapter job reads one shared head and writes back to the same
-        branch, so a daily matrix of twenty adapters races on every run. The
-        loser of that race has already published its records to the datastore
-        by this point, and dropping its state commit would leave those
-        records with no fingerprints, so the next run would publish them
-        again under fresh paths.
+        The commit sends no parent, so it lands on whatever the branch head
+        is at the moment the Hub processes it. This is safe rather than a
+        lost update because a job only ever writes files it owns:
+        ``state/<adapter>.*`` and this adapter's raw snapshot directory. The
+        workflow's per-adapter concurrency group guarantees no second job is
+        writing the same ones, so two adapter jobs committing at once touch
+        disjoint files and neither can overwrite the other's work. Pinning a
+        parent would only reject one of two disjoint writes and force a
+        needless retry, which is the 412 storm this path used to produce.
 
-        A race resolves one of two ways, and both are retried here. The head
-        moved, in which case the next attempt rebases onto it; or the Hub's
-        per-repository commit lock was held by a commit still in flight, in
-        which case the head has not moved yet and the next attempt waits and
-        keeps the same parent. An unmoved head is therefore not evidence
-        against a race.
-
-        Retrying is safe rather than a lost update because a job only ever
-        writes files it owns: ``state/<adapter>.*`` and this adapter's raw
-        snapshot directory. The workflow's per-adapter concurrency group is
-        what guarantees no second job is writing the same ones. A failure
+        One race remains. Every adapter job of a matrix commits to this one
+        branch, so the Hub's per-repository commit lock is contended, and a
+        job that loses it is refused with a 409 before its commit is even
+        attempted. That is retried after a backoff; the loser has already
+        published its records to the datastore by this point, and dropping
+        its state commit would leave those records with no fingerprints, so
+        the next run would publish them again under fresh paths. A failure
         that is not a conflict is re-raised untouched, so a permission or
-        transport error still fails the job immediately.
+        transport error still fails the job immediately. This mirrors the
+        datastore path in :mod:`every_eval_ever.cron.submit`.
 
         Visibility is confirmed here rather than trusted from startup, because
         the adapter has been running in between and a repository's visibility
@@ -589,7 +576,6 @@ class RawStore:
         if not operations:
             return None
         self._require_private()
-        parent = parent_commit
         for attempt in range(1, COMMIT_ATTEMPTS + 1):
             try:
                 return self.api.create_commit(
@@ -598,7 +584,6 @@ class RawStore:
                     revision=self.revision,
                     operations=operations,
                     commit_message=message,
-                    parent_commit=parent,
                 )
             except Exception as exc:  # noqa: BLE001 - re-raised with context
                 last = attempt == COMMIT_ATTEMPTS
@@ -607,26 +592,13 @@ class RawStore:
                         f'could not write to {self.repo_id}: '
                         f'{type(exc).__name__}: {exc}'
                     ) from exc
-                moved = self._moved_head(parent)
-                if moved is not None:
-                    parent = moved
+                print(
+                    f'{self.repo_id}: commit attempt {attempt} lost the '
+                    f'per-repository lock ({type(exc).__name__}), retrying',
+                    file=sys.stderr,
+                )
                 wait_before_retry(attempt)
         return None
-
-    def _moved_head(self, parent: str | None) -> str | None:
-        """Return the branch head if it moved under us, else ``None``.
-
-        ``None`` also covers a head that could not be read and a commit sent
-        without a parent, so the caller keeps the parent it has rather than
-        treating an unanswered question as a moved branch.
-        """
-        if parent is None:
-            return None
-        try:
-            current = self.head_commit()
-        except StoreError:
-            return None
-        return current if current and current != parent else None
 
 
 def plan_raw_upload(

--- a/tests/test_cron_cli.py
+++ b/tests/test_cron_cli.py
@@ -329,10 +329,11 @@ def test_the_snapshot_is_committed_before_the_records_are_published(
         'state/hle.pending',
         'state/hle.inflight',
     }
-    assert before['parent_commit'] == 'headsha'
-    # The second commit builds on the first rather than on the head the state
-    # was read at, which the first one moved.
-    assert after['parent_commit'] == 'newsha'
+    # Neither commit pins a parent. Each lands on the live head, so a
+    # concurrent adapter job moving the head between these two writes cannot
+    # 412 either of them.
+    assert 'parent_commit' not in before
+    assert 'parent_commit' not in after
     # Nothing is left in flight once the ledger names it.
     assert json.loads(hub.files['state/hle.inflight'])['records'] == []
     report = json.loads(hub.files[f'{RAW_PREFIX}/run.json'])

--- a/tests/test_cron_store_and_submit.py
+++ b/tests/test_cron_store_and_submit.py
@@ -326,7 +326,6 @@ def test_a_commit_re_checks_visibility_rather_than_trusting_startup() -> None:
         raw_store.commit(
             store.state_operations(store.AdapterState(adapter='hle')),
             message='state',
-            parent_commit='headsha',
         )
 
     assert hub.commits == []
@@ -340,7 +339,6 @@ def test_a_commit_whose_visibility_cannot_be_confirmed_is_refused() -> None:
         store.RawStore(hub).commit(
             store.state_operations(store.AdapterState(adapter='hle')),
             message='state',
-            parent_commit='headsha',
         )
 
     assert hub.commits == []
@@ -355,7 +353,6 @@ def test_a_cold_start_is_an_empty_ledger_that_says_so() -> None:
     assert not state.exists
     assert state.fingerprints == set()
     assert state.pull_request_number is None
-    assert state.parent_commit == 'headsha'
 
 
 def test_state_round_trips_through_the_store() -> None:
@@ -376,7 +373,6 @@ def test_state_round_trips_through_the_store() -> None:
     raw_store.commit(
         store.state_operations(state),
         message='state',
-        parent_commit='headsha',
     )
     reloaded = raw_store.read_state('hle')
 
@@ -412,7 +408,6 @@ def test_an_in_flight_batch_round_trips_through_the_store() -> None:
     raw_store.commit(
         [store.inflight_operation(batch)],
         message='in flight',
-        parent_commit='headsha',
     )
     reloaded = raw_store.read_inflight('hle')
 
@@ -430,7 +425,6 @@ def test_an_emptied_in_flight_file_is_written_rather_than_deleted() -> None:
     store.RawStore(hub).commit(
         [store.inflight_operation(store.InflightBatch(adapter='hle'))],
         message='settled',
-        parent_commit='headsha',
     )
 
     assert 'state/hle.inflight' in hub.files
@@ -486,8 +480,14 @@ def test_a_fingerprint_file_alone_still_counts_as_existing_state() -> None:
     assert state.fingerprints == {'aaa', 'bbb'}
 
 
-def test_state_writes_carry_the_commit_they_were_read_at() -> None:
-    """So a concurrent run 409s instead of overwriting a newer ledger."""
+def test_state_writes_send_no_parent_so_disjoint_writes_never_412() -> None:
+    """A commit lands on the live head rather than a head read earlier.
+
+    Each adapter job writes only files it owns, so two jobs committing at
+    once touch disjoint files and cannot overwrite each other. Pinning a
+    parent would reject one of the two and force a needless retry, which is
+    the 412 storm this path used to produce, so no parent is sent.
+    """
     hub = FakeHub()
     raw_store = store.RawStore(hub)
     state = raw_store.read_state('hle')
@@ -496,10 +496,9 @@ def test_state_writes_carry_the_commit_they_were_read_at() -> None:
     raw_store.commit(
         store.state_operations(state),
         message='state',
-        parent_commit=state.parent_commit,
     )
 
-    assert hub.commits[0]['parent_commit'] == 'headsha'
+    assert 'parent_commit' not in hub.commits[0]
 
 
 def test_a_rejected_write_is_reported_not_swallowed() -> None:
@@ -510,16 +509,7 @@ def test_a_rejected_write_is_reported_not_swallowed() -> None:
         store.RawStore(hub).commit(
             store.state_operations(store.AdapterState(adapter='hle')),
             message='state',
-            parent_commit='headsha',
         )
-
-
-def test_an_unresolvable_store_revision_is_fatal() -> None:
-    hub = FakeHub()
-    hub.dataset_info = _raise(RuntimeError('no such repo'))
-
-    with pytest.raises(store.StoreError, match='could not resolve'):
-        store.RawStore(hub).read_state('hle')
 
 
 def test_the_store_refuses_an_empty_repository_id() -> None:
@@ -625,45 +615,51 @@ def test_an_unchanged_payload_is_referenced_not_re_uploaded(
 
 
 def test_two_adapters_from_one_head_both_record_their_state() -> None:
-    """The loser of the race has already published; it must still be recorded.
+    """Two jobs writing disjoint files from one head must both land.
 
-    Every job in the daily matrix reads the same raw-store head. Dropping the
-    second one's state commit would leave the records it just put in the
-    datastore with no fingerprints, so the next run would publish them again.
+    Every job in the daily matrix reads the same raw-store head, and the head
+    moves as each one commits. When a commit pinned the head it was read at, a
+    concurrent write would move the head first and the second commit would be
+    refused with a 412 even though the two touch entirely different files. A
+    commit sends no parent now, so a moving head is not a conflict and both
+    jobs record their state. Dropping the second one's state commit would
+    leave the records it just put in the datastore with no fingerprints, so
+    the next run would publish them again.
     """
     hub = FakeHub(sha='headsha')
     first = store.RawStore(hub)
     second = store.RawStore(hub)
     first_state = first.read_state('hle')
     second_state = second.read_state('mt_bench')
-    assert first_state.parent_commit == second_state.parent_commit
 
     real_create_commit = hub.create_commit
 
-    def reject_a_stale_parent(**kwargs):
-        if kwargs.get('parent_commit') != hub.sha:
+    def refuse_any_pinned_parent(**kwargs):
+        # A commit that pins a parent no longer matching the (already moved)
+        # head is exactly the 412 this design removes; sending no parent must
+        # never trip it.
+        if kwargs.get('parent_commit') is not None:
             raise RuntimeError('412 Precondition Failed')
         result = real_create_commit(**kwargs)
         hub.sha = f'{hub.sha}-moved'
         return result
 
-    hub.create_commit = reject_a_stale_parent
+    hub.create_commit = refuse_any_pinned_parent
 
     first_state.fingerprints.add('a')
     first.commit(
         store.state_operations(first_state),
         message='hle',
-        parent_commit=first_state.parent_commit,
     )
     second_state.fingerprints.add('b')
     second.commit(
         store.state_operations(second_state),
         message='mt_bench',
-        parent_commit=second_state.parent_commit,
     )
 
     assert hub.files['state/hle.fingerprints'].split() == ['a']
     assert hub.files['state/mt_bench.fingerprints'].split() == ['b']
+    assert all('parent_commit' not in c for c in hub.commits)
 
 
 def test_a_rejected_commit_that_is_not_a_race_still_fails(
@@ -679,19 +675,18 @@ def test_a_rejected_commit_that_is_not_a_race_still_fails(
         raw_store.commit(
             store.state_operations(state),
             message='hle',
-            parent_commit=state.parent_commit,
         )
 
     assert retry_waits == []
 
 
 def test_a_held_commit_lock_is_waited_out_not_reported(retry_waits) -> None:
-    """The head has not moved, and it is still a race.
+    """A 409 is the Hub's per-repository lock, and it is retried.
 
     Four adapter jobs of one matrix commit to this branch at once and the Hub
-    serialises them, so the losers are refused with 409 before the winner's
-    commit has moved the head at all. Reading an unmoved head as evidence
-    against a race fails the job for the one reason a retry would fix.
+    serialises them, so the losers are refused with 409 while another commit
+    holds the lock. That is the one race left once no parent is pinned, and a
+    retry after a backoff is exactly what clears it.
     """
     hub = FakeHub(sha='headsha')
     raw_store = store.RawStore(hub)
@@ -717,7 +712,6 @@ def test_a_held_commit_lock_is_waited_out_not_reported(retry_waits) -> None:
     raw_store.commit(
         store.state_operations(state),
         message='hle',
-        parent_commit=state.parent_commit,
     )
 
     assert hub.files['state/hle.fingerprints'].split() == ['a']
@@ -737,7 +731,6 @@ def test_a_lock_that_never_clears_fails_after_its_attempts(
         raw_store.commit(
             store.state_operations(state),
             message='hle',
-            parent_commit=state.parent_commit,
         )
 
     assert retry_waits == list(range(1, store.COMMIT_ATTEMPTS))


### PR DESCRIPTION
## The failure

The daily adapter cron fails intermittently with `412 Precondition Failed` when writing `evaleval/EEE_raw`. The last run failed this way for `artificial_analysis` and `arc_agi`. It is self-inflicted, not a Hub outage, and merging #263 (the 409 lock retry) did not fix it because 412 is a different race.

`RawStore.commit` read the branch head at run start and passed it as `parent_commit`. The matrix runs several adapter jobs at once, all committing to this one branch, so a concurrent commit moves the head first and the Hub rejects the next commit with 412 — even though the two commits touch **entirely disjoint files**. The 412 retry re-read the head from `dataset_info`, which is cache-lagged; when that read lagged, the stale parent never advanced and all eight attempts 412 identically, failing the job.

## Why the precondition protected nothing

Every adapter job writes only files it owns — `state/<adapter>.*` and its own `raw/<adapter>/...` snapshot directory — and the workflow's per-adapter `concurrency` group guarantees no second job writes the same ones. Two jobs committing at once therefore touch disjoint paths and cannot overwrite each other's work. The optimistic-concurrency guard had nothing to guard; it only manufactured the 412.

## The fix

Send no `parent_commit`. The commit lands on whatever the live head is, so a head that moved under a disjoint write is no longer an error and the whole 412 class disappears structurally. The one race left is the Hub's per-repository commit lock (409), retried after a backoff exactly as before (unchanged from #263).

This converges the raw-store path onto the datastore path in `every_eval_ever/cron/submit.py`, which already commits with no parent and did **not** fail in the same run. One pattern for both writers now.

Deleted the machinery that existed only to feed the precondition: `_moved_head`, the `head_commit()` read in `read_state`, and the `AdapterState.parent_commit` field. Added a per-retry stderr line so a genuinely contended lock is visible in the run logs instead of silent.

## Tested without waiting for cron

- `test_state_writes_send_no_parent_so_disjoint_writes_never_412` — a commit carries no parent precondition.
- `test_two_adapters_from_one_head_both_record_their_state` — rewritten to model the exact production race: a fake Hub that moves the head on each commit and refuses any pinned parent. Both adapters land; with the old code the second 412'd.
- The 409 lock tests (`..._waited_out_not_reported`, `..._never_clears_fails_after_its_attempts`, and the non-race 403 test) stay green, so the retry budget is unchanged.

Full suite: 814 passed, 20 skipped. `ruff check` clean.