### PR TITLE
Give the Terminal-Bench metric a join key

### DIFF
--- a/every_eval_ever/adapters/terminal_bench_2/adapter.py
+++ b/every_eval_ever/adapters/terminal_bench_2/adapter.py
@@ -328,6 +328,12 @@ def convert_entry(
         evaluation_timestamp=date,
         metric_config=MetricConfig(
             evaluation_description='Task resolution accuracy across 87 terminal tasks with 5 trials each',
+            # Namespaced, not the registry's `accuracy`: this is the share of 87
+            # tasks resolved, averaged over 5 trials each, on the leaderboard's
+            # own percent scale. The registry carries no Terminal-Bench metric,
+            # and joining a trial-averaged resolution rate to plain `accuracy`
+            # would merge two different quantities.
+            metric_id='terminal-bench-2.0.accuracy',
             metric_name='Accuracy',
             metric_kind='accuracy',
             metric_unit='percent',

--- a/tests/test_terminal_bench_2_adapter.py
+++ b/tests/test_terminal_bench_2_adapter.py
@@ -31,6 +31,24 @@ def test_normalized_entries_convert_and_validate(tmp_path: Path):
         assert report.valid, report.errors
 
 
+def test_the_metric_carries_a_join_key_that_is_not_plain_accuracy():
+    """A trial-averaged resolution rate must not join to registry `accuracy`.
+
+    The metric had no `metric_id` at all, so nothing tied these scores together
+    across refreshes. The registry carries no Terminal-Bench metric, so the id is
+    namespaced: it claims a stable join key within this source and no global
+    identity, the same shape `mmlu_pro` uses.
+    """
+    bundles = adapter.make_logs([_entry()], retrieved_timestamp='1234567890.0')
+
+    metric = bundles[0][0].evaluation_results[0].metric_config
+    assert metric.metric_id == 'terminal-bench-2.0.accuracy'
+    # The percent scale and its bounds are the leaderboard's own and unchanged;
+    # only the missing id is being filled in here.
+    assert metric.metric_unit == 'percent'
+    assert (metric.min_score, metric.max_score) == (0, 100)
+
+
 def test_custom_leaderboard_url_is_recorded_as_source():
     leaderboard_url = 'https://example.com/terminal-bench-2'
 


### PR DESCRIPTION
Found while sweeping for the `±` scaling defect (#276). Two things looked wrong; only one is.

**Real: no `metric_id`.** `terminal_bench_2` set none, so nothing ties these scores to each other across refreshes, let alone to another source. Now `terminal-bench-2.0.accuracy` — namespaced, not the registry's `accuracy`, for two reasons. The registry carries no Terminal-Bench metric, and this number is the share of 87 tasks resolved *averaged over 5 trials each*, which is not the quantity plain `accuracy` names. Joining the two would merge different measurements, the same trap as `pass@k` versus `pass^k`. Same shape `mmlu_pro` uses for an unregistered metric.

**Not real: the percent scale.** I flagged `[0, 100]` as diverging from `fields.md`'s "an accuracy-family metric takes the registry entry's `[0, 1]`" — but that presumes an entry to resolve, and there is none. The registry itself carries 44 metrics at `[0, 100]` against 213 at `[0, 1]`, so scale is per-metric there too. This adapter's bounds, `metric_unit: percent` and its standard error are all on one scale and internally consistent, so there is nothing here I am sure enough to change. Whether an *unregistered* metric should be rescaled anyway is what #246 is arguing for the converters, and it belongs there.

**Seven other adapters also set no `metric_id`** — `exgentic`, `global_mmlu_lite`, `hfopenllm_v2`, `multi_swe_bench`, `rewardbench`, `swe_bench_verified`, `swe_polybench`. Each needs its own judgement about whether its metric *is* a registry canonical (`global_mmlu_lite`'s MCQ accuracy probably is; `swe_bench_verified`'s resolved rate probably is not), so they want one PR each rather than a blanket edit. Happy to work through them.

One test, asserting the id and that the scale is unchanged. 920 passed, 32 skipped; ruff clean.