### PR TITLE
Stop publishing a pre-v0.4 lm-eval standard error as if it were a score

### DIFF
--- a/every_eval_ever/converters/common/metrics.py
+++ b/every_eval_ever/converters/common/metrics.py
@@ -100,6 +100,9 @@ CANONICAL_METRIC_IDS: dict[str, str] = {
     'exact_match': 'exact-match',
     'f1': 'f1',
     'f1_score': 'f1',
+    # lm-eval v0.3 reports perplexity under `ppl` (v0.4 renamed it), so both
+    # spellings reach the one registry metric rather than fragmenting by format.
+    'ppl': 'perplexity',
     'perplexity': 'perplexity',
     'precision': 'precision',
     'recall': 'recall',

--- a/every_eval_ever/converters/common/metrics.py
+++ b/every_eval_ever/converters/common/metrics.py
@@ -85,6 +85,12 @@ METRIC_ID_REGISTRY_REVISION = '8b83e9c'
 # Only names the registry actually carries appear here; the rest are namespaced.
 CANONICAL_METRIC_IDS: dict[str, str] = {
     'acc': 'accuracy',
+    # Length-normalized accuracy is a different computation from `acc` on the same
+    # items, and the registry keeps them apart. It is carried as
+    # `normalized-accuracy` there, with `acc_norm` already among its aliases; the
+    # hosted resolver reports no match only because the live Space lags the seed,
+    # which is why this looked unregistered.
+    'acc_norm': 'normalized-accuracy',
     'accuracy': 'accuracy',
     'bleu': 'bleu',
     'bleu_1': 'bleu-1',

--- a/every_eval_ever/converters/lm_eval/adapter.py
+++ b/every_eval_ever/converters/lm_eval/adapter.py
@@ -51,6 +51,24 @@ from .utils import (
 )
 
 
+def _is_stderr_key(key: str) -> bool:
+    """True for the standard-error companion of a score key, in either format.
+
+    lm-eval v0.4 writes `acc_stderr,none`; v0.3 and earlier write a bare
+    `acc_stderr`. Matching only the comma form let every v0.3 standard error fall
+    through as if it were a metric of its own, so a record reported the spread as
+    the score.
+    """
+    return '_stderr,' in key or key.endswith('_stderr')
+
+
+def _stderr_key_for(metric_name: str, filter_name: str, key: str) -> str:
+    """The standard-error key that pairs with `key`, in `key`'s own format."""
+    if ',' in key:
+        return f'{metric_name}_stderr,{filter_name}'
+    return f'{metric_name}_stderr'
+
+
 class LMEvalAdapter(BaseEvaluationAdapter):
     """Converts lm-evaluation-harness results to every_eval_ever format."""
 
@@ -156,7 +174,7 @@ class LMEvalAdapter(BaseEvaluationAdapter):
                     'sample_len',
                     'sample_count',
                 )
-                and '_stderr,' not in k
+                and not _is_stderr_key(k)
             )
             if not has_metric:
                 continue
@@ -245,7 +263,7 @@ class LMEvalAdapter(BaseEvaluationAdapter):
                 'sample_count',
             ):
                 continue
-            if '_stderr,' in key:
+            if _is_stderr_key(key):
                 continue
             if not isinstance(value, (int, float)):
                 continue
@@ -256,7 +274,7 @@ class LMEvalAdapter(BaseEvaluationAdapter):
                 metric_name = key
                 filter_name = 'none'
 
-            stderr_key = f'{metric_name}_stderr,{filter_name}'
+            stderr_key = _stderr_key_for(metric_name, filter_name, key)
             stderr_val = task_results.get(stderr_key)
             # lm-eval writes the string 'N/A' when it computed no standard error
             # for a metric: its aggregation has no standard-error routine, or the

--- a/every_eval_ever/converters/lm_eval/utils.py
+++ b/every_eval_ever/converters/lm_eval/utils.py
@@ -147,6 +147,8 @@ LM_EVAL_METRIC_BOUNDS = {
     'ter': (0.0, float('inf')),
     'word_perplexity': (1.0, float('inf')),
     'byte_perplexity': (1.0, float('inf')),
+    # v0.3's spelling of the same metric; see CANONICAL_METRIC_IDS.
+    'ppl': (1.0, float('inf')),
     'perplexity': (1.0, float('inf')),
     'bits_per_byte': (0.0, float('inf')),
 }

