### PR TITLE
Run ruff in CI, and delete the note that said nothing did

### DIFF
--- a/.agents/skills/eee-dataset-conversion/reference/gotchas.md
+++ b/.agents/skills/eee-dataset-conversion/reference/gotchas.md
@@ -78,9 +78,7 @@
   repo should be a deliberate, separate act. Give the adapter `--save-raw-json` /
   `--input-json` so a fetched payload can be replayed offline — that's also what makes the
   fixture-based test possible without mocking HTTP.
-- **ruff is configured but not enforced by CI** — `pyproject.toml` selects E/F/I (E501
-  and E402 ignored); no workflow runs it, so nothing will tell you but a reviewer. Run
-  `uv run ruff check` yourself; fix import order, and use `# noqa: E402` after an
-  `importorskip` block.
+- **Import order after an `importorskip` block** — CI's `ruff` row selects E/F/I, so put
+  `# noqa: E402` on an import that has to follow the skip guard.
 - **Stale helpers** — `helpers.make_evaluation_log`/`make_evaluation_result` miss the
   now-required `eval_library`/per-result `source_data`; build the models by hand.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,18 @@ on:
 permissions:
   contents: read
 jobs:
+  lint:
+    name: ruff
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: astral-sh/setup-uv@v7.6.0
+      # No project sync: ruff is pinned in the dev group and needs nothing else,
+      # so this row stays green when a dependency resolution is what is broken.
+      - name: Lint
+        run: uv run --only-group dev ruff check every_eval_ever tests scripts
+
   tests:
     name: ${{ matrix.deps }} / ${{ matrix.resolution }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
`gotchas.md` carried this:

> **ruff is configured but not enforced by CI** — `pyproject.toml` selects E/F/I (E501 and E402 ignored); no workflow runs it, so nothing will tell you but a reviewer.

That is a missing check written down as an instruction, which AGENTS.md says to invert — *"if a test or a CI job can enforce a rule, add that instead of writing the rule down, and delete the prose it replaces."* It also cost something real this week: main sat with a broken import order in `open_medical_llm` for the length of a merge (#267), because pytest was the only gate and pytest does not care about import order.

**The job** installs only the dev group rather than syncing the project, so the lint row stays green when a dependency resolution is what is broken, and it lints `every_eval_ever`, `tests` and `scripts`.

**Nothing turns red.** I checked main and every open PR under the exact command — #257, #258, #261, #271, and the tau-bench and drugbank branches are all clean.

**The prose shrinks to the rule the check leaves behind**, two lines instead of four: put `# noqa: E402` on an import that has to follow an `importorskip` guard. The rest was describing the gap this closes.