### PR TITLE
Cut skill text that records how a rule was reached, not what to follow

### DIFF
--- a/.agents/skills/eee-dataset-conversion/reference/fields.md
+++ b/.agents/skills/eee-dataset-conversion/reference/fields.md
@@ -65,8 +65,8 @@ comes from **`evaluation_results[0].source_data.dataset_name`** unless you pass
   For a multi-benchmark leaderboard, namespace the collection by the source
   (`data/vals-ai/`, `data/hal-<benchmark>/`): fanning out into bare `data/gaia/`,
   `data/usaco/` puts your leaderboard's numbers in the same directory as everyone
-  else's records for that benchmark and loses the provenance. (This was the
-  maintainers' resolution on the HAL adapter.) The benchmark identity always lives in
+  else's records for that benchmark and loses the provenance. The benchmark identity
+  always lives in
   `evaluation_name` + `source_data` regardless.
 - With the default one-log-per-model grain, the first result silently decides the
   directory — so pass `collection_override` rather than relying on result ordering.
@@ -78,9 +78,7 @@ comes from **`evaluation_results[0].source_data.dataset_name`** unless you pass
 - `source_type` — the artifact you hold, NOT who ran it: raw per-item run outputs
   → `evaluation_run` (even if a third party ran them); only-aggregate reported numbers
   → `documentation` (a leaderboard scrape stays `documentation` even though a pipeline
-  produced the numbers). `evaluator_relationship` separately records WHO ran it. (The
-  README/schema phrase it "run locally"; that under-specifies third-party raw runs —
-  the artifact-you-hold test is what governs.)
+  produced the numbers). `evaluator_relationship` separately records WHO ran it.
 - `source_name` — the platform/leaderboard, NOT the benchmark or author.
 - `source_organization_name` — the aggregator/publisher org, NOT a username
   or the model developer.
@@ -148,11 +146,10 @@ comes from **`evaluation_results[0].source_data.dataset_name`** unless you pass
     carries e.g. `mteb-score`, `mmau-pro-open-ended-judge-score`).
   - **Never a bare semantically-empty id** — `score`/`rank`/`cost` mean something
     different on every leaderboard; namespace those or resolve them to a specific
-    registry metric. This is the most repeated review comment on adapter PRs.
+    registry metric.
   - Keeping `accuracy` on two benchmarks apart is **`evaluation_name`'s job**, not the
     metric id's. Don't smuggle the benchmark into `metric_id` to get separation you
     already have.
-  (Not schema-required — which is exactly why it gets omitted.)
 - **The canonical *scale* is a property of the metric, and it comes from the registry
   entry — not from whatever scale the source printed.** The registry stores bounds per
   metric: every accuracy-family entry is `[0,1]`, while benchmark-specific judge scores

--- a/.agents/skills/eee-dataset-conversion/reference/gotchas.md
+++ b/.agents/skills/eee-dataset-conversion/reference/gotchas.md
@@ -1,18 +1,12 @@
 # Gotchas that cost real time (with fixes)
 
-*Scope: deeper failure modes and mechanisms. For what each field means, see
-`fields.md` / `instance-level.md`; this file is the "why it bit us" layer.*
+*Scope: failure modes and mechanisms. What each field means → `fields.md` /
+`instance-level.md`.*
 
-- **`inf` bounds — settled: emit `±inf`, don't hand-roll it.** A genuinely unbounded
-  `continuous` metric (PSNR, perplexity, WER) sets `min_score`/`max_score` to
-  `float('-inf')`/`float('inf')`. The library serializes those as the JSON strings
-  `"Infinity"`/`"-Infinity"` (a `field_serializer` on the bounds, every_eval_ever#212 —
-  valid RFC-8259 JSON that reads back to a float), so just save through
-  `save_evaluation_log`/`model_dump_json` and it round-trips + validates. Do **not**
-  hand-roll `json.dumps(..., allow_nan=True)`: that writes a bare `Infinity` token,
-  which the strict read path (#212) now rejects. `null` ≠ unbounded — `null` is
-  "not provided" and still fails `continuous`. Give a finite bound only when a real
-  nominal scale exists (`[0,1]`/`[0,100]`); don't invent one for an open-ended metric.
+- **`±inf` bounds only round-trip through the library's writer.** Save an unbounded
+  `continuous` metric through `save_evaluation_log`/`model_dump_json`; hand-rolling
+  `json.dumps(..., allow_nan=True)` writes a bare `Infinity` token that the strict read
+  path rejects. The rule for when `±inf` is right at all: `datastore-gate.md` §score.
 - **Model deployment axes — the library hides your omission.** It auto-fills both to
   `"unknown"`, so a green *library* validate says nothing about whether you set them;
   the CLI errors. Enums and the vocabulary-skew warning: `datastore-gate.md` §deployment.

--- a/.agents/skills/eee-dataset-conversion/reference/instance-level.md
+++ b/.agents/skills/eee-dataset-conversion/reference/instance-level.md
@@ -66,9 +66,8 @@ sub-objects, never at top level either) — route instance extras into `metadata
 
 ### Hashing (`sample_hash`)
 Optional cross-model/adapter join key — use exactly this recipe so hashes match
-across adapters (matches `every_eval_ever/adapters/openeval`; historically the
-converters computed it inconsistently). Full `reference` list; `[]` when empty. Only
-meaningful once
+across adapters (`every_eval_ever/adapters/openeval` is the reference
+implementation). Full `reference` list; `[]` when empty. Only meaningful once
 `input.raw` is answer-free:
 ```python
 sample_hash = hashlib.sha256(


### PR DESCRIPTION
A pass over the conversion skill for the failure mode that let #271 happen — text that is in the wrong file, longer than the thing it says, or about how a rule came to be rather than what to do. 850 lines to 840, and one stale claim gone.

**Duplication.** The `±inf` gotcha re-derived a rule `datastore-gate.md` §score already states, cited the issue that fixed the serializer twice, and re-explained that `null` is not unbounded — which §score also says. What only lives in `gotchas.md` is the mechanism: a hand-rolled `json.dumps(..., allow_nan=True)` writes a bare `Infinity` token the strict reader rejects. Ten lines to four, pointing at §score for when `±inf` is right at all.

**Self-description.** `gotchas.md` introduced itself as *"the 'why it bit us' layer"*. Someone opening it mid-task wants the failure mode, not the file's biography.

**How a decision was reached, rather than the decision.**
- *"(This was the maintainers' resolution on the HAL adapter.)"* — the rule stands on its reason, which the preceding sentence gives.
- *"This is the most repeated review comment on adapter PRs."* — true, and unactionable.
- *"(Not schema-required — which is exactly why it gets omitted.)"* — the bullet already says always set it.
- *"historically the converters computed it inconsistently"* — the recipe is the rule.

**Stale meta-commentary.** `source_type` carried a parenthetical saying the README and schema phrase it "run locally" and under-specify third-party raw runs. Neither says that any more — the schema says "whether the data comes from a direct evaluation run or from documentation" — so the skill was apologising for wording that no longer exists. Sharpening the schema's own description is in #271, which is where the codegen already runs.

**Not touched:** `fields.md` is 210 lines and the largest reference, but it is field-by-field lookup, which is what that length buys. I would rather watch it than split it — more files means more places for a rule to hide, which is exactly how the developer-folder rule got lost.

`uv run pytest tests` 859 passed, 31 skipped, `test_skill_conversion.py` included; `uv run ruff check` clean.