### PR TITLE
Add aiXamine adapter

### DIFF
--- a/every_eval_ever/adapters/aixamine/__init__.py
+++ b/every_eval_ever/adapters/aixamine/__init__.py
@@ -1,0 +1,1 @@
+"""aiXamine adapter package."""

--- a/every_eval_ever/adapters/aixamine/adapter.py
+++ b/every_eval_ever/adapters/aixamine/adapter.py
@@ -76,8 +76,20 @@ def _model_details(access_type):
     return {"deployment_type": "externally_managed", "model_availability": "closed_weights"}
 
 
-def _model_id(model):
+def _access_date(model):
+    ts = model.get("createdAt") or ""
+    return ts[:10] if len(ts) >= 10 else None
+
+
+def _dated_name(model):
     name = model["name"]
+    if model.get("accessType") == "huggingface":
+        return name
+    date = _access_date(model)
+    return f"{name}-{date}" if date else name
+
+
+def _model_id(name, model):
     if "/" in name:
         return name
     dev = model.get("developer")
@@ -141,9 +153,10 @@ def _static_categories(cats):
 
 def build_service_logs(report, model, catalog, retrieved_ts):
     """One EvaluationLog per service present in the report (static + dynamic)."""
-    model_id = _model_id(model)
+    name = _dated_name(model)
     developer = _resolve_developer(model)
