### PR TITLE
Add a wrapper that points the lm_eval converter at a public repo of harness JSON

### DIFF
--- a/every_eval_ever/adapters/README.md
+++ b/every_eval_ever/adapters/README.md
@@ -77,6 +77,7 @@ re-hosting bytes that are already durably stored.
 | `vals_ai` | Vals.ai benchmark leaderboards | Scrapes Vals.ai benchmark pages and converts their embedded leaderboard results into `data/vals-ai/`. |
 | `bfcl` | BFCL leaderboard CSV | Converts BFCL leaderboard data with per-metric evaluation names and bounded continuous scores. |
 | `sciarena` | SciArena leaderboard API | Converts SciArena leaderboard results. |
+| `stablelm_evals` | lm-eval harness outputs in `Stability-AI/StableLM` | A **wrapper**, not a converter: pins the source commit, repairs the model identity `pretrained=` leaves org-less, and hands the files to the in-tree `lm_eval` converter with one collection pinned. 29 open-weights models x 11 benchmarks into `data/stablelm-evals/`, including SciQ and LAMBADA-OpenAI. Copy it to ingest another public repository of harness JSON. See [`stablelm_evals/README.md`](stablelm_evals/README.md). |
 | `global_mmlu_lite` | Kaggle API | Fetches Global MMLU Lite leaderboard results from Kaggle. |
 | `hfopenllm_v2` | HuggingFace Spaces API | Fetches the Open LLM Leaderboard v2 (4576+ models). The leaderboard is no longer maintained upstream, so this converts a frozen archive and is not scheduled. |
 | `helm` | HELM leaderboard | Converts HELM leaderboard data. Supports `--leaderboard_name` for Capabilities/Lite/Classic/Instruct/MMLU. |