--- a/tests/converter_cases.py
+++ b/tests/converter_cases.py
@@ -99,6 +99,37 @@ CASES: tuple[ConverterCase, ...] = (
         ),
     ),
     ConverterCase(
+        source='lm_eval',
+        log_path=REPO_ROOT
+        / 'tests/data/lm_eval_v03/results_v03_no_comma_metric_keys.json',
+        # lm-eval v0.3 and earlier write bare `acc` / `acc_stderr` keys, without the
+        # `,filter` suffix v0.4 added. Only the comma form was recognised, so every
+        # standard error here fell through as a metric of its own and a record
+        # reported the spread as the score. Two tasks, two real metrics each.
+        aggregates=2,
+        results=4,
+        model_id='bigscience/bloom-3b',
+        scores={
+            'sciq/acc': 0.891,
+            'sciq/acc_norm': 0.816,
+            'arc_easy/acc': 0.5942760942760943,
+            'arc_easy/acc_norm': 0.5328282828282829,
+        },
+        metric_names=frozenset({'acc', 'acc_norm'}),
+        # `acc_norm` is length-normalized accuracy, which the registry carries as
+        # `normalized-accuracy` rather than folding into `accuracy`. Both ids being
+        # present is what says the two were not merged.
+        metric_ids=frozenset({'accuracy', 'normalized-accuracy'}),
+        # Each score keeps its own companion standard error. No `num_samples`: the
+        # v0.3 format records no `n-samples` block.
+        uncertainty_keys=frozenset({'standard_error'}),
+        required_source_paths=(
+            'config.model',
+            'config.model_args',
+            'results.*',
+        ),
+    ),
+    ConverterCase(
         source='inspect',
         log_path=REPO_ROOT
         / 'tests/data/inspect/data_cyse2_vuln_exploit_challenges.json',

--- a/tests/data/lm_eval_v03/results_v03_no_comma_metric_keys.json
+++ b/tests/data/lm_eval_v03/results_v03_no_comma_metric_keys.json
@@ -1,0 +1,32 @@
+{
+ "results": {
+  "sciq": {
+   "acc": 0.891,
+   "acc_stderr": 0.009859828407037191,
+   "acc_norm": 0.816,
+   "acc_norm_stderr": 0.012259457340938588
+  },
+  "arc_easy": {
+   "acc": 0.5942760942760943,
+   "acc_stderr": 0.010075755540128871,
+   "acc_norm": 0.5328282828282829,
+   "acc_norm_stderr": 0.010237645778853869
+  }
+ },
+ "versions": {
+  "sciq": 0,
+  "arc_easy": 0
+ },
+ "config": {
+  "model": "gpt2",
+  "model_args": "use_fast=True,pretrained=bigscience/bloom-3b,trust_remote_code=True,low_cpu_mem_usage=True,dtype=auto",
+  "num_fewshot": 0,
+  "batch_size": "8",
+  "batch_sizes": [],
+  "device": null,
+  "no_cache": true,
+  "limit": null,
+  "bootstrap_iters": 100000,
+  "description_dict": {}
+ }
+}


### PR DESCRIPTION
Converting a pre-v0.4 lm-eval log publishes its standard errors as scores. Found while pointing the existing converter at a public repository of harness outputs, which is what surfaced a format the fixtures never covered.

## What goes wrong

lm-eval v0.4 writes a metric key as `acc,none` and its companion as `acc_stderr,none`. v0.3 and earlier write bare `acc` and `acc_stderr`. The converter tested for `'_stderr,' in key`, which matches only the comma form, so a pre-v0.4 log hit two failures at once.

The companion was not skipped, so it became a result of its own with the spread in `score_details.score`. And the sibling score lost its uncertainty, because the lookup built `f'{metric_name}_stderr,{filter_name}'` — a key that cannot exist in a format with no commas.

One `sciq` task from `Stability-AI/StableLM`'s committed evals, before:

```
sciq  metric_id=accuracy                              score=0.891
sciq  metric_id=lm-evaluation-harness.acc_stderr      score=0.009859828407037191
sciq  metric_id=lm-evaluation-harness.acc_norm        score=0.816
sciq  metric_id=lm-evaluation-harness.acc_norm_stderr score=0.012259457340938588
```

Two of those four are dispersion wearing a score's clothes, and both validate cleanly. A consumer averaging that task's scores mixes them in. After:

```
sciq  metric_id=accuracy             score=0.891  uncertainty.standard_error=0.009859828407037191
sciq  metric_id=normalized-accuracy  score=0.816  uncertainty.standard_error=0.012259457340938588
```

This is the rule the `inspect` converter case already states in `tests/converter_cases.py` — "the scorer's `std`, which belongs in `uncertainty`, not in a score of its own". lm_eval was the outlier for one of its two input formats.

## The changes

**Recognise either spelling.** `_is_stderr_key` matches `_stderr,` or a trailing `_stderr`, used at both call sites. `_stderr_key_for` derives the companion key in the same format as the score key it belongs to, so neither format loses its uncertainty.

**`acc_norm` gains its canonical id.** It is length-normalized accuracy, a different computation from `acc` on the same items, and the registry carries it as `normalized-accuracy` with `acc_norm` already among its aliases. It was namespaced as an unregistered metric because the hosted resolver reports `no_match` for every spelling of it — the live Space lags the seed data, and reading that as absence is a trap worth naming, since it also invites minting a duplicate canonical.

**A fixture for the format that had none.** `tests/data/lm_eval_v03/`, taken from a real published log, plus a `ConverterCase` asserting four results across two tasks, both metric ids present, and an uncertainty on every score. It sits in its own directory so `test_transform_from_directory` still describes what it scans.

## Scope and blast radius

`metric_config_fields` is shared, so the `acc_norm` mapping changes any converter that reports that metric name — which is the intent, since the alternative is two ids for one quantity.

**No published datastore record carries the affected ids.** I checked all 47,181 aggregate records at `main`: zero contain `lm-evaluation-harness.acc_stderr`, `lm-evaluation-harness.acc_norm_stderr`, or `lm-evaluation-harness.acc_norm`. The 268 records that mention `acc_norm_stderr` are `open-medical-llm`, which already does the right thing (`metric_id: accuracy` with the value in `uncertainty`). So this corrects what the converter would produce, not data already submitted.

## Not in this PR

`evaluation_id` is keyed on the retrieval timestamp (`f'{task_name}/{model_info.id}/{retrieved_timestamp}'`), so re-converting the same log mints a new identity. That affects both formats and every existing lm_eval conversion, so changing it is a material change in outcome and wants its own decision rather than riding along here.

## Verification

- `uv run pytest tests` — 1,003 passed, 45 skipped.
- `uv run ruff check every_eval_ever tests` — clean.
- Round-tripped against the real source file: `sciq` accuracy stays 0.891 and its standard error 0.009859828407037191, now attached rather than published separately.
