### PR TITLE
Put a rescaled score's reported spread on the score's scale

### DIFF
--- a/every_eval_ever/adapters/paperswithcode/adapter.py
+++ b/every_eval_ever/adapters/paperswithcode/adapter.py
@@ -172,6 +172,28 @@ def _to_float(text: str) -> float | None:
     return val if math.isfinite(val) else None
 
 
+def _canonical_uncertainty(
+    uncertainty_text: str | None,
+    scale_detail: dict[str, Any] | None,
+) -> float | None:
+    """Put a reported spread on the same scale as the rescaled score.
+
+    Returns None when nothing was reported, when the spread is not a bare number
+    (PwC prints things like ``0.3 (n=5)``), or when no rescale was applied — in
+    the last case the verbatim figure is already canonical and repeating it would
+    only invite the two to drift.
+    """
+    if not uncertainty_text:
+        return None
+    factor = (scale_detail or {}).get('canonical_rescale_factor')
+    if not isinstance(factor, (int, float)) or factor == 1.0:
+        return None
+    value = _to_float(uncertainty_text.removesuffix('%').strip())
+    if value is None or value < 0:
+        return None
+    return value * factor
+
+
 def parse_metric_value(raw: Any) -> tuple[float | None, str | None]:
     """Return (score, uncertainty_text).
 
@@ -881,6 +903,13 @@ def score_details(
                 **(scale_detail or {}),
                 'raw_value': raw_value,
                 'reported_uncertainty': uncertainty_text,
+                # A spread is in the score's units, so a rescaled score leaves
+                # the verbatim figure on a different scale — 0.31 beside a score
+                # of 0.6265. The verbatim text stays what the source printed;
+                # this is the same number on the scale `score` is on.
+                'reported_uncertainty_canonical': _canonical_uncertainty(
+                    uncertainty_text, scale_detail
+                ),
                 'pwc_evaluation_id': ev.get('id'),
                 'best_rank': ev.get('best_rank'),
                 'best_metric': ev.get('best_metric'),

--- a/tests/test_paperswithcode_adapter.py
+++ b/tests/test_paperswithcode_adapter.py
@@ -906,6 +906,56 @@ def test_reported_uncertainty_kept_as_text_not_typed_se():
     assert 'reported_uncertainty' not in sd2.details
 
 
+def test_a_rescaled_score_carries_its_spread_on_the_same_scale():
+    """A spread is in the score's units, so a rescale has to reach it too.
+
+    Without this, a percent-scale row published `score=0.337` beside
+    `reported_uncertainty=0.82`, a spread wider than the metric's whole range.
+    The verbatim figure stays what the source printed; the canonical one is what
+    a consumer can compare against `score`.
+    """
+    sd = adapter.score_details(
+        {'id': '1'},
+        '33.7 ± 0.82',
+        0.337,
+        '0.82',
+        {},
+        None,
+        {'canonical_rescale_factor': 0.01, 'rescale_basis': 'group_uniform'},
+    )
+
+    assert sd.details['reported_uncertainty'] == '0.82'
+    # Compared as a number, not a string: the multiply is left exact, the same
+    # way the rescaled score is, so the repr can carry a float artifact.
+    assert float(sd.details['reported_uncertainty_canonical']) == pytest.approx(
+        0.0082
+    )
+
+
+def test_an_unrescaled_score_does_not_repeat_its_spread():
+    """Repeating an unchanged figure under a second key only invites drift."""
+    sd = adapter.score_details({'id': '1'}, '0.337 ± 0.0082', 0.337, '0.0082', {}, None)
+
+    assert sd.details['reported_uncertainty'] == '0.0082'
+    assert 'reported_uncertainty_canonical' not in sd.details
+
+
+def test_a_spread_that_is_not_a_bare_number_is_left_alone():
+    """PwC prints things like '0.3 (n=5)'; guessing at those would be worse."""
+    sd = adapter.score_details(
+        {'id': '1'},
+        '33.7 ± 0.3 (n=5)',
+        0.337,
+        '0.3 (n=5)',
+        {},
+        None,
+        {'canonical_rescale_factor': 0.01},
+    )
+
+    assert sd.details['reported_uncertainty'] == '0.3 (n=5)'
+    assert 'reported_uncertainty_canonical' not in sd.details
+
+
 def test_source_metadata_provenance_reflects_source():
     # local --dump: no bucket provenance claim, records the dump file name
     local = adapter.build_source_metadata(


### PR DESCRIPTION
`adapters/paperswithcode` maps source values onto the registry's canonical scale — a percent-reported accuracy is published as `0.337` with `canonical_rescale_factor: 0.01`. The `±` figure beside it is kept verbatim, so a published record reads:

    score: 0.337
    canonical_rescale_factor: 0.01
    reported_uncertainty: "0.82"

A spread wider than the metric's whole range, in the same details map, with nothing saying the two are on different scales.

**What changes.** `reported_uncertainty` stays exactly what the source printed — published records already use that key, and redefining it would make old and new records disagree silently. `reported_uncertainty_canonical` is added: the same number on the scale `score` is on, present only when a rescale was applied and the spread is a bare number. PwC also prints `0.3 (n=5)`, and guessing at those would be worse than leaving them.

No typed `Uncertainty` either way. PwC's `±` does not declare whether it is a standard error, a standard deviation or a CI half-width, and this adapter's existing comment says so — that reasoning is untouched.

**How it was found.** Comparing this adapter against #260, which reads the same dump and had the same defect. Neither PR review caught it; the comparison did. #260's fix now follows the convention set here.

Three tests: a rescaled row, an unrescaled one (which must *not* repeat the figure under a second key), and a non-numeric spread. 922 passed, 32 skipped; ruff clean.