--- a/every_eval_ever/adapters/catalog.py
+++ b/every_eval_ever/adapters/catalog.py
@@ -320,6 +320,19 @@ ADAPTERS: tuple[AdapterSpec, ...] = (
         timeout_minutes=30,
     ),
     AdapterSpec(
+        key='stablelm_evals',
+        module='every_eval_ever.adapters.stablelm_evals.adapter',
+        collections=('stablelm-evals',),
+        cadence='weekly',
+        weekday=5,
+        notes=(
+            'Wraps the in-tree lm_eval converter around the harness outputs '
+            'committed under evals/ in Stability-AI/StableLM. The repository is '
+            'archived research output rather than a live leaderboard, so this is '
+            'weekly and --emit-source-version skips it while the commit holds.'
+        ),
+    ),
+    AdapterSpec(
         key='mercor_eval',
         module='every_eval_ever.adapters.mercor_eval.adapter',
         # One collection per Mercor benchmark slug. A new benchmark on their

--- a/every_eval_ever/adapters/stablelm_evals/README.md
+++ b/every_eval_ever/adapters/stablelm_evals/README.md
@@ -1,0 +1,80 @@
+# StableLM evals
+
+Publishes the lm-evaluation-harness outputs Stability AI committed under `evals/` in
+[Stability-AI/StableLM](https://github.com/Stability-AI/StableLM), into
+`data/stablelm-evals/`.
+
+**This is a wrapper, not a converter.** The in-tree `lm_eval` converter already
+reads this format. Everything here is the three things a public repository of
+harness JSON needs before the converter can be pointed at it, and it is worth
+copying for the next such repository.
+
+```bash
+uv run python -m every_eval_ever.adapters.stablelm_evals.adapter \
+  --output-dir /tmp/stablelm-evals-smoke/data/stablelm-evals
+
+uv run python -m every_eval_ever validate \
+  '/tmp/stablelm-evals-smoke/data/stablelm-evals/*/*/*.json'
+```
+
+## The three things a wrapper adds
+
+**Pin the source.** The revision is resolved to a commit sha before any file is
+fetched, so every record cites bytes that cannot move. `--allow-unpinned-source` is
+required to proceed without one.
+
+**Repair the model identity.** The converter takes `model_info.id` from
+`config.model_args`'s `pretrained=` value and refuses an id with no publishing
+namespace, which is right — a placeholder developer routes unrelated models into one
+directory. 28 of the 29 files here name a full repo id. One
+(`evals/stablelm-3b-4e1t.json`) was run from a local checkout, so its org is
+supplied through `ORGLESS_MODEL_ORG`, where the decision is visible. An org-less id
+that is *not* listed there fails the row rather than getting a guess.
+
+**Pin one collection.** Left alone the converter files each task into its own bare
+collection — `data/sciq/`, `data/piqa/`, `data/lambada_openai/` — which mixes these
+numbers with every other source's records for the same benchmark and loses the
+provenance. `publish_evaluation_logs(collection_override=...)` keeps the source
+together.
+
+## Coverage
+
+29 models x 11 benchmarks, 293 records carrying 530 results, 0 dropped. The 2026-09-02
+conversion of commit `93eea082c4` validates 293/293 through the CLI with semantic
+checks on and no warnings.
+
+Benchmarks: `arc_challenge`, `arc_easy`, `boolq`, `hellaswag`, `lambada_openai`,
+`openbookqa`, `piqa`, `sciq`, `siqa`, `truthfulqa_mc`, `winogrande`.
+
+Models, all open-weights: Pythia (2.8b-deduped, 6.9b, 12b), GPT-J-6B, GPT-NeoX-20B,
+BLOOM (3b, 7b1), OPT (2.7b, 6.7b), LLaMA-1 via `huggyllama`, Llama-2 (7b, 13b),
+MPT-7B, Falcon-7B, RedPajama-INCITE-7B-Base, Qwen-7B and Qwen-7B-Chat, Cerebras
+BTLM-3B-8K, OpenLLaMA x3, Mistral-7B via `kittn`, phi-1.5, Baichuan2-7B-Base, and
+five StableLM releases.
+
+Two of those are the reason this source is worth having. It carries SciQ for 29
+models and LAMBADA-OpenAI for 29, both of which the datastore held almost nothing
+for.
+
+## What is not converted
+
+`evals/open_llm_leaderboard/` holds per-task files for two models rather than one
+file per model — a different shape this wrapper does not read. Excluded by prefix
+and reported on every run, so the 8 files are visible rather than silently absent.
+
+## Notes on the source
+
+These runs predate lm-eval v0.4: `versions` uses the integer form and metric keys
+carry no `,filter` suffix, so `eval_library.version` is recorded as `0.3`. The
+converter's handling of that format was wrong until #285 — standard errors were
+published as scores — so records generated before that fix should be regenerated.
+
+`evals/external/togethercomputer-RedPajama-INCITE-7B-Base2.json` names `Base2` in
+its filename while `config.model_args` says
+`pretrained=togethercomputer/RedPajama-INCITE-7B-Base`. The identity comes from
+`model_args`, which is what the harness was actually given.
+
+Two entries are community mirrors rather than first-party repos —
+`huggyllama/llama-7b` for LLaMA-1 and `kittn/mistral-7B-v0.1-hf` for Mistral-7B.
+They are published as the source ran them; aliasing a mirror onto its upstream is
+the eval-card-registry's job, not this adapter's.

--- a/every_eval_ever/adapters/stablelm_evals/__init__.py
+++ b/every_eval_ever/adapters/stablelm_evals/__init__.py
@@ -1,0 +1,1 @@
+"""StableLM evals wrapper around the in-tree lm_eval converter."""

--- a/every_eval_ever/adapters/stablelm_evals/adapter.py
+++ b/every_eval_ever/adapters/stablelm_evals/adapter.py
@@ -1,0 +1,328 @@
+"""Publish the lm-eval harness outputs Stability AI committed alongside StableLM.
+
+This adapter is a **wrapper**, not a converter. `Stability-AI/StableLM` commits raw
+lm-evaluation-harness result files under `evals/`, and the in-tree `lm_eval`
+converter already reads that format. All this file adds is the three things a
+public repository of harness JSON needs before the converter can be pointed at it:
+
+1. **Pin the source.** Resolve the revision to a commit sha before fetching, so
+   every record cites bytes that cannot move.
+2. **Repair the model identity.** The converter takes `model_info.id` from
+   `config.model_args`'s `pretrained=` value and refuses an id with no publishing
+   namespace, which is correct -- a placeholder developer would route unrelated
+   models into one directory. One file here was run from a local checkout and
+   needs its org supplied.
+3. **Pin one collection.** Left alone the converter files each task into its own
+   bare collection (`data/sciq/`, `data/piqa/`, ...), which mixes these numbers
+   with every other source's records for the same benchmark and loses the
+   provenance. `collection_override` keeps the source together.
+
+**Copying this for another repository of harness JSON** means changing `SOURCE_*`,
+`COLLECTION`, `list_result_files`, and `ORGLESS_MODEL_ORG`. Nothing else here is
+specific to StableLM, and nothing here re-implements conversion.
+
+    uv run python -m every_eval_ever.adapters.stablelm_evals.adapter \
+        --output-dir /tmp/stablelm-evals-smoke/data/stablelm-evals
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from every_eval_ever.converters.common.publication import (
+    publish_evaluation_logs,
+)
+from every_eval_ever.converters.lm_eval.adapter import LMEvalAdapter
+from every_eval_ever.helpers import (
+    SourceConversionResult,
+    SourceRecordFailure,
+    default_failure_report_path,
+    raw_capture,
+    save_failure_report,
+)
+
+SRC = 'stablelm_evals'
+COLLECTION = 'stablelm-evals'
+
+OWNER_REPO = 'Stability-AI/StableLM'
+PROJECT_URL = f'https://github.com/{OWNER_REPO}'
+COMMITS_API = f'https://api.github.com/repos/{OWNER_REPO}/commits/'
+TREE_API = f'https://api.github.com/repos/{OWNER_REPO}/git/trees/'
+RAW_BASE = f'https://raw.githubusercontent.com/{OWNER_REPO}/'
+
+#: The harness that produced these files. `versions` in every result file is the
+#: v0.3-era integer form (`{"arc_challenge": 0}`), not the v0.4 float form, and the
+#: metric keys carry no `,none` suffix, so the runs predate v0.4.
+EVAL_LIBRARY_NAME = 'lm-evaluation-harness'
+EVAL_LIBRARY_VERSION = '0.3'
+
+#: `evals/open_llm_leaderboard/` holds per-task files for two models rather than one
+#: file per model, a different shape this wrapper does not read. Excluded by prefix
+#: rather than silently skipped, and reported.
+SKIP_PREFIX = 'evals/open_llm_leaderboard/'
+
+#: The one file run from a local checkout, so `pretrained=` carries no namespace.
+#: Supplying it here rather than defaulting a developer keeps the guess visible.
+ORGLESS_MODEL_ORG = {
+    'stablelm-3b-4e1t': 'stabilityai',
+}
+
+_PRETRAINED_RE = re.compile(r'(?<![\w-])pretrained=([^,]+)')
+
+
+def resolve_commit(revision: str, *, timeout: float = 30.0) -> str | None:
+    """Return the commit sha `revision` names, or None if it cannot be read."""
+    if len(revision) == 40 and all(c in '0123456789abcdef' for c in revision.lower()):
+        return revision.lower()
+    try:
+        resp = requests.get(f'{COMMITS_API}{revision}', timeout=timeout)
+        resp.raise_for_status()
+        return str(resp.json()['sha'])
+    except Exception:  # noqa: BLE001 -- the caller decides whether this is fatal
+        return None
+
+
+def list_result_files(sha: str, *, timeout: float = 30.0) -> tuple[list[str], list[str]]:
+    """Return `(result files, skipped files)` under `evals/` at `sha`."""
+    resp = requests.get(f'{TREE_API}{sha}?recursive=1', timeout=timeout)
+    resp.raise_for_status()
+    tree = resp.json()
+    if tree.get('truncated'):
+        raise SystemExit(
+            'the git tree listing came back truncated, so the file set would be '
+            'incomplete and the run would silently publish a subset'
+        )
+    under_evals = [
+        item['path'] for item in tree['tree']
+        if item['type'] == 'blob' and item['path'].startswith('evals/')
+    ]
+    keep = [p for p in under_evals if not p.startswith(SKIP_PREFIX)]
+    skipped = [p for p in under_evals if p.startswith(SKIP_PREFIX)]
+    return sorted(keep), sorted(skipped)
+
+
+def normalize_model_args(payload: dict[str, Any], source_ref: str) -> str:
+    """Give `config.model_args` a `pretrained=` value that names a real repo.
+
+    Returns the resolved `developer/model` id. Raises when the id has no namespace
+    and none is registered, rather than inventing one.
+    """
+    config = payload.get('config')
+    if not isinstance(config, dict):
+        raise ValueError(f'{source_ref}: no config block, so no model identity')
+    model_args = config.get('model_args')
+    if not isinstance(model_args, str):
+        raise ValueError(f'{source_ref}: config.model_args is not a string')
+    found = _PRETRAINED_RE.search(model_args)
+    if not found:
+        raise ValueError(f'{source_ref}: config.model_args has no pretrained= value')
+    raw = found.group(1).strip()
+    if '/' in raw:
+        return raw
+    org = ORGLESS_MODEL_ORG.get(raw)
+    if not org:
+        raise ValueError(
+            f'{source_ref}: pretrained={raw!r} names no publishing namespace and '
+            'is not in ORGLESS_MODEL_ORG; add it there rather than letting the '
+            'record claim an untrue identity'
+        )
+    resolved = f'{org}/{raw}'
+    config['model_args'] = model_args.replace(found.group(0), f'pretrained={resolved}')
+    return resolved
+
+
+def stage_sources(
+    sha: str, paths: list[str], staging: Path, *, timeout: float = 60.0
+) -> tuple[dict[str, str], list[SourceRecordFailure]]:
+    """Download each result file, repair its identity, write it where the converter
+    will find it. Returns `(staged filename -> model id, failures)`.
+
+    The converter discovers files by a `results_*.json` name, so each source file is
+    staged under that pattern with its own basename preserved for traceability.
+    """
+    staged: dict[str, str] = {}
+    failures: list[SourceRecordFailure] = []
+    for path in paths:
+        url = f'{RAW_BASE}{sha}/{path}'
+        try:
+            resp = requests.get(url, timeout=timeout)
+            resp.raise_for_status()
+            payload = resp.json()
+        except Exception as exc:  # noqa: BLE001 -- one unreadable file is data
+            failures.append(SourceRecordFailure(
+                source_ref=path, reason=f'could not read source file: {exc}',
+                source_record={'path': path, 'url': url},
+            ))
+            continue
+        raw_capture.record(
+            url=url, content=resp.content, content_type='application/json',
+            label=f'StableLM evals {path}',
+        )
+        try:
+            model_id = normalize_model_args(payload, path)
+        except ValueError as exc:
+            failures.append(SourceRecordFailure(
+                source_ref=path, reason=str(exc),
+                source_record={'path': path, 'config': payload.get('config')},
+            ))
+            continue
+        slug = Path(path).name.removesuffix('.json')
+        name = f'results_{slug}.json'
+        (staging / name).write_text(json.dumps(payload))
+        staged[name] = model_id
+    return staged, failures
+
+
+def convert(
+    sha: str, staging: Path, staged: dict[str, str], retrieved_ts: str
+) -> list[Any]:
+    """Hand the staged files to the in-tree lm_eval converter."""
+    metadata = {
+        'source_organization_name': 'Stability AI',
+        'source_organization_url': PROJECT_URL,
+        'evaluator_relationship': 'third_party',
+        'eval_library_name': EVAL_LIBRARY_NAME,
+        'eval_library_version': EVAL_LIBRARY_VERSION,
+        'parent_eval_output_dir': str(staging),
+        'retrieved_timestamp': retrieved_ts,
+        'source_commit': sha,
+    }
+    result = LMEvalAdapter().transform_from_directory_result(staging, metadata)
+    return list(result.records)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        '--output-dir', type=Path,
+        default=Path(f'/tmp/{COLLECTION}-smoke/data/{COLLECTION}'),
+        help='Collection directory to write into, i.e. <root>/data/stablelm-evals. '
+             'Defaults outside any checkout.',
+    )
+    ap.add_argument(
+        '--revision', default='main',
+        help='Branch, tag or commit of Stability-AI/StableLM to convert. Resolved '
+             'to a commit sha before anything is fetched.',
+    )
+    ap.add_argument(
+        '--allow-unpinned-source', action='store_true',
+        help='Proceed when the revision cannot be resolved to a commit sha.',
+    )
+    ap.add_argument('--limit', type=int, default=None, help='Convert only the first N files.')
+    ap.add_argument(
+        '--replace-existing', action='store_true',
+        help='Replace records already in the output directory. Filenames are fresh '
+             'uuid4s, so without this a populated directory is an error.',
+    )
+    ap.add_argument('--failure-report', type=Path, default=None)
+    ap.add_argument(
+        '--emit-source-version', action='store_true',
+        help='Print the resolved source commit and exit without converting.',
+    )
+    return ap.parse_args(argv)
+
+
+def run(args: argparse.Namespace) -> list[Path]:
+    sha = resolve_commit(args.revision)
+    if sha is None:
+        if not args.allow_unpinned_source:
+            raise SystemExit(
+                f'could not resolve {args.revision!r} to a commit sha in '
+                f'{OWNER_REPO}. Every record cites its source commit, so a moving '
+                'reference is refused. Pass --allow-unpinned-source to override.'
+            )
+        sha = args.revision
+    if args.emit_source_version:
+        print(sha)
+        return []
+
+    output_dir = Path(args.output_dir)
+    if output_dir.name != COLLECTION:
+        raise SystemExit(
+            f'--output-dir must end in {COLLECTION!r}; got {output_dir}. Otherwise '
+            'the run reports one destination and writes to another.'
+        )
+
+    paths, skipped = list_result_files(sha)
+    if args.limit is not None:
+        paths = paths[: args.limit]
+    if not paths:
+        raise SystemExit(f'no result files found under evals/ at {sha}')
+
+    staging_root = Path(tempfile.mkdtemp(prefix='eee-stablelm-'))
+    try:
+        staging = staging_root / 'in'
+        staging.mkdir()
+        staged, failures = stage_sources(sha, paths, staging)
+        if not staged:
+            raise SystemExit(
+                f'none of the {len(paths)} source file(s) yielded a usable model '
+                'identity, so nothing would be published'
+            )
+        logs = convert(sha, staging, staged, str(time.time()))
+        result = SourceConversionResult(
+            source_name='StableLM evals',
+            total_records=len(paths),
+            records=[],
+            failures=failures,
+        )
+        report = save_failure_report(
+            result, args.failure_report or default_failure_report_path(output_dir)
+        )
+        print(
+            f'Conversion accounting: {report} ({len(failures)} unconverted, '
+            f'{len(skipped)} file(s) skipped as a different shape)'
+        )
+
+        existing = sorted(output_dir.glob('*/*/*.json'))
+        if existing and not args.replace_existing:
+            raise SystemExit(
+                f'{len(existing)} record(s) already exist under {output_dir}, e.g. '
+                f'{existing[0]}. Filenames are fresh uuid4s, so writing now would '
+                'add a second copy of every evaluation. Pass --replace-existing.'
+            )
+
+        written = publish_evaluation_logs(
+            logs,
+            base_output_dir=output_dir.parent,
+            file_uuids=[str(uuid.uuid4()) for _ in logs],
+            collection_override=COLLECTION,
+        )
+        if existing and args.replace_existing:
+            for path in existing:
+                path.unlink()
+    finally:
+        shutil.rmtree(staging_root, ignore_errors=True)
+
+    print(
+        f'Coverage: {len(paths)} source file(s) -> {len(written)} record(s); '
+        f'{len(failures)} dropped, {len(skipped)} skipped -> {output_dir}'
+    )
+    if skipped:
+        print(
+            f'  skipped (per-task files, a shape this wrapper does not read): '
+            f'{", ".join(skipped[:4])}'
+            + (' ...' if len(skipped) > 4 else ''),
+            file=sys.stderr,
+        )
+    result.raise_if_incomplete()
+    return written
+
+
+def main() -> None:
+    run(parse_args())
+
+
+if __name__ == '__main__':
+    main()

--- a/every_eval_ever/converters/common/metrics.py
+++ b/every_eval_ever/converters/common/metrics.py
@@ -100,6 +100,9 @@ CANONICAL_METRIC_IDS: dict[str, str] = {
     'exact_match': 'exact-match',
     'f1': 'f1',
     'f1_score': 'f1',
+    # lm-eval v0.3 reports perplexity under `ppl` (v0.4 renamed it), so both
+    # spellings reach the one registry metric rather than fragmenting by format.
+    'ppl': 'perplexity',
     'perplexity': 'perplexity',
     'precision': 'precision',
     'recall': 'recall',

--- a/every_eval_ever/converters/common/metrics.py
+++ b/every_eval_ever/converters/common/metrics.py
@@ -85,6 +85,12 @@ METRIC_ID_REGISTRY_REVISION = '8b83e9c'
 # Only names the registry actually carries appear here; the rest are namespaced.
 CANONICAL_METRIC_IDS: dict[str, str] = {
     'acc': 'accuracy',
+    # Length-normalized accuracy is a different computation from `acc` on the same
+    # items, and the registry keeps them apart. It is carried as
+    # `normalized-accuracy` there, with `acc_norm` already among its aliases; the
+    # hosted resolver reports no match only because the live Space lags the seed,
+    # which is why this looked unregistered.
+    'acc_norm': 'normalized-accuracy',
     'accuracy': 'accuracy',
     'bleu': 'bleu',
     'bleu_1': 'bleu-1',

--- a/every_eval_ever/converters/lm_eval/adapter.py
+++ b/every_eval_ever/converters/lm_eval/adapter.py
@@ -51,6 +51,24 @@ from .utils import (
 )
 
 
+def _is_stderr_key(key: str) -> bool:
+    """True for the standard-error companion of a score key, in either format.
+
+    lm-eval v0.4 writes `acc_stderr,none`; v0.3 and earlier write a bare
+    `acc_stderr`. Matching only the comma form let every v0.3 standard error fall
+    through as if it were a metric of its own, so a record reported the spread as
+    the score.
+    """
+    return '_stderr,' in key or key.endswith('_stderr')
+
+
+def _stderr_key_for(metric_name: str, filter_name: str, key: str) -> str:
+    """The standard-error key that pairs with `key`, in `key`'s own format."""
+    if ',' in key:
+        return f'{metric_name}_stderr,{filter_name}'
+    return f'{metric_name}_stderr'
+
+
 class LMEvalAdapter(BaseEvaluationAdapter):
     """Converts lm-evaluation-harness results to every_eval_ever format."""
 
@@ -156,7 +174,7 @@ class LMEvalAdapter(BaseEvaluationAdapter):
                     'sample_len',
                     'sample_count',
                 )
-                and '_stderr,' not in k
+                and not _is_stderr_key(k)
             )
             if not has_metric:
                 continue
