### PR TITLE
Declare the scale you computed on, rather than converting toward a guess

### DIFF
--- a/.agents/skills/eee-dataset-conversion/reference/datastore-gate.md
+++ b/.agents/skills/eee-dataset-conversion/reference/datastore-gate.md
@@ -56,7 +56,13 @@ Re-derive this list from `REGISTERED_CHECKS`, `_DEPLOYMENT_TYPES`,
   bounds the *source's* numbers live in, and convert deliberately if you rescale.
 - `score_type: continuous` requires both bounds; a supplied-but-unparseable bound is
   also an error. `±inf` is accepted (serialized as the JSON strings
-  `"Infinity"`/`"-Infinity"`); `null` is "not provided", never "unbounded".
+  `"Infinity"`/`"-Infinity"`); `null` is "not provided", never "unbounded". Omitting
+  `score_type` is how a metric whose range you cannot establish stays gate-clean — see
+  `fields.md` §metric_config.
+- **The join key is `metric_id` *plus* the bounds.** Scores are declared on the scale
+  their source computed on, so two records sharing a `metric_id` are comparable only
+  when their `[min_score, max_score]` agree. A consumer normalizes from the declared
+  bounds; a producer does not rescale toward a guess.
 - Uncertainty must be finite where present: `standard_deviation`,
   `standard_error.value`, `confidence_interval.{lower,upper,confidence_level}`.
 

--- a/.agents/skills/eee-dataset-conversion/reference/fields.md
+++ b/.agents/skills/eee-dataset-conversion/reference/fields.md
@@ -152,18 +152,26 @@ comes from **`evaluation_results[0].source_data.dataset_name`** unless you pass
   - Keeping `accuracy` on two benchmarks apart is **`evaluation_name`'s job**, not the
     metric id's. Don't smuggle the benchmark into `metric_id` to get separation you
     already have.
-- **The canonical *scale* is a property of the metric, and it comes from the registry
-  entry — not from whatever scale the source printed.** The registry stores bounds per
-  metric: every accuracy-family entry is `[0,1]`, while benchmark-specific judge scores
-  (`mmau-pro-open-ended-judge-score`, `mteb-score`) are `[0,100]`. So take
-  `min_score`/`max_score`/`lower_is_better`/`score_type` from the resolved entry, and
-  **convert the source value onto that scale** (a leaderboard's `62.65` becomes
-  `0.6265` for `accuracy`, `metric_unit: proportion`). Convert the uncertainty with
-  it — a standard error is a spread in the score's units — and keep the source's raw
-  figure in `score_details.details` so the conversion stays auditable. Never invent a
-  bound to fit the number you scraped; if the metric isn't in the registry, register it
-  from a cited definition (the `paperswithcode` adapter's `METRIC_MAINTENANCE.md` is
-  the worked example) rather than guessing.
+- **Declare the scale you computed on; convert only when you can prove the mapping.**
+  Bounds are per metric, not per repo — the registry itself carries 213 metrics on
+  `[0,1]` and 44 on `[0,100]` — so `min_score`/`max_score` say which scale *this* score
+  is on, and a consumer normalizes from them. Take them from the resolved registry entry
+  when the metric resolves; take them from the metric's definition in the harness that
+  computed it when it does not (sacrebleu's `bleu` is 0–100, nltk's `sentence_bleu` is
+  0–1 — the bare name cannot carry a range). A metric whose range you cannot establish
+  gets **no bounds**, no `score_type`, and an `additional_details.bounds_status:
+  unknown`: "not provided" is true where `[0,1]` on an unbounded metric is a lie.
+  Never invent a bound to fit the number you scraped.
+- **If you do convert, prove it and record it.** Rescaling a published figure onto
+  another scale asserts a mapping the source never stated, and a wrong guess is a wrong
+  number no reader can detect. Convert only where the source states its scale or the
+  metric's definition fixes it; then record the factor (`canonical_rescale_factor` and
+  why, as `adapters/paperswithcode` does), keep the source's own figure in
+  `score_details.details`, and **scale the uncertainty with the score** — a spread is in
+  the score's units, and left alone it reads as wider than the metric's whole range
+  (#276). A metric missing from the registry is worth registering from a cited
+  definition (`paperswithcode`'s `METRIC_MAINTENANCE.md` is the worked example), which is
+  a better fix than rescaling toward a guess.
 - `metric_config.llm_scoring` — required shape for judge/rubric-scored metrics:
   `judges` (≥1, and each `JudgeConfig` needs a **full `model_info`** for the judge model)
   plus `input_prompt`, the actual judging prompt template (not a paraphrase or a


### PR DESCRIPTION
Settles a contradiction an adapter author currently hits head-on.

`fields.md` said: *the canonical scale is a property of the metric, it comes from the registry entry, so take the bounds from the resolved entry and* ***convert the source value onto that scale***.

#246 says the opposite for the harness converters: the range comes from the metric's name layered per harness, because sacrebleu's `bleu` is 0–100 while nltk's `bleu_1` is 0–1, and a metric in no table gets no bounds, no `score_type`, and a `bounds_status: unknown` marker.

**Settled toward #246**, on three grounds.

A consumer holding declared bounds can normalize at read time. A producer that converts and guesses wrong publishes a number no reader can detect as wrong — and `adapters/paperswithcode`, the one adapter that does rescale, needs a `scale_anomaly` marker for values it cannot place, which is what guessing looks like in practice. Meanwhile the registry itself carries 213 metrics on `[0,1]` and 44 on `[0,100]`, so there was never one canonical scale to convert toward.

**What changes in the docs.** `fields.md`'s convert-onto-canonical bullet becomes two: declare the scale you computed on and mark an unestablishable range `unknown`; and if you do convert, prove the mapping and record the factor, the source figure, and the uncertainty scaled with the score (#276). `datastore-gate.md` §score gains the join contract — **`metric_id` plus the bounds** — since two records sharing an id are comparable only when their ranges agree. That deliberately puts normalizing on consumers, which is the real cost of this choice and is now written down.

**What it settles elsewhere.** #246 needs no change. `terminal_bench_2`'s percent scale is correct as it stands (#277 gives it the join key it was missing). And no published score changes, where the other choice would have rewritten five adapters' numbers.

Net +8 lines on the skill, both bullets rewritten in place. 919 passed, 32 skipped, `test_skill_conversion.py` included.