### PR TITLE
Fix HELM test fixture paths left on pre-#248 colon names

### DIFF
--- a/tests/test_helm_adapter.py
+++ b/tests/test_helm_adapter.py
@@ -279,7 +279,7 @@ def test_num_samples_follows_the_split_a_score_was_computed_on():
     adapter = HELMAdapter()
     converted_eval = _load_eval(
         adapter,
-        'tests/data/helm/mmlu:subject=philosophy,'
+        'tests/data/helm/mmlu-subject=philosophy,'
         'method=multiple_choice_joint,model=openai_gpt2',
         {
             'source_organization_name': 'TestOrg',
@@ -376,7 +376,7 @@ def test_sample_count_survives_a_run_without_per_instance_stats():
 
     adapter = HELMAdapter()
     source = Path(
-        'tests/data/helm/mmlu:subject=philosophy,'
+        'tests/data/helm/mmlu-subject=philosophy,'
         'method=multiple_choice_joint,model=openai_gpt2'
     )
 


### PR DESCRIPTION
Two tests in test_helm_adapter.py still point at the old colon fixture path that PR #248 renamed away, so main fails whenever the full CI job runs with the helm extra installed.

## What broke
PR #248 renamed the HELM fixture directories to drop Windows-incompatible colons and updated most references, but two inline path literals kept the old `mmlu:subject=...` name. The directory on disk is `mmlu-subject=...`, so the tests raise FileNotFoundError.

## Why it stayed hidden
Both tests are gated by `skipif(_HELM_IMPORT_ERROR)`. The core CI job has no helm extra and skips them, staying green. Only the full job installs the helm extra and runs them, and that job went red.

## Fix
Point the two literals at the hyphen name that matches the committed fixtures and every other reference in the file.

## Verification
With all extras installed to mirror the full job, the suite is 1108 passed, 1 skipped, 0 failed. The one remaining skip is the pre-existing `helm declares no required source paths` case.