@@ -245,7 +263,7 @@ class LMEvalAdapter(BaseEvaluationAdapter):
                 'sample_count',
             ):
                 continue
-            if '_stderr,' in key:
+            if _is_stderr_key(key):
                 continue
             if not isinstance(value, (int, float)):
                 continue
@@ -256,7 +274,7 @@ class LMEvalAdapter(BaseEvaluationAdapter):
                 metric_name = key
                 filter_name = 'none'
 
-            stderr_key = f'{metric_name}_stderr,{filter_name}'
+            stderr_key = _stderr_key_for(metric_name, filter_name, key)
             stderr_val = task_results.get(stderr_key)
             # lm-eval writes the string 'N/A' when it computed no standard error
             # for a metric: its aggregation has no standard-error routine, or the

--- a/every_eval_ever/converters/lm_eval/utils.py
+++ b/every_eval_ever/converters/lm_eval/utils.py
@@ -147,6 +147,8 @@ LM_EVAL_METRIC_BOUNDS = {
     'ter': (0.0, float('inf')),
     'word_perplexity': (1.0, float('inf')),
     'byte_perplexity': (1.0, float('inf')),
+    # v0.3's spelling of the same metric; see CANONICAL_METRIC_IDS.
+    'ppl': (1.0, float('inf')),
     'perplexity': (1.0, float('inf')),
     'bits_per_byte': (0.0, float('inf')),
 }