-    mi = ModelInfo(name=model["name"], id=model_id, developer=developer,
+    model_id = _model_id(name, model)
+    mi = ModelInfo(name=name, id=model_id, developer=developer,
                    additional_details=_model_details(model.get("accessType")))
 
     # catalog lookups: service_value -> {name, tests:{test_value:{name,description}}}
@@ -186,7 +199,7 @@ def build_service_logs(report, model, catalog, retrieved_ts):
         collection = collection_for(svc_value)
         log = EvaluationLog(
             schema_version=SCHEMA_VERSION,
-            evaluation_id=f"{collection}/{developer}_{model['name'].replace('/', '_')}",
+            evaluation_id=f"{collection}/{developer}_{name.replace('/', '_')}",
             retrieved_timestamp=retrieved_ts,
             source_metadata=SourceMetadata(
                 source_name=collection,
@@ -205,7 +218,7 @@ def build_service_logs(report, model, catalog, retrieved_ts):
             model_info=mi,
             evaluation_results=results,
         )
-        logs.append((collection, developer, model["name"], log))
+        logs.append((collection, developer, name, log))
     return logs
 
 

--- a/every_eval_ever/adapters/aixamine/adapter.py
+++ b/every_eval_ever/adapters/aixamine/adapter.py
@@ -84,6 +84,14 @@ def _model_id(model):
     return f"{dev}/{name}" if dev else name
 
 
+def _resolve_developer(model):
+    dev = (model.get("developer") or "").strip()
+    if dev:
+        return dev
+    name = model.get("name", "")
+    return name.split("/")[0] if "/" in name else None
+
+
 def _metric_config(test_value, description):
     """aiXamine scores are a 0-100 rate (safe / pass / accepted); higher is better."""
     return MetricConfig(
@@ -134,7 +142,7 @@ def _static_categories(cats):
 def build_service_logs(report, model, catalog, retrieved_ts):
     """One EvaluationLog per service present in the report (static + dynamic)."""
     model_id = _model_id(model)
-    developer = model.get("developer") or (model_id.split("/")[0] if "/" in model_id else "unknown")
+    developer = _resolve_developer(model)
     mi = ModelInfo(name=model["name"], id=model_id, developer=developer,
                    additional_details=_model_details(model.get("accessType")))
 
@@ -254,6 +262,8 @@ def enumerate_reports(base, access_type=None, page_size=50, max_pages=None):
 
 def _outputs_for(report, model, catalog, out_root, retrieved_ts, outputs, failures):
     """Append this (report, model)'s service logs to outputs / failures."""
+    if _resolve_developer(model) is None:
+        return
     try:
         logs = build_service_logs(report, model, catalog, retrieved_ts)
     except Exception as exc:

--- a/every_eval_ever/adapters/aixamine/adapter.py
+++ b/every_eval_ever/adapters/aixamine/adapter.py
@@ -1,0 +1,334 @@
+"""aiXamine adapter — converts aiXamine public-API evaluation reports into EEE.
+
+aiXamine (https://aixamine.qcri.org) is a safety, security and privacy-focused LLM trust-evaluation
+platform. It groups 46 static + 5 dynamic tests into 9 services. This adapter
+reads the aiXamine PUBLIC API and emits one aggregate EEE
+log per (model, service):
+
+    data/aixamine_<service>/<developer>/<model>/<uuid>.json
+
+Each service log carries that service's PUBLIC tests as evaluation_results, plus a
+per-category sub-result.
+
+Usage:
+    # offline, from a captured fixture bundle (report.json, model.json, services.json)
+    uv run python -m every_eval_ever.adapters.aixamine.adapter --input-dir <dir>
+    # live against the aiXamine public API
+    uv run python -m every_eval_ever.adapters.aixamine.adapter \
+        --api-url https://aixamine.qcri.org/api/v1 --report-id <id>
+"""
+import argparse
+import json
+import time
+from pathlib import Path
+
+from every_eval_ever.eval_types import (
+    EvalLibrary,
+    EvaluationLog,
+    EvaluationResult,
+    EvaluatorRelationship,
+    MetricConfig,
+    ModelInfo,
+    ScoreDetails,
+    ScoreType,
+    SourceDataPrivate,
+    SourceMetadata,
+)
+from every_eval_ever.helpers import (
+    SCHEMA_VERSION,
+    EvaluationLogOutput,
+    SourceConversionResult,
+    SourceRecordFailure,
+    default_failure_report_path,
+    fetch_json,
+    save_evaluation_logs,
+    save_failure_report,
+)
+
+SRC = "aixamine"
+ORG_NAME = "aiXamine"
+HOMEPAGE = "https://aixamine.qcri.org"
+PAPER = "https://arxiv.org/abs/2608.20554"
+
+# aiXamine tests that map to an existing canonical EEE benchmark ids
+CANONICAL = {
+    "simpleqa": "simpleqa",
+    "truthfulqa": "truthfulqa",
+    "triviaqa": "triviaqa",
+    "bbq": "bbq",
+    "xs-test": "xstest",
+    "simple-safety": "simplesafetytests",
+    "anthropic-redteam": "anthropic-red-team",
+}
+
+
+def collection_for(service_value):
+    return f"{SRC}_{service_value.replace('-', '_')}"
+
+
+def benchmark_id(test_value):
+    return CANONICAL.get(test_value, test_value)
+
+
+def _model_details(access_type):
+    if access_type == "huggingface":
+        return {"deployment_type": "self_deployed", "model_availability": "open_weights"}
+    return {"deployment_type": "externally_managed", "model_availability": "closed_weights"}
+
+
+def _model_id(model):
+    name = model["name"]
+    if "/" in name:
+        return name
+    dev = model.get("developer")
+    return f"{dev}/{name}" if dev else name
+
+
+def _metric_config(test_value, description):
+    """aiXamine scores are a 0-100 rate (safe / pass / accepted); higher is better."""
+    return MetricConfig(
+        evaluation_description=description or None,
+        metric_id=f"{SRC}.rate",
+        metric_name="score",
+        metric_kind="accuracy",
+        metric_unit="percent",
+        lower_is_better=False,
+        score_type=ScoreType.continuous,
+        min_score=0.0,
+        max_score=100.0,
+    )
+
+
+def _result(service, test_value, name, description, score, categories, eval_ts):
+    """One overall result for a test + dotted per-category sub-results."""
+    bid = benchmark_id(test_value)
+    results = [
+        EvaluationResult(
+            evaluation_result_id=f"{SRC}.{service}.{test_value}",
+            evaluation_name=bid,
+            evaluation_timestamp=eval_ts,
+            source_data=SourceDataPrivate(dataset_name=bid, source_type="other"),
+            metric_config=_metric_config(test_value, description),
+            score_details=ScoreDetails(score=float(score)),
+        )
+    ]
+    for cat, cscore in (categories or {}).items():
+        results.append(
+            EvaluationResult(
+                evaluation_result_id=f"{SRC}.{service}.{test_value}.{cat}",
+                evaluation_name=f"{bid}.{cat}",
+                evaluation_timestamp=eval_ts,
+                source_data=SourceDataPrivate(dataset_name=f"{bid} ({cat})", source_type="other"),
+                metric_config=_metric_config(test_value, f"{name} — {cat}"),
+                score_details=ScoreDetails(score=float(cscore)),
+            )
+        )
+    return results
+
+
+def _static_categories(cats):
+    """report static categories: {cat: {score, subcategories:[...]}} -> {cat: score}."""
+    return {c: v.get("score") for c, v in (cats or {}).items() if isinstance(v, dict) and v.get("score") is not None}
+
+
+def build_service_logs(report, model, catalog, retrieved_ts):
+    """One EvaluationLog per service present in the report (static + dynamic)."""
+    model_id = _model_id(model)
+    developer = model.get("developer") or (model_id.split("/")[0] if "/" in model_id else "unknown")
+    mi = ModelInfo(name=model["name"], id=model_id, developer=developer,
+                   additional_details=_model_details(model.get("accessType")))
+
+    # catalog lookups: service_value -> {name, tests:{test_value:{name,description}}}
+    svc_meta = {s["value"]: s for s in catalog}
+
+    logs = []  # (collection, developer, model_name, EvaluationLog)
+    services = {}  # service_value -> list[EvaluationResult]
+
+    # static
+    for svc_value, svc in (report.get("services") or {}).items():
+        tests = svc.get("tests") or {}
+        for tv, tdata in tests.items():
+            if tdata.get("score") is None:
+                continue
+            tmeta = _catalog_test(svc_meta, svc_value, tv)
+            ets = _iso_from(tdata)
+            services.setdefault(svc_value, []).extend(
+                _result(svc_value, tv, tmeta.get("name", tv), tmeta.get("description"),
+                        tdata["score"], _static_categories(tdata.get("categories")), ets)
+            )
+
+    # dynamic (latest version per test)
+    for svc_value, svc in ((report.get("dynamic") or {}).get("services") or {}).items():
+        tests = svc.get("tests") or {}
+        for tv, tdata in tests.items():
+            versions = tdata.get("versions") or []
+            if not versions:
+                continue
+            v = versions[0]
+            if v.get("score") is None:
+                continue
+            tmeta = _catalog_test(svc_meta, svc_value, tv)
+            services.setdefault(svc_value, []).extend(
+                _result(svc_value, tv, tmeta.get("name", tv), tmeta.get("description"),
+                        v["score"], v.get("categories"), v.get("generatedAt"))
+            )
+
+    for svc_value, results in services.items():
+        smeta = svc_meta.get(svc_value, {})
+        collection = collection_for(svc_value)
+        log = EvaluationLog(
+            schema_version=SCHEMA_VERSION,
+            evaluation_id=f"{collection}/{developer}_{model['name'].replace('/', '_')}",
+            retrieved_timestamp=retrieved_ts,
+            source_metadata=SourceMetadata(
+                source_name=collection,
+                source_type="documentation",
+                source_organization_name=ORG_NAME,
+                source_organization_url=HOMEPAGE,
+                evaluator_relationship=EvaluatorRelationship.first_party,
+                additional_details={
+                    "service": svc_value,
+                    "service_name": smeta.get("name", svc_value),
+                    "paper": PAPER,
+                    "homepage": HOMEPAGE,
+                },
+            ),
+            eval_library=EvalLibrary(name=SRC, version="unknown"),
+            model_info=mi,
+            evaluation_results=results,
+        )
+        logs.append((collection, developer, model["name"], log))
+    return logs
+
+
+def _catalog_test(svc_meta, svc_value, test_value):
+    svc = svc_meta.get(svc_value, {})
+    for t in svc.get("tests", []):
+        if t.get("value") == test_value:
+            return t
+    return {}
+
+
+def _iso_from(tdata):
+    return None  # static tests carry a duration, not a wall-clock timestamp in the report
+
+
+# ── Fetch ────────────────────────────────────────────────────────────────────
+
+def _catalog(catalog):
+    return catalog["services"] if isinstance(catalog, dict) and "services" in catalog else catalog
+
+
+def _bundle_from_fixture(input_dir):
+    d = Path(input_dir)
+    return (json.load(open(d / "report.json")),
+            json.load(open(d / "model.json")),
+            _catalog(json.load(open(d / "services.json"))))
+
+
+def _bundle_live(base, report_id):
+    report = fetch_json(f"{base}/reports/{report_id}")
+    model = fetch_json(f"{base}/models/{report['model']}")
+    catalog = _catalog(fetch_json(f"{base}/examinations/getServices"))
+    return report, model, catalog
+
+
+def enumerate_reports(base, access_type=None, page_size=50, max_pages=None):
+    """Page through the PUBLIC search endpoint; yield (report_id, model_id, accessType)."""
+    page = 1
+    while True:
+        d = fetch_json(f"{base}/reports/search?page={page}&limit={page_size}")
+        rows = d.get("overview") or []
+        if not rows:
+            break
+        for r in rows:
+            if access_type and r.get("accessType") != access_type:
+                continue
+            if r.get("report") and r.get("_id"):
+                yield r["report"], r["_id"], r.get("accessType")
+        total_pages = d.get("totalPages") or 1
+        if page >= total_pages or (max_pages and page >= max_pages):
+            break
+        page += 1
+
+
+def _outputs_for(report, model, catalog, out_root, retrieved_ts, outputs, failures):
+    """Append this (report, model)'s service logs to outputs / failures."""
+    try:
+        logs = build_service_logs(report, model, catalog, retrieved_ts)
+    except Exception as exc:
+        failures.append(SourceRecordFailure(
+            source_ref=f"{SRC} report {report.get('_id')}", reason=str(exc),
+            source_record={"model": model.get("name")}))
+        return
+    for collection, developer, model_name, log in logs:
+        try:
+            outputs.append(EvaluationLogOutput(
+                eval_log=EvaluationLog.model_validate(log.model_dump()),
+                base_dir=out_root / collection,
+                developer=developer, model_name=model_name))
+        except Exception as exc:
+            failures.append(SourceRecordFailure(
+                source_ref=f"{collection}/{model_name}", reason=str(exc),
+                source_record={"collection": collection, "model": model_name}))
+
+
+def build_result(args, retrieved_ts):
+    out_root, outputs, failures = args.output_dir, [], []
+    if args.input_dir:
+        report, model, catalog = _bundle_from_fixture(args.input_dir)
+        _outputs_for(report, model, catalog, out_root, retrieved_ts, outputs, failures)
+        total = 1
+    else:
+        base = args.api_url.rstrip("/")
+        catalog = _catalog(fetch_json(f"{base}/examinations/getServices"))
+        if args.report_id:
+            pairs = [(args.report_id, None, None)]
+        else:  # --all: enumerate via public search
+            pairs = list(enumerate_reports(base, args.access_type, max_pages=args.max_pages))
+        total = len(pairs)
+        for report_id, model_id, _ in pairs:
+            try:
+                report = fetch_json(f"{base}/reports/{report_id}")
+                model = fetch_json(f"{base}/models/{model_id or report['model']}")
+            except Exception as exc:
+                failures.append(SourceRecordFailure(
+                    source_ref=f"{SRC} report {report_id}", reason=str(exc),
+                    source_record={"report_id": report_id}))
+                continue
+            _outputs_for(report, model, catalog, out_root, retrieved_ts, outputs, failures)
+    return SourceConversionResult(source_name=SRC, total_records=total,
+                                  records=outputs, failures=failures)
+
+
+def parse_args(argv=None):
+    ap = argparse.ArgumentParser(description="Convert aiXamine reports into EEE records")
+    ap.add_argument("--output-dir", type=Path, default=Path(f"/tmp/{SRC}-smoke/data"))
+    ap.add_argument("--input-dir", type=Path, default=None,
+                    help="Fixture dir with report.json/model.json/services.json (offline)")
+    ap.add_argument("--api-url", type=str, default="https://aixamine.qcri.org/api/v1",
+                    help="aiXamine public API base (default: production; pass a dev URL to override)")
+    ap.add_argument("--report-id", type=str, default=None, help="Convert a single report")
+    ap.add_argument("--all", dest="all", action="store_true",
+                    help="Enumerate all public reports via /reports/search (default when no report-id/input-dir)")
+    ap.add_argument("--access-type", type=str, default=None, choices=["huggingface", "openai"],
+                    help="Restrict --all to open-weight (huggingface) or API (openai) models")
+    ap.add_argument("--max-pages", type=int, default=None, help="Cap search pages (testing)")
+    ap.add_argument("--failure-report", type=Path, default=None)
+    return ap.parse_args(argv)
+
+
+def run(args):
+    retrieved_ts = str(time.time())
+    result = build_result(args, retrieved_ts)
+    paths = save_evaluation_logs(result.records)
+    print(f"wrote {len(paths)} logs from {result.total_records} report(s) -> {args.output_dir}")
+    if result.failures:
+        rp = save_failure_report(result, args.failure_report or default_failure_report_path(args.output_dir))
+        print(f"failure report: {rp}")
+        result.raise_if_incomplete()
+    return paths
+
+
+if __name__ == "__main__":
+    run(parse_args())

--- a/every_eval_ever/adapters/aixamine/adapter.py
+++ b/every_eval_ever/adapters/aixamine/adapter.py
@@ -203,7 +203,7 @@ def build_service_logs(report, model, catalog, retrieved_ts):
             retrieved_timestamp=retrieved_ts,
             source_metadata=SourceMetadata(
                 source_name=collection,
-                source_type="documentation",
+                source_type="evaluation_run",
                 source_organization_name=ORG_NAME,
                 source_organization_url=HOMEPAGE,
                 evaluator_relationship=EvaluatorRelationship.first_party,
@@ -242,9 +242,9 @@ def _catalog(catalog):
 
 def _bundle_from_fixture(input_dir):
     d = Path(input_dir)
-    return (json.load(open(d / "report.json")),
-            json.load(open(d / "model.json")),
-            _catalog(json.load(open(d / "services.json"))))
+    return (json.loads((d / "report.json").read_text(encoding="utf-8")),
+            json.loads((d / "model.json").read_text(encoding="utf-8")),
+            _catalog(json.loads((d / "services.json").read_text(encoding="utf-8"))))
 
 
 def _bundle_live(base, report_id):

--- a/every_eval_ever/adapters/aixamine/adapter.py
+++ b/every_eval_ever/adapters/aixamine/adapter.py
@@ -199,7 +199,7 @@ def build_service_logs(report, model, catalog, retrieved_ts):
         collection = collection_for(svc_value)
         log = EvaluationLog(
             schema_version=SCHEMA_VERSION,
-            evaluation_id=f"{collection}/{developer}_{name.replace('/', '_')}",
+            evaluation_id=f"{collection}/{model_id.replace('/', '_')}/{report.get('_id') or retrieved_ts}",
             retrieved_timestamp=retrieved_ts,
             source_metadata=SourceMetadata(
                 source_name=collection,

--- a/every_eval_ever/adapters/aixamine/adapter.py
+++ b/every_eval_ever/adapters/aixamine/adapter.py
@@ -276,6 +276,10 @@ def enumerate_reports(base, access_type=None, page_size=50, max_pages=None):
 def _outputs_for(report, model, catalog, out_root, retrieved_ts, outputs, failures):
     """Append this (report, model)'s service logs to outputs / failures."""
     if _resolve_developer(model) is None:
+        failures.append(SourceRecordFailure(
+            source_ref=f"{SRC} report {report.get('_id')}",
+            reason="model has no developer and its name carries no namespace",
+            source_record={"model": model.get("name")}))
         return
     try:
         logs = build_service_logs(report, model, catalog, retrieved_ts)

--- a/every_eval_ever/adapters/aixamine/adapter.py
+++ b/every_eval_ever/adapters/aixamine/adapter.py
@@ -108,7 +108,7 @@ def _metric_config(test_value, description):
     """aiXamine scores are a 0-100 rate (safe / pass / accepted); higher is better."""
     return MetricConfig(
         evaluation_description=description or None,
-        metric_id=f"{SRC}.rate",
+        metric_id=f"{SRC}.{test_value}",
         metric_name="score",
         metric_kind="accuracy",
         metric_unit="percent",

--- a/every_eval_ever/adapters/aixamine/adapter.py
+++ b/every_eval_ever/adapters/aixamine/adapter.py
@@ -199,7 +199,7 @@ def build_service_logs(report, model, catalog, retrieved_ts):
         collection = collection_for(svc_value)
         log = EvaluationLog(
             schema_version=SCHEMA_VERSION,
-            evaluation_id=f"{collection}/{model_id.replace('/', '_')}/{report.get('_id') or retrieved_ts}",
+            evaluation_id=f"{collection}/{model_id.replace('/', '_')}/{report['_id']}",
             retrieved_timestamp=retrieved_ts,
             source_metadata=SourceMetadata(
                 source_name=collection,
@@ -210,7 +210,7 @@ def build_service_logs(report, model, catalog, retrieved_ts):
                 additional_details={
                     "service": svc_value,
                     "service_name": smeta.get("name", svc_value),
-                    "paper": PAPER,
+                    "paper_url": PAPER,
                     "homepage": HOMEPAGE,
                 },
             ),
@@ -275,6 +275,12 @@ def enumerate_reports(base, access_type=None, page_size=50, max_pages=None):
 
 def _outputs_for(report, model, catalog, out_root, retrieved_ts, outputs, failures):
     """Append this (report, model)'s service logs to outputs / failures."""
+    if not report.get("_id"):
+        failures.append(SourceRecordFailure(
+            source_ref=f"{SRC} report {report.get('_id')}",
+            reason="report has no _id",
+            source_record={"model": model.get("name")}))
+        return
     if _resolve_developer(model) is None:
         failures.append(SourceRecordFailure(
             source_ref=f"{SRC} report {report.get('_id')}",

--- a/every_eval_ever/adapters/catalog.py
+++ b/every_eval_ever/adapters/catalog.py
@@ -220,6 +220,30 @@ def _helm(key: str, leaderboard: str, weekday: int) -> AdapterSpec:
 
 ADAPTERS: tuple[AdapterSpec, ...] = (
     AdapterSpec(
+        key='aixamine',
+        module='every_eval_ever.adapters.aixamine.adapter',
+        collections=(
+            'aixamine_adversarial_robustness',
+            'aixamine_code_security',
+            'aixamine_fairness_bias',
+            'aixamine_hallucination',
+            'aixamine_jailbreak',
+            'aixamine_model_data_privacy',
+            'aixamine_ood_robustness',
+            'aixamine_over_refusal',
+            'aixamine_safety_alignment',
+        ),
+        output_scope='data_root',
+        extra_args=('--all',),
+        cadence='weekly',
+        weekday=0,
+        timeout_minutes=45,
+        notes=(
+            'Enumerates public reports via the aiXamine public API '
+            '(/reports/search) and emits one aggregate log per (model, service). '
+        ),
+    ),
+    AdapterSpec(
         key='arc_agi',
         module='every_eval_ever.adapters.arc_agi.adapter',
         collections=('arc-agi',),

--- a/tests/test_aixamine_adapter.py
+++ b/tests/test_aixamine_adapter.py
@@ -53,8 +53,10 @@ REPORT = {
     },
 }
 
-MODEL_HF = {"name": "meta-llama/Llama-3.1-8B-Instruct", "developer": "meta-llama", "accessType": "huggingface"}
-MODEL_API = {"name": "gpt-5", "developer": "OpenAI", "accessType": "openai"}
+MODEL_HF = {"name": "meta-llama/Llama-3.1-8B-Instruct", "developer": "meta-llama",
+            "accessType": "huggingface", "createdAt": "2026-01-15T10:00:00.000Z"}
+MODEL_API = {"name": "gpt-5", "developer": "OpenAI", "accessType": "openai",
+             "createdAt": "2026-01-15T10:00:00.000Z"}
 
 
 def _save_and_validate(logs, tmp_path) -> list[Path]:
@@ -94,11 +96,21 @@ def test_canonical_mapping_bare_names_and_categories(tmp_path):
 
 def test_api_model_marked_closed_weights(tmp_path):
     logs = aix.build_service_logs(REPORT, MODEL_API, CATALOG, "123")
-    _, _, _, log = logs[0]
-    assert log.model_info.id == "OpenAI/gpt-5"
+    collection, dev, model_name, log = logs[0]
+    # API models get the aiXamine access date appended as a snapshot suffix.
+    assert log.model_info.id == "OpenAI/gpt-5-2026-01-15"
+    assert log.model_info.name == "gpt-5-2026-01-15"
+    assert model_name == "gpt-5-2026-01-15"
     assert log.model_info.additional_details["model_availability"] == "closed_weights"
     assert log.model_info.additional_details["deployment_type"] == "externally_managed"
     _save_and_validate(logs, tmp_path)
+
+
+def test_hf_model_not_date_stamped(tmp_path):
+    logs = aix.build_service_logs(REPORT, MODEL_HF, CATALOG, "123")
+    _, _, model_name, log = logs[0]
+    assert log.model_info.id == "meta-llama/Llama-3.1-8B-Instruct"
+    assert model_name == "meta-llama/Llama-3.1-8B-Instruct"
 
 
 def test_source_metadata_is_first_party_documentation(tmp_path):

--- a/tests/test_aixamine_adapter.py
+++ b/tests/test_aixamine_adapter.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from every_eval_ever.adapters.aixamine import adapter as aix
+from every_eval_ever.eval_types import EvaluationLog
+from every_eval_ever.helpers import EvaluationLogOutput, save_evaluation_logs
+from every_eval_ever.validate import validate_file
+
+CATALOG = [
+    {
+        "value": "hallucination",
+        "name": "Hallucination",
+        "tests": [
+            {"value": "halueval", "name": "HaluEval", "description": "Hallucination eval."},
+            {"value": "simpleqa", "name": "SimpleQA", "description": "Short-form factuality."},
+            {"value": "factqa", "name": "FactQA", "description": "Dynamic factual QA.", "dynamic": True},
+        ],
+    },
+    {
+        "value": "fairness-bias",
+        "name": "Fairness & Bias",
+        "tests": [{"value": "bbq", "name": "BBQ", "description": "Bias benchmark."}],
+    },
+]
+
+REPORT = {
+    "_id": "r1",
+    "model": "m1",
+    "services": {
+        "hallucination": {
+            "tests": {
+                "halueval": {"score": 55.3, "categories": {"QA": {"score": 44.2, "subcategories": []}}},
+                "simpleqa": {"score": 30.0, "categories": {}},
+            }
+        },
+        "fairness-bias": {"tests": {"bbq": {"score": 71.4, "categories": {}}}},
+    },
+    "dynamic": {
+        "services": {
+            "hallucination": {
+                "tests": {
+                    "factqa": {
+                        "versions": [
+                            {"score": 83.5, "testVersion": "v1",
+                             "generatedAt": "2026-06-29T08:22:39.894Z",
+                             "categories": {"LA": 65, "ST": 91.6}}
+                        ]
+                    }
+                }
+            }
+        }
+    },
+}
+
+MODEL_HF = {"name": "meta-llama/Llama-3.1-8B-Instruct", "developer": "meta-llama", "accessType": "huggingface"}
+MODEL_API = {"name": "gpt-5", "developer": "OpenAI", "accessType": "openai"}
+
+
+def _save_and_validate(logs, tmp_path) -> list[Path]:
+    outputs = [
+        EvaluationLogOutput(
+            eval_log=EvaluationLog.model_validate(log.model_dump()),
+            base_dir=tmp_path / "data" / collection,
+            developer=dev,
+            model_name=model_name,
+        )
+        for collection, dev, model_name, log in logs
+    ]
+    paths = save_evaluation_logs(outputs)
+    assert paths
+    for path in paths:
+        report = validate_file(path)
+        assert report.valid, report.errors
+    return paths
+
+
+def test_one_log_per_service_and_validates(tmp_path):
+    logs = aix.build_service_logs(REPORT, MODEL_HF, CATALOG, "123")
+    collections = {c for c, _, _, _ in logs}
+    assert collections == {"aixamine_hallucination", "aixamine_fairness_bias"}
+    _save_and_validate(logs, tmp_path)
+
+
+def test_canonical_mapping_bare_names_and_categories(tmp_path):
+    logs = aix.build_service_logs(REPORT, MODEL_HF, CATALOG, "123")
+    names = {r.evaluation_name for _, _, _, log in logs for r in log.evaluation_results}
+    assert "bbq" in names            # canonical id for a confident match
+    assert "halueval" in names       # bare aiXamine name otherwise
+    assert "halueval.QA" in names    # static category sub-result
+    assert "factqa" in names         # dynamic test (latest version)
+    assert "factqa.LA" in names      # dynamic category sub-result
+
+
+def test_api_model_marked_closed_weights(tmp_path):
+    logs = aix.build_service_logs(REPORT, MODEL_API, CATALOG, "123")
+    _, _, _, log = logs[0]
+    assert log.model_info.id == "OpenAI/gpt-5"
+    assert log.model_info.additional_details["model_availability"] == "closed_weights"
+    assert log.model_info.additional_details["deployment_type"] == "externally_managed"
+    _save_and_validate(logs, tmp_path)
+
+
+def test_source_metadata_is_first_party_documentation(tmp_path):
+    logs = aix.build_service_logs(REPORT, MODEL_HF, CATALOG, "123")
+    _, _, _, log = logs[0]
+    assert log.eval_library.name == "aixamine"
+    assert log.source_metadata.source_type.value == "documentation"
+    assert log.source_metadata.evaluator_relationship.value == "first_party"

--- a/tests/test_aixamine_adapter.py
+++ b/tests/test_aixamine_adapter.py
@@ -135,6 +135,14 @@ def test_evaluation_id_stable_per_report_no_collision(tmp_path):
     assert "meta-llama_meta-llama" not in id1
 
 
+def test_metric_id_is_per_test(tmp_path):
+    logs = aix.build_service_logs(REPORT, MODEL_HF, CATALOG, "123")
+    ids = {r.metric_config.metric_id for _, _, _, log in logs for r in log.evaluation_results}
+    assert "aixamine.halueval" in ids
+    assert "aixamine.bbq" in ids
+    assert "aixamine.rate" not in ids
+
+
 def test_source_metadata_is_first_party_documentation(tmp_path):
     logs = aix.build_service_logs(REPORT, MODEL_HF, CATALOG, "123")
     _, _, _, log = logs[0]

--- a/tests/test_aixamine_adapter.py
+++ b/tests/test_aixamine_adapter.py
@@ -143,9 +143,9 @@ def test_metric_id_is_per_test(tmp_path):
     assert "aixamine.rate" not in ids
 
 
-def test_source_metadata_is_first_party_documentation(tmp_path):
+def test_source_metadata_is_first_party_evaluation_run(tmp_path):
     logs = aix.build_service_logs(REPORT, MODEL_HF, CATALOG, "123")
     _, _, _, log = logs[0]
     assert log.eval_library.name == "aixamine"
-    assert log.source_metadata.source_type.value == "documentation"
+    assert log.source_metadata.source_type.value == "evaluation_run"
     assert log.source_metadata.evaluator_relationship.value == "first_party"

--- a/tests/test_aixamine_adapter.py
+++ b/tests/test_aixamine_adapter.py
@@ -113,6 +113,17 @@ def test_hf_model_not_date_stamped(tmp_path):
     assert model_name == "meta-llama/Llama-3.1-8B-Instruct"
 
 
+def test_missing_developer_records_failure(tmp_path):
+    model_no_dev = {"name": "mystery-model", "accessType": "openai",
+                    "createdAt": "2026-01-15T10:00:00.000Z"}
+    outputs, failures = [], []
+    aix._outputs_for(REPORT, model_no_dev, CATALOG, tmp_path, "123", outputs, failures)
+    assert outputs == []
+    assert len(failures) == 1
+    assert failures[0].source_record == {"model": "mystery-model"}
+    assert "developer" in failures[0].reason
+
+
 def test_source_metadata_is_first_party_documentation(tmp_path):
     logs = aix.build_service_logs(REPORT, MODEL_HF, CATALOG, "123")
     _, _, _, log = logs[0]

--- a/tests/test_aixamine_adapter.py
+++ b/tests/test_aixamine_adapter.py
@@ -124,6 +124,15 @@ def test_missing_developer_records_failure(tmp_path):
     assert "developer" in failures[0].reason
 
 
+def test_missing_report_id_records_failure(tmp_path):
+    report_no_id = {k: v for k, v in REPORT.items() if k != "_id"}
+    outputs, failures = [], []
+    aix._outputs_for(report_no_id, MODEL_HF, CATALOG, tmp_path, "123", outputs, failures)
+    assert outputs == []
+    assert len(failures) == 1
+    assert "_id" in failures[0].reason
+
+
 def test_evaluation_id_stable_per_report_no_collision(tmp_path):
     r1, r2 = {**REPORT, "_id": "r1"}, {**REPORT, "_id": "r2"}
     id1 = aix.build_service_logs(r1, MODEL_HF, CATALOG, "t1")[0][3].evaluation_id

--- a/tests/test_aixamine_adapter.py
+++ b/tests/test_aixamine_adapter.py
@@ -124,6 +124,17 @@ def test_missing_developer_records_failure(tmp_path):
     assert "developer" in failures[0].reason
 
 
+def test_evaluation_id_stable_per_report_no_collision(tmp_path):
+    r1, r2 = {**REPORT, "_id": "r1"}, {**REPORT, "_id": "r2"}
+    id1 = aix.build_service_logs(r1, MODEL_HF, CATALOG, "t1")[0][3].evaluation_id
+    id1b = aix.build_service_logs(r1, MODEL_HF, CATALOG, "t2")[0][3].evaluation_id
+    id2 = aix.build_service_logs(r2, MODEL_HF, CATALOG, "t1")[0][3].evaluation_id
+    assert id1 == id1b
+    assert id1 != id2
+    assert id1.endswith("/r1")
+    assert "meta-llama_meta-llama" not in id1
+
+
 def test_source_metadata_is_first_party_documentation(tmp_path):
     logs = aix.build_service_logs(REPORT, MODEL_HF, CATALOG, "123")
     _, _, _, log = logs[0]


### PR DESCRIPTION
Adds an adapter for **aiXamine** ([aixamine.qcri.org](https://aixamine.qcri.org), [paper](https://arxiv.org/abs/2608.20554)), converting its public-API reports into EEE records — one aggregate log per (model, service) across 9 services.

- `adapters/aixamine/` — the adapter + tests
- `catalog.py` — scheduled entry (9 collections, weekly)

API models are date-stamped with their access date; HF models keep their repo id. Tests pass. Output validates clean.
