### PR TITLE
Sort the open_medical_llm imports the merge left unsorted

### DIFF
--- a/every_eval_ever/adapters/open_medical_llm/adapter.py
+++ b/every_eval_ever/adapters/open_medical_llm/adapter.py
@@ -44,12 +44,12 @@ from every_eval_ever.eval_types import (
 )
 from every_eval_ever.helpers import (
     SCHEMA_VERSION,
-    raw_capture,
     EvaluationLogOutput,
     SourceConversionResult,
     SourceRecordExclusion,
     SourceRecordFailure,
     default_failure_report_path,
+    raw_capture,
     require_finite_number,
     save_evaluation_logs,
     save_failure_report,


### PR DESCRIPTION
`uv run ruff check` fails on main at 22c46d0: `raw_capture` landed in the `every_eval_ever.helpers` import block out of order when #204 merged main in. One-line I001 autofix.

CI does not run ruff, so nothing caught it — that is worth a follow-up, separately.