--- a/tests/converter_cases.py
+++ b/tests/converter_cases.py
@@ -99,6 +99,37 @@ CASES: tuple[ConverterCase, ...] = (
         ),
     ),
     ConverterCase(
+        source='lm_eval',
+        log_path=REPO_ROOT
+        / 'tests/data/lm_eval_v03/results_v03_no_comma_metric_keys.json',
+        # lm-eval v0.3 and earlier write bare `acc` / `acc_stderr` keys, without the
+        # `,filter` suffix v0.4 added. Only the comma form was recognised, so every
+        # standard error here fell through as a metric of its own and a record
+        # reported the spread as the score. Two tasks, two real metrics each.
+        aggregates=2,
+        results=4,
+        model_id='bigscience/bloom-3b',
+        scores={
+            'sciq/acc': 0.891,
+            'sciq/acc_norm': 0.816,
+            'arc_easy/acc': 0.5942760942760943,
+            'arc_easy/acc_norm': 0.5328282828282829,
+        },
+        metric_names=frozenset({'acc', 'acc_norm'}),
+        # `acc_norm` is length-normalized accuracy, which the registry carries as
+        # `normalized-accuracy` rather than folding into `accuracy`. Both ids being
+        # present is what says the two were not merged.
+        metric_ids=frozenset({'accuracy', 'normalized-accuracy'}),
+        # Each score keeps its own companion standard error. No `num_samples`: the
+        # v0.3 format records no `n-samples` block.
+        uncertainty_keys=frozenset({'standard_error'}),
+        required_source_paths=(
+            'config.model',
+            'config.model_args',
+            'results.*',
+        ),
+    ),
+    ConverterCase(
         source='inspect',
         log_path=REPO_ROOT
         / 'tests/data/inspect/data_cyse2_vuln_exploit_challenges.json',

--- a/tests/data/lm_eval_v03/results_v03_no_comma_metric_keys.json
+++ b/tests/data/lm_eval_v03/results_v03_no_comma_metric_keys.json
@@ -1,0 +1,32 @@
+{
+ "results": {
+  "sciq": {
+   "acc": 0.891,
+   "acc_stderr": 0.009859828407037191,
+   "acc_norm": 0.816,
+   "acc_norm_stderr": 0.012259457340938588
+  },
+  "arc_easy": {
+   "acc": 0.5942760942760943,
+   "acc_stderr": 0.010075755540128871,
+   "acc_norm": 0.5328282828282829,
+   "acc_norm_stderr": 0.010237645778853869
+  }
+ },
+ "versions": {
+  "sciq": 0,
+  "arc_easy": 0
+ },
+ "config": {
+  "model": "gpt2",
+  "model_args": "use_fast=True,pretrained=bigscience/bloom-3b,trust_remote_code=True,low_cpu_mem_usage=True,dtype=auto",
+  "num_fewshot": 0,
+  "batch_size": "8",
+  "batch_sizes": [],
+  "device": null,
+  "no_cache": true,
+  "limit": null,
+  "bootstrap_iters": 100000,
+  "description_dict": {}
+ }
+}

--- a/tests/test_stablelm_evals_adapter.py
+++ b/tests/test_stablelm_evals_adapter.py
@@ -1,0 +1,210 @@
+"""Offline tests for the StableLM evals wrapper.
+
+The wrapper's own job is small -- pin the source, repair the model identity, pin one
+collection -- so that is what these cover. Conversion itself belongs to the lm_eval
+converter and is covered by its own `ConverterCase`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from every_eval_ever.adapters.stablelm_evals import adapter
+
+SHA = 'b' * 40
+
+
+def _payload(pretrained: str, tasks: dict | None = None) -> dict:
+    return {
+        'results': tasks or {
+            'sciq': {
+                'acc': 0.891, 'acc_stderr': 0.009859828407037191,
+                'acc_norm': 0.816, 'acc_norm_stderr': 0.012259457340938588,
+            },
+        },
+        'versions': {'sciq': 0},
+        'config': {
+            'model': 'gpt2',
+            'model_args': f'use_fast=True,pretrained={pretrained},dtype=auto',
+            'num_fewshot': 0, 'batch_size': '8', 'bootstrap_iters': 100000,
+            'limit': None,
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# model identity, which is the whole reason this wrapper exists
+# --------------------------------------------------------------------------- #
+def test_a_full_repo_id_passes_through():
+    payload = _payload('bigscience/bloom-3b')
+    assert adapter.normalize_model_args(payload, 'f.json') == 'bigscience/bloom-3b'
+    # untouched, so the record keeps what the harness was actually given
+    assert 'pretrained=bigscience/bloom-3b' in payload['config']['model_args']
+
+
+def test_a_registered_orgless_id_gains_its_namespace():
+    """One file was run from a local checkout, so `pretrained=` has no org."""
+    payload = _payload('stablelm-3b-4e1t')
+    assert adapter.normalize_model_args(payload, 'f.json') == 'stabilityai/stablelm-3b-4e1t'
+    assert 'pretrained=stabilityai/stablelm-3b-4e1t' in payload['config']['model_args']
+
+
+def test_an_unregistered_orgless_id_is_refused_not_guessed():
+    """A placeholder developer would route unrelated models into one directory."""
+    payload = _payload('some-local-checkout')
+    with pytest.raises(ValueError, match='no publishing namespace'):
+        adapter.normalize_model_args(payload, 'f.json')
+
+
+@pytest.mark.parametrize('config', [None, 'not-a-dict', {'model_args': 42}, {}])
+def test_a_malformed_config_is_a_failure_with_a_reason(config):
+    payload = {'results': {}, 'config': config}
+    with pytest.raises(ValueError):
+        adapter.normalize_model_args(payload, 'f.json')
+
+
+def test_pretrained_is_read_as_its_own_key():
+    """`model_args` is a comma-joined key=value string, and other keys end in the
+    same letters -- matching loosely would read the wrong value."""
+    payload = _payload('bigscience/bloom-3b')
+    payload['config']['model_args'] = (
+        'peft_pretrained=someone/else,pretrained=bigscience/bloom-3b,dtype=auto'
+    )
+    assert adapter.normalize_model_args(payload, 'f.json') == 'bigscience/bloom-3b'
+
+
+# --------------------------------------------------------------------------- #
+# staging
+# --------------------------------------------------------------------------- #
+def test_staging_names_files_the_converter_will_discover(tmp_path, monkeypatch):
+    """The converter finds logs by a `results_*.json` name."""
+    calls = {}
+
+    class FakeResp:
+        status_code = 200
+        content = b'{}'
+
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    def fake_get(url, timeout=None):
+        calls[url] = calls.get(url, 0) + 1
+        name = url.rsplit('/', 1)[-1]
+        pretrained = 'stablelm-3b-4e1t' if name.startswith('stablelm') else 'bigscience/bloom-3b'
+        return FakeResp(_payload(pretrained))
+
+    monkeypatch.setattr(adapter.requests, 'get', fake_get)
+    staging = tmp_path / 'in'
+    staging.mkdir()
+    staged, failures = adapter.stage_sources(
+        SHA, ['evals/external/bigscience-bloom-3b.json', 'evals/stablelm-3b-4e1t.json'],
+        staging,
+    )
+    assert failures == []
+    assert set(staged) == {
+        'results_bigscience-bloom-3b.json', 'results_stablelm-3b-4e1t.json'
+    }
+    assert set(staged.values()) == {'bigscience/bloom-3b', 'stabilityai/stablelm-3b-4e1t'}
+    for name in staged:
+        assert json.loads((staging / name).read_text())['config']['model_args']
+    # every source file fetched from the pinned sha, not a branch
+    assert all(SHA in url for url in calls)
+
+
+def test_an_unreadable_source_file_is_a_failure_not_a_crash(tmp_path, monkeypatch):
+    def fake_get(url, timeout=None):
+        raise RuntimeError('404')
+
+    monkeypatch.setattr(adapter.requests, 'get', fake_get)
+    staging = tmp_path / 'in'
+    staging.mkdir()
+    staged, failures = adapter.stage_sources(SHA, ['evals/x.json'], staging)
+    assert staged == {}
+    assert len(failures) == 1
+    assert 'could not read source file' in failures[0].reason
+
+
+# --------------------------------------------------------------------------- #
+# CLI guards
+# --------------------------------------------------------------------------- #
+def test_an_unresolvable_revision_stops_the_run_unless_allowed(tmp_path, monkeypatch):
+    monkeypatch.setattr(adapter, 'resolve_commit', lambda revision, **kw: None)
+    args = adapter.parse_args([
+        '--revision', 'no-such-branch',
+        '--output-dir', str(tmp_path / 'data' / adapter.COLLECTION),
+    ])
+    with pytest.raises(SystemExit, match='could not resolve'):
+        adapter.run(args)
+
+
+def test_output_dir_must_be_the_collection_directory(tmp_path, monkeypatch):
+    """Left to the converter each task becomes its own bare collection, which is
+    what `collection_override` prevents -- so the destination has to be explicit."""
+    monkeypatch.setattr(adapter, 'resolve_commit', lambda revision, **kw: SHA)
+    args = adapter.parse_args([
+        '--output-dir', str(tmp_path / 'data' / 'not-the-collection'),
+    ])
+    with pytest.raises(SystemExit, match=adapter.COLLECTION):
+        adapter.run(args)
+    assert not list(tmp_path.glob('data/**/*.json'))
+
+
+def test_a_sha_revision_needs_no_network(monkeypatch):
+    def fail(*a, **k):
+        raise AssertionError('resolve_commit should not call out for a sha')
+
+    monkeypatch.setattr(adapter.requests, 'get', fail)
+    assert adapter.resolve_commit(SHA) == SHA
+
+
+def test_emit_source_version_prints_the_commit_and_converts_nothing(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(adapter, 'resolve_commit', lambda revision, **kw: SHA)
+    args = adapter.parse_args([
+        '--emit-source-version',
+        '--output-dir', str(tmp_path / 'data' / adapter.COLLECTION),
+    ])
+    assert adapter.run(args) == []
+    assert capsys.readouterr().out.strip() == SHA
+    assert not list(tmp_path.glob('data/**/*.json'))
+
+
+def test_a_truncated_tree_listing_stops_the_run(monkeypatch):
+    """A truncated listing would publish a silent subset of the source."""
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {'truncated': True, 'tree': []}
+
+    monkeypatch.setattr(adapter.requests, 'get', lambda url, timeout=None: FakeResp())
+    with pytest.raises(SystemExit, match='truncated'):
+        adapter.list_result_files(SHA)
+
+
+def test_per_task_files_are_skipped_and_reported(monkeypatch):
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {'truncated': False, 'tree': [
+                {'type': 'blob', 'path': 'evals/external/a.json'},
+                {'type': 'blob', 'path': f'{adapter.SKIP_PREFIX}b-hellaswag.json'},
+                {'type': 'blob', 'path': 'README.md'},
+            ]}
+
+    monkeypatch.setattr(adapter.requests, 'get', lambda url, timeout=None: FakeResp())
+    keep, skipped = adapter.list_result_files(SHA)
+    assert keep == ['evals/external/a.json']
+    assert skipped == [f'{adapter.SKIP_PREFIX}b-hellaswag.json']


### PR DESCRIPTION
Stability AI committed the lm-evaluation-harness outputs behind StableLM under `evals/`, and the in-tree `lm_eval` converter already reads that format. **So this adds no conversion.** It adds the three things a public repository of harness JSON needs before the converter can be pointed at it, and it is deliberately small enough to copy for the next one.

**Coverage: 29 source files → 293 records carrying 530 results, 0 dropped, 8 skipped.** All 293 pass the CLI validator with semantic checks on and no warnings, every result carries bounds, no duplicates.

## What a wrapper has to add

**Pin the source.** The revision resolves to a commit sha before any file is fetched, so no record can cite bytes that moved. `--allow-unpinned-source` is required to proceed without one, and a truncated git-tree listing stops the run rather than publishing a silent subset.

**Repair the model identity.** The converter takes `model_info.id` from `config.model_args`'s `pretrained=` value and refuses an id with no publishing namespace — correctly, since a placeholder developer routes unrelated models into one directory. 28 of the 29 files name a full repo id. `evals/stablelm-3b-4e1t.json` was run from a local checkout, so its org is supplied through `ORGLESS_MODEL_ORG` where the decision stays visible; an org-less id that is not listed there fails its row instead of getting a guess.

**Pin one collection.** Left alone the converter files each task into its own bare collection — `data/sciq/`, `data/piqa/`, `data/lambada_openai/` — which mixes these numbers with every other source's records for the same benchmark and loses the provenance. `publish_evaluation_logs(collection_override=...)` keeps the source together. This is the one behaviour worth knowing about if you copy the file.

## Why this source

29 open-weights models over 11 benchmarks, and unusually it reaches the pre-2024 generation in machine-readable form: Pythia (2.8b-deduped, 6.9b, 12b), GPT-J-6B, GPT-NeoX-20B, BLOOM (3b, 7b1), OPT (2.7b, 6.7b), LLaMA-1, Llama-2 (7b, 13b), MPT-7B, Falcon-7B, RedPajama-INCITE-7B-Base, Qwen-7B and Qwen-7B-Chat, Cerebras BTLM-3B-8K, OpenLLaMA ×3, Mistral-7B, phi-1.5, Baichuan2-7B-Base, and five StableLM releases.

Two of the benchmarks are the reason it is worth having. **SciQ for 29 models and LAMBADA-OpenAI for 29**, both of which the datastore held almost nothing for. MPT-7B's SciQ number, for instance, exists only because Stability measured it — `mosaicml/llm-foundry` has no SciQ anywhere.

## Decision log

**A wrapper rather than a new adapter.** Confidence high. Re-implementing conversion for a format the repo already reads would be two code paths to keep in step.

**Not parameterised into a generic harness-JSON adapter.** There is a second repository of the same shape, so the pattern recurs — but a parameterised adapter is a cross-package design change, and a small file others can copy costs less than a shared abstraction that has to fit every future source. Confidence medium; I would take the argument the other way.

**Mirrors published as the source ran them.** `huggyllama/llama-7b` for LLaMA-1 and `kittn/mistral-7B-v0.1-hf` for Mistral-7B are community mirrors, not first-party repos. Aliasing a mirror onto its upstream is the eval-card-registry's job. Confidence high.

**`RedPajama-INCITE-7B-Base2` filename vs `...-Base` in `model_args`.** The identity comes from `model_args`, which is what the harness was actually given. Confidence high.

**`truthfulqa_mc`'s `mc1`/`mc2` stay namespaced.** They are task-specific constructs rather than global metrics, so `lm-evaluation-harness.mc1` is right and the registry carries no canonical for them. Confidence high.

## Dependency

The runs predate lm-eval v0.4, and the converter's handling of that format was wrong: standard errors were published as scores and `acc_norm`/`ppl` reached no canonical id. This branch **includes** those fixes (#285) so it produces correct records standing alone; they are open separately for review because they change what every lm_eval conversion produces.

## Verification

- `uv run python -m every_eval_ever validate '<out>/data/stablelm-evals/*/*/*.json'` — 293 passed, 0 errors, 0 warnings, at the final datastore path with semantic checks on.
- `uv run python -m every_eval_ever.check_duplicate_entries` — clean.
- `uv run pytest tests/test_stablelm_evals_adapter.py` — 16 passed, offline, no network.
- `uv run pytest tests` — 1,023 passed, 45 skipped.
- `uv run ruff check` — clean.
- Round-tripped against the source: bloom-3b's `sciq` accuracy stays 0.891 and its `lambada_openai` accuracy 0.5173685231903745, each with its published standard error attached.

## Related

- Converter fixes this needs: #285
- Registry ids: evaleval/eval-card-registry#64
- Data: a submission to `evaleval/EEE_datastore` follows
