### PR TITLE
Tag BenchPress metric direction and split its unconvertible-row failure reasons

### DIFF
--- a/every_eval_ever/adapters/benchpress/adapter.py
+++ b/every_eval_ever/adapters/benchpress/adapter.py
@@ -111,6 +111,15 @@ METRIC_BOUNDS = {
     'raw': (-INF, INF),
 }
 
+# metric_type -> lower_is_better, for the families whose direction the metric
+# itself fixes. Consulted only when a benchmark states no `higher_is_better`, so
+# a declared flag always wins. An error rate goes down; a score goes up.
+METRIC_DIRECTION = {
+    'wer': True, 'dollars': True,
+    'pct': False, 'bleu': False, 'elo': False,
+    'rating': False, 'index': False, 'raw': False,
+}
+
 # Recognized eval FRAMEWORKS that may appear in the free-text harness field.
 RECOGNIZED_HARNESS = {
     'lm-evaluation-harness': 'lm-evaluation-harness', 'lm-eval': 'lm-evaluation-harness',
@@ -411,6 +420,25 @@ def metric_bounds(benchmark: dict) -> tuple[float, float, str]:
     return -INF, INF, 'unbounded_default'
 
 
+def metric_direction(benchmark: dict) -> tuple[bool, str]:
+    """(lower_is_better, source) for a benchmark's metric.
+
+    A benchmark's own ``higher_is_better`` wins; otherwise the metric family
+    fixes the direction (an error rate goes down, a score goes up). The schema
+    requires a bool, so where neither settles it higher-is-better is assumed and
+    the source is tagged ``unknown`` -- a guessed direction is never recorded as
+    a stated one. ``source`` is ``declared``, ``metric_family`` or ``unknown``.
+    """
+    cs = benchmark.get('canonical_setting') or {}
+    higher = cs.get('higher_is_better')
+    if isinstance(higher, bool):
+        return (higher is False), 'declared'
+    metric_type = cs.get('metric_type')
+    if metric_type in METRIC_DIRECTION:
+        return METRIC_DIRECTION[metric_type], 'metric_family'
+    return False, 'unknown'
+
+
 def _within_bounds(score: float, bounds: MetricConfig) -> bool:
     """Whether a score sits inside the bounds the record itself declares.
 
@@ -465,6 +493,7 @@ def make_evaluation_result(score: dict, benchmark: dict) -> EvaluationResult | N
     metric_type = cs.get('metric_type')
     bslug = _slug(benchmark['id'])
     lo, hi, bound_strategy = metric_bounds(benchmark)
+    lower_is_better, direction_source = metric_direction(benchmark)
 
     ref_url = score.get('reference_url')
     dataset_url = benchmark.get('source_url')
@@ -501,12 +530,13 @@ def make_evaluation_result(score: dict, benchmark: dict) -> EvaluationResult | N
             metric_name=benchmark.get('metric') or (metric_type or 'score'),
             metric_kind=metric_type or 'score',
             metric_unit=METRIC_UNIT.get(metric_type, 'points'),
-            lower_is_better=(cs.get('higher_is_better') is False),
+            lower_is_better=lower_is_better,
             score_type=ScoreType.continuous,
             min_score=lo,
             max_score=hi,
             additional_details=_str_map({
                 'bound_strategy': bound_strategy,
+                'direction_source': direction_source,
                 'benchpress_metric_type': metric_type,
                 'benchpress_harness': harness,
                 'eval_framework': harness_canon,

--- a/every_eval_ever/adapters/benchpress/adapter.py
+++ b/every_eval_ever/adapters/benchpress/adapter.py
@@ -645,9 +645,21 @@ def make_logs(payload: dict[str, Any],
             ))
             continue
         if result is None:
+            missing = [
+                label for label, present in (
+                    (f"model_id {score['model_id']!r}", model is not None),
+                    (f"benchmark_id {score['benchmark_id']!r}", benchmark is not None),
+                ) if not present
+            ]
+            reason = (
+                f'{" and ".join(missing)} not in this export, so the score has '
+                'no model or benchmark metadata to convert'
+                if missing else
+                'the source row carries no score value'
+            )
             failures.append(SourceRecordFailure(
                 source_ref=_score_ref(score),
-                reason='no score, or the model/benchmark id is not in this export',
+                reason=reason,
                 source_record=score,
             ))
             continue

--- a/tests/test_benchpress_adapter.py
+++ b/tests/test_benchpress_adapter.py
@@ -244,6 +244,48 @@ def test_unbounded_metric_uses_infinity():
     assert rating.max_score == float("inf")
 
 
+def test_direction_falls_back_to_family_then_unknown_and_is_tagged():
+    """A declared higher_is_better wins; where absent the metric family fixes
+    the direction (WER goes down), and a genuinely unknown direction is tagged
+    so a guess is never recorded as a stated one."""
+    payload = sample_payload()
+    payload["benchmarks"] += [
+        {"id": "asr_wer", "name": "ASR WER", "category": "Speech",
+         "metric": "WER", "source_url": None,
+         "canonical_setting": {"metric_type": "wer"}},   # no higher_is_better
+        {"id": "mystery", "name": "Mystery", "category": "Misc",
+         "metric": "f1", "source_url": None,
+         "canonical_setting": {"metric_type": "f1"}},     # family + flag unknown
+    ]
+    payload["scores"] += [
+        {"model_id": "gpt-oss-120b", "benchmark_id": "asr_wer", "score": 0.15,
+         "reference_url": "https://x.example/wer", "source_type": "leaderboard",
+         "audit_status": "verified"},
+        {"model_id": "gpt-oss-120b", "benchmark_id": "mystery", "score": 0.9,
+         "reference_url": "https://x.example/f1", "source_type": "leaderboard",
+         "audit_status": "verified"},
+    ]
+    third = next(
+        b.log for b in adapter.make_logs(payload).records
+        if b.developer == "openai"
+        and b.log.source_metadata.evaluator_relationship.value == "third_party")
+    by_id = {r.evaluation_result_id: r.metric_config
+             for r in third.evaluation_results}
+
+    wer = by_id["asr-wer"]
+    assert wer.lower_is_better is True
+    assert wer.additional_details["direction_source"] == "metric_family"
+
+    mystery = by_id["mystery"]
+    assert mystery.lower_is_better is False
+    assert mystery.additional_details["direction_source"] == "unknown"
+
+    # The benchmark that states higher_is_better keeps it, tagged `declared`.
+    rating = by_id["codeforces-rating"]
+    assert rating.lower_is_better is False
+    assert rating.additional_details["direction_source"] == "declared"
+
+
 def test_version_provenance_recorded():
     details = _logs_by_relationship()["other"].log.source_metadata.additional_details
     assert details["benchpress_source_git_commit"] == "5be3b4eddf0188721ff25f00713b589b2cbed8e0"

--- a/tests/test_benchpress_adapter.py
+++ b/tests/test_benchpress_adapter.py
@@ -343,6 +343,30 @@ def test_a_score_that_will_not_parse_fails_only_its_own_row(tmp_path):
         assert validate_file(path).valid
 
 
+def test_missing_metadata_and_no_score_are_reported_as_distinct_reasons():
+    """A benchmark absent from the export, a model absent, and a row with no
+    score value are three different problems and must not share one reason."""
+    payload = sample_payload()
+    payload['scores'] += [
+        {'model_id': 'gpt-oss-120b', 'benchmark_id': 'not_a_benchmark',
+         'score': 12.0, 'reference_url': 'https://x.invalid',
+         'source_type': 'leaderboard', 'audit_status': 'verified'},
+        {'model_id': 'not_a_model', 'benchmark_id': 'aime_2025', 'score': 12.0,
+         'reference_url': 'https://y.invalid', 'source_type': 'leaderboard',
+         'audit_status': 'verified'},
+        {'model_id': 'gpt-oss-120b', 'benchmark_id': 'aime_2025', 'score': None,
+         'reference_url': 'https://z.invalid', 'source_type': 'leaderboard',
+         'audit_status': 'verified'},
+    ]
+    by_ref = {f.source_ref: f.reason for f in adapter.make_logs(payload).failures}
+
+    assert "benchmark_id 'not_a_benchmark' not in this export" in (
+        by_ref['gpt-oss-120b/not_a_benchmark'])
+    assert "model_id 'not_a_model' not in this export" in (
+        by_ref['not_a_model/aime_2025'])
+    assert by_ref['gpt-oss-120b/aime_2025'] == 'the source row carries no score value'
+
+
 def test_a_schema_error_is_recorded_against_its_source_row():
     """A field the schema rejects is bad source data, not an aborted run."""
     payload = sample_payload()


### PR DESCRIPTION
These two commits were made on #197 after it had already merged at its pre-refinement head 8d33cdf70, so they never landed on main. This PR carries them.

**Direction resolution.** lower_is_better now comes from the benchmark's declared higher_is_better where present, falls back to the metric family for fixed-direction metrics like WER, and records the resolved source in metric_config.additional_details.direction_source. A direction that neither settles stays higher-is-better as the schema requires and is tagged unknown, so a guessed direction is never recorded as a stated one. On the current microsoft/benchpress-score-matrix snapshot this tags 6 results unknown that previously defaulted to higher-is-better silently.

**Failure reasons.** A row that produced no result was reported with one combined reason covering a missing model id, a missing benchmark id, and an absent score value. Each now names the cause that actually applies. On the live snapshot the 7 aider_polyglot rows read as a benchmark absent from the export instead of the ambiguous combined message.

Validated against the live dataset before opening this. 8713 source scores produce 468 logs with 400 excluded and 20 failed, and the non-zero exit lands as a tolerated partial refresh. New tests cover the three-tier direction resolution and the three distinct failure reasons. Full benchpress and adapter-catalog suites pass and ruff is clean.