### PR TITLE
Declare a metric's scale only where something backs the claim

### DIFF
--- a/every_eval_ever/adapters/arc_agi/adapter.py
+++ b/every_eval_ever/adapters/arc_agi/adapter.py
@@ -225,14 +225,15 @@ def compute_metric_bounds(rows: list[dict]) -> dict[str, dict[str, float]]:
         float(row['cost']) for row in rows if row.get('cost') is not None
     ]
 
+    # Cost has no ceiling. An observed maximum is whatever the dearest model in
+    # this batch happened to cost, so declaring it makes the same metric a
+    # different scale on every refresh and two records incomparable.
+    unbounded = {'min_score': 0.0, 'max_score': float('inf')}
     bounds = {'score': {'min_score': 0.0, 'max_score': 1.0}}
     if cost_per_task_values:
-        bounds['cost_per_task'] = {
-            'min_score': 0.0,
-            'max_score': max(cost_per_task_values),
-        }
+        bounds['cost_per_task'] = dict(unbounded)
     if cost_values:
-        bounds['cost'] = {'min_score': 0.0, 'max_score': max(cost_values)}
+        bounds['cost'] = dict(unbounded)
     return bounds
 
 

--- a/every_eval_ever/adapters/artificial_analysis/adapter.py
+++ b/every_eval_ever/adapters/artificial_analysis/adapter.py
@@ -55,7 +55,12 @@ class MetricSpec:
     lower_is_better: bool
     min_score: float
     max_score: float | None = None
-    use_observed_max: bool = False
+    #: The quantity has no ceiling — a price, a latency, a throughput.
+    unbounded_above: bool = False
+    #: The source publishes no range and none can be established from the
+    #: metric's definition, so the record declares no bounds at all and carries
+    #: `bounds_status: unknown` instead of a guess.
+    range_unknown: bool = False
     include_prompt_options: bool = False
 
 
@@ -70,7 +75,7 @@ METRIC_SPECS = [
         metric_unit='points',
         lower_is_better=False,
         min_score=0.0,
-        use_observed_max=True,
+        range_unknown=True,
     ),
     MetricSpec(
         evaluation_name='artificial_analysis.artificial_analysis_coding_index',
@@ -82,7 +87,7 @@ METRIC_SPECS = [
         metric_unit='points',
         lower_is_better=False,
         min_score=0.0,
-        use_observed_max=True,
+        range_unknown=True,
     ),
     MetricSpec(
         evaluation_name='artificial_analysis.artificial_analysis_math_index',
@@ -94,7 +99,7 @@ METRIC_SPECS = [
         metric_unit='points',
         lower_is_better=False,
         min_score=0.0,
-        use_observed_max=True,
+        range_unknown=True,
     ),
     MetricSpec(
         evaluation_name='artificial_analysis.mmlu_pro',
@@ -250,7 +255,7 @@ METRIC_SPECS = [
         metric_unit='usd_per_1m_tokens',
         lower_is_better=True,
         min_score=0.0,
-        use_observed_max=True,
+        unbounded_above=True,
     ),
     MetricSpec(
         evaluation_name='artificial_analysis.price_1m_input_tokens',
@@ -262,7 +267,7 @@ METRIC_SPECS = [
         metric_unit='usd_per_1m_tokens',
         lower_is_better=True,
         min_score=0.0,
-        use_observed_max=True,
+        unbounded_above=True,
     ),
     MetricSpec(
         evaluation_name='artificial_analysis.price_1m_output_tokens',
@@ -274,7 +279,7 @@ METRIC_SPECS = [
         metric_unit='usd_per_1m_tokens',
         lower_is_better=True,
         min_score=0.0,
-        use_observed_max=True,
+        unbounded_above=True,
     ),
     MetricSpec(
         evaluation_name='artificial_analysis.median_output_tokens_per_second',
@@ -286,7 +291,7 @@ METRIC_SPECS = [
         metric_unit='tokens_per_second',
         lower_is_better=False,
         min_score=0.0,
-        use_observed_max=True,
+        unbounded_above=True,
         include_prompt_options=True,
     ),
     MetricSpec(
@@ -299,7 +304,7 @@ METRIC_SPECS = [
         metric_unit='seconds',
         lower_is_better=True,
         min_score=0.0,
-        use_observed_max=True,
+        unbounded_above=True,
         include_prompt_options=True,
     ),
     MetricSpec(
@@ -312,7 +317,7 @@ METRIC_SPECS = [
         metric_unit='seconds',
         lower_is_better=True,
         min_score=0.0,
-        use_observed_max=True,
+        unbounded_above=True,
         include_prompt_options=True,
     ),
 ]
@@ -434,26 +439,6 @@ def get_metric_value(model: dict[str, Any], spec: MetricSpec) -> float | None:
     )
 
 
-def compute_observed_max_scores(
-    models: list[dict[str, Any]],
-) -> dict[str, float]:
-    observed_max_scores: dict[str, float] = {}
-
-    for spec in METRIC_SPECS:
-        if not spec.use_observed_max:
-            continue
-
-        values = [
-            value
-            for model in models
-            if (value := _valid_metric_value(model, spec)) is not None
-        ]
-        if values:
-            observed_max_scores[spec.evaluation_name] = max(values)
-
-    return observed_max_scores
-
-
 def _valid_metric_value(
     model: dict[str, Any], spec: MetricSpec
 ) -> float | None:
@@ -529,13 +514,12 @@ def make_model_info(model: dict[str, Any]) -> tuple[ModelInfo, str, str]:
 
 def make_metric_config(
     spec: MetricSpec,
-    observed_max_scores: dict[str, float],
     prompt_options: dict[str, Any],
 ) -> MetricConfig:
     max_score = spec.max_score
-    if max_score is None:
-        max_score = observed_max_scores.get(spec.evaluation_name)
-    if max_score is None:
+    if spec.unbounded_above:
+        max_score = float('inf')
+    if max_score is None and not spec.range_unknown:
         raise ValueError(
             f'No max_score available for metric {spec.evaluation_name!r}.'
         )
@@ -543,9 +527,15 @@ def make_metric_config(
     additional_details = {
         'raw_metric_field': spec.source_key,
         'bound_strategy': (
-            'observed_max_from_snapshot' if spec.use_observed_max else 'fixed'
+            'unbounded_above'
+            if spec.unbounded_above
+            else 'unknown'
+            if spec.range_unknown
+            else 'fixed'
         ),
     }
+    if spec.range_unknown:
+        additional_details['bounds_status'] = 'unknown'
 
     metric_parameters: dict[str, str | float | bool | None] | None = None
     if spec.include_prompt_options and isinstance(prompt_options, dict):
@@ -556,18 +546,25 @@ def make_metric_config(
         if not metric_parameters:
             metric_parameters = None
 
+    shared = {
+        'evaluation_description': spec.evaluation_description,
+        'metric_id': spec.evaluation_name,
+        'metric_name': spec.metric_name,
+        'metric_kind': spec.metric_kind,
+        'metric_unit': spec.metric_unit,
+        'metric_parameters': metric_parameters,
+        'lower_is_better': spec.lower_is_better,
+        'additional_details': additional_details,
+    }
+    if spec.range_unknown:
+        # No bounds and no score_type. "Not provided" is true where a guessed
+        # range is a claim the source never made.
+        return MetricConfig(**shared)
     return MetricConfig(
-        evaluation_description=spec.evaluation_description,
-        metric_id=spec.evaluation_name,
-        metric_name=spec.metric_name,
-        metric_kind=spec.metric_kind,
-        metric_unit=spec.metric_unit,
-        metric_parameters=metric_parameters,
-        lower_is_better=spec.lower_is_better,
+        **shared,
         score_type=ScoreType.continuous,
         min_score=spec.min_score,
         max_score=max_score,
-        additional_details=additional_details,
     )
 
 
@@ -622,7 +619,6 @@ def make_score_details(
 def make_evaluation_results(
     model: dict[str, Any],
     payload: dict[str, Any],
-    observed_max_scores: dict[str, float],
     *,
     failures: list[SourceRecordFailure] | None = None,
     source_ref: str | None = None,
@@ -642,7 +638,7 @@ def make_evaluation_results(
                     evaluation_name=spec.evaluation_name,
                     source_data=source_data,
                     metric_config=make_metric_config(
-                        spec, observed_max_scores, prompt_options
+                        spec, prompt_options
                     ),
                     score_details=make_score_details(model, spec, score),
                 )
@@ -674,7 +670,6 @@ def make_evaluation_results(
 def make_log(
     model: dict[str, Any],
     payload: dict[str, Any],
-    observed_max_scores: dict[str, float],
     retrieved_timestamp: str,
     *,
     failures: list[SourceRecordFailure] | None = None,
@@ -707,8 +702,7 @@ def make_log(
         evaluation_results=make_evaluation_results(
             model,
             payload,
-            observed_max_scores,
-            failures=failures,
+                failures=failures,
             source_ref=source_ref,
         ),
     )
@@ -720,7 +714,6 @@ def convert_models(
     models: list[dict[str, Any]],
     payload: dict[str, Any],
     output_dir: Path,
-    observed_max_scores: dict[str, float],
     retrieved_timestamp: str,
 ) -> SourceConversionResult[EvaluationLogOutput]:
     """Convert usable models while retaining model and metric failures."""
@@ -733,8 +726,7 @@ def convert_models(
             log, developer, model_path_name = make_log(
                 model,
                 payload,
-                observed_max_scores,
-                retrieved_timestamp,
+                        retrieved_timestamp,
                 failures=failures,
                 source_ref=source_ref,
             )
@@ -788,14 +780,12 @@ def run(args: argparse.Namespace) -> int:
 
     maybe_save_raw_json(payload, args.save_raw_json)
     models = validate_payload(payload)
-    observed_max_scores = compute_observed_max_scores(models)
     retrieved_timestamp = str(time.time())
 
     result = convert_models(
         models,
         payload,
         args.output_dir,
-        observed_max_scores,
         retrieved_timestamp,
     )
     paths = save_evaluation_logs(result.records)

--- a/every_eval_ever/adapters/bfcl/adapter.py
+++ b/every_eval_ever/adapters/bfcl/adapter.py
@@ -55,7 +55,7 @@ class MetricSpec:
     lower_is_better: bool
     min_score: float
     max_score: float | None = None
-    use_observed_max: bool = False
+    unbounded_above: bool = False
 
 
 METRIC_SPECS = [
@@ -68,7 +68,7 @@ METRIC_SPECS = [
         metric_unit='position',
         lower_is_better=True,
         min_score=1.0,
-        use_observed_max=True,
+        unbounded_above=True,
     ),
     MetricSpec(
         evaluation_name='bfcl.overall.overall_accuracy',
@@ -90,7 +90,7 @@ METRIC_SPECS = [
         metric_unit='usd',
         lower_is_better=True,
         min_score=0.0,
-        use_observed_max=True,
+        unbounded_above=True,
     ),
     MetricSpec(
         evaluation_name='bfcl.overall.latency_mean_s',
@@ -101,7 +101,7 @@ METRIC_SPECS = [
         metric_unit='seconds',
         lower_is_better=True,
         min_score=0.0,
-        use_observed_max=True,
+        unbounded_above=True,
     ),
     MetricSpec(
         evaluation_name='bfcl.overall.latency_std_s',
@@ -112,7 +112,7 @@ METRIC_SPECS = [
         metric_unit='seconds',
         lower_is_better=True,
         min_score=0.0,
-        use_observed_max=True,
+        unbounded_above=True,
     ),
     MetricSpec(
         evaluation_name='bfcl.overall.latency_p95_s',
@@ -123,7 +123,7 @@ METRIC_SPECS = [
         metric_unit='seconds',
         lower_is_better=True,
         min_score=0.0,
-        use_observed_max=True,
+        unbounded_above=True,
     ),
     MetricSpec(
         evaluation_name='bfcl.non_live.ast_accuracy',
@@ -457,43 +457,17 @@ def make_source_data() -> dict:
     }
 
 
-def compute_observed_max_scores(rows: list[dict]) -> dict[str, float]:
-    observed_max_scores: dict[str, float] = {}
-    for spec in METRIC_SPECS:
-        if not spec.use_observed_max:
-            continue
-
-        values = []
-        for row in rows:
-            try:
-                value = parse_value(row.get(spec.column, ''))
-            except (TypeError, ValueError):
-                continue
-            if value is not None:
-                values.append(value)
-
-        if not values:
-            raise SystemExit(
-                f'Could not determine max_score for {spec.column!r}; no numeric values were found.'
-            )
-
-        observed_max_scores[spec.column] = max(values)
-
-    return observed_max_scores
-
-
 def make_result(
     row: dict,
     spec: MetricSpec,
-    observed_max_scores: dict[str, float],
 ) -> dict | None:
     value = parse_value(row[spec.column])
     if value is None:
         return None
 
     max_score = spec.max_score
-    if spec.use_observed_max:
-        max_score = observed_max_scores[spec.column]
+    if spec.unbounded_above:
+        max_score = float('inf')
 
     return {
         'evaluation_result_id': f'{spec.evaluation_name}::{spec.metric_id.split(".")[-1]}',
@@ -519,11 +493,11 @@ def make_result(
 
 
 def make_results(
-    row: dict, observed_max_scores: dict[str, float]
+    row: dict
 ) -> list[dict]:
     results = []
     for spec in METRIC_SPECS:
-        result = make_result(row, spec, observed_max_scores)
+        result = make_result(row, spec)
         if result is not None:
             results.append(result)
     return results
@@ -531,7 +505,6 @@ def make_results(
 
 def make_log(
     row: dict,
-    observed_max_scores: dict[str, float],
     retrieved_timestamp: str,
 ) -> tuple[dict, str, str]:
     raw_model = row['Model']
@@ -578,7 +551,7 @@ def make_log(
             'developer': developer,
             'additional_details': additional_details,
         },
-        'evaluation_results': make_results(row, observed_max_scores),
+        'evaluation_results': make_results(row),
     }
 
     return log, developer, model
@@ -587,7 +560,6 @@ def make_log(
 def convert_rows(
     rows: list[dict],
     out_root: Path,
-    observed_max_scores: dict[str, float],
     retrieved_timestamp: str,
 ) -> SourceConversionResult[EvaluationLogOutput]:
     outputs = []
@@ -595,7 +567,7 @@ def convert_rows(
     for index, row in enumerate(rows, start=2):
         try:
             raw_log, developer, model = make_log(
-                row, observed_max_scores, retrieved_timestamp
+                row, retrieved_timestamp
             )
             log = EvaluationLog.model_validate(raw_log)
             if not log.evaluation_results:
@@ -642,7 +614,6 @@ def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
 
     rows = load_rows(args.input_csv)
-    observed_max_scores = compute_observed_max_scores(rows)
     retrieved_timestamp = str(time.time())
 
     if args.model is not None:
@@ -656,7 +627,6 @@ def main(argv: list[str] | None = None) -> None:
     result = convert_rows(
         rows,
         args.output_dir,
-        observed_max_scores,
         retrieved_timestamp,
     )
     paths = save_evaluation_logs(result.records)

--- a/every_eval_ever/adapters/cocoabench/adapter.py
+++ b/every_eval_ever/adapters/cocoabench/adapter.py
@@ -327,15 +327,16 @@ def compute_metric_bounds(
         }
     }
 
+    # A duration and a dollar cost have no ceiling. An observed maximum is a
+    # property of this batch, so declaring it makes the same metric a different
+    # scale on every refresh.
+    unbounded = {'min_score': 0.0, 'max_score': float('inf')}
     if avg_times:
-        bounds['avg_time_s'] = {'min_score': 0.0, 'max_score': max(avg_times)}
+        bounds['avg_time_s'] = dict(unbounded)
     if avg_costs:
-        bounds['avg_cost_usd'] = {'min_score': 0.0, 'max_score': max(avg_costs)}
+        bounds['avg_cost_usd'] = dict(unbounded)
     if total_costs:
-        bounds['total_cost_usd'] = {
-            'min_score': 0.0,
-            'max_score': max(total_costs),
-        }
+        bounds['total_cost_usd'] = dict(unbounded)
 
     return bounds
 

--- a/every_eval_ever/adapters/sciarena/adapter.py
+++ b/every_eval_ever/adapters/sciarena/adapter.py
@@ -94,21 +94,18 @@ def compute_metric_bounds(rows: list[dict]) -> dict[str, dict[str, float]]:
         and _is_float(row["cost_per_100_calls_usd"])
     ]
 
+    # An Elo rating, a leaderboard rank and a dollar cost have no ceiling. The
+    # observed extremes are properties of today's roster, so declaring them
+    # gives the same metric a different scale whenever the roster changes.
     bounds = {
-        "elo": {
-            "min_score": min(rating_values),
-            "max_score": max(rating_values),
-        },
-        "rank": {
-            "min_score": 1.0,
-            "max_score": max(rank_values),
-        },
+        "elo": {"min_score": 0.0, "max_score": float("inf")},
+        "rank": {"min_score": 1.0, "max_score": float("inf")},
     }
 
     if cost_values:
         bounds["cost_per_100_calls_usd"] = {
             "min_score": 0.0,
-            "max_score": max(cost_values),
+            "max_score": float("inf"),
         }
 
     return bounds

--- a/every_eval_ever/converters/lm_eval/adapter.py
+++ b/every_eval_ever/converters/lm_eval/adapter.py
@@ -39,6 +39,7 @@ from every_eval_ever.helpers.io import (
 )
 
 from .utils import (
+    CANONICAL_RESCALE,
     LM_EVAL_HARNESS_ID,
     LM_EVAL_METRIC_BOUNDS,
     MODEL_TYPE_TO_INFERENCE_ENGINE,
@@ -314,6 +315,27 @@ class LMEvalAdapter(BaseEvaluationAdapter):
                     ),
                 )
 
+            # A percentage converted onto its canonical proportion scale. The
+            # source figure is kept, and the spread moves with the score — a
+            # spread is in the score's units, and left alone it reads as wider
+            # than the metric's whole range.
+            details = None
+            factor = CANONICAL_RESCALE.get(metric_name)
+            if factor is not None and isinstance(value, (int, float)):
+                details = {
+                    'canonical_rescale_factor': str(factor),
+                    'rescale_basis': 'harness_percent_to_canonical_proportion',
+                    'source_score': str(value),
+                }
+                value = value * factor
+                if uncertainty is not None and uncertainty.standard_error:
+                    details['source_standard_error'] = str(
+                        uncertainty.standard_error.value
+                    )
+                    uncertainty.standard_error.value = (
+                        uncertainty.standard_error.value * factor
+                    )
+
             eval_name = task_name
             if filter_name != 'none':
                 eval_name = f'{task_name}/{filter_name}'
@@ -330,6 +352,7 @@ class LMEvalAdapter(BaseEvaluationAdapter):
                     score_details=ScoreDetails(
                         score=value,
                         uncertainty=uncertainty,
+                        details=details,
                     ),
                     generation_config=gen_config,
                 )

--- a/every_eval_ever/converters/lm_eval/utils.py
+++ b/every_eval_ever/converters/lm_eval/utils.py
@@ -135,10 +135,20 @@ LM_EVAL_HARNESS_ID = 'lm-evaluation-harness'
 # and `ter` are sacrebleu's, which report 0-100 rather than the 0-1 of nltk's
 # sentence_bleu; `ter` has no ceiling, since a hypothesis can need more edits
 # than the reference has tokens.
+#: Metrics the harness reports as a percentage of a quantity whose canonical
+#: registry entry is a proportion. BLEU is a brevity penalty times a geometric
+#: mean of clipped precisions, so the quantity is on `[0, 1]` and sacrebleu's
+#: x100 is a rendering of it. `chrf` and `ter` are percentages too, but neither
+#: resolves to a registry entry, so they stay namespaced on the scale the harness
+#: used and need no conversion.
+CANONICAL_RESCALE: dict[str, float] = {'bleu': 0.01}
+
 LM_EVAL_METRIC_BOUNDS = {
     'mc1': (0.0, 1.0),
     'mc2': (0.0, 1.0),
-    'bleu': (0.0, 100.0),
+    # Declared on the canonical proportion scale, which the adapter converts
+    # the harness's percentage onto. See CANONICAL_RESCALE.
+    'bleu': (0.0, 1.0),
     'chrf': (0.0, 100.0),
     'rouge1': (0.0, 1.0),
     'rouge2': (0.0, 1.0),

--- a/every_eval_ever/helpers/schema.py
+++ b/every_eval_ever/helpers/schema.py
@@ -30,43 +30,51 @@ def make_metric_config(
     description: str,
     lower_is_better: bool = False,
     score_type: ScoreType = ScoreType.continuous,
-    min_score: float = 0.0,
-    max_score: float = 1.0,
+    min_score: Optional[float] = None,
+    max_score: Optional[float] = None,
     level_names: Optional[List[str]] = None,
     has_unknown_level: Optional[bool] = None,
 ) -> MetricConfig:
-    """
-    Create a MetricConfig with sensible defaults.
+    """Build a ``MetricConfig``.
 
-    Most evaluations use continuous scores from 0-1 where higher is better,
-    so those are the defaults.
+    A ``continuous`` metric needs both bounds, and they are the caller's to
+    supply. There is no default pair, because `[0, 1]` is a claim about the
+    scale a score was computed on and a wrong one is a wrong number no reader
+    can detect. Pass ``float('inf')`` for a quantity with no ceiling.
 
     Args:
         description: Human-readable description of the metric
         lower_is_better: Whether lower scores are better (default: False)
         score_type: Type of score (default: continuous)
-        min_score: Minimum possible score (default: 0.0)
-        max_score: Maximum possible score (default: 1.0)
+        min_score: Low end of the scale this score is on. Required for
+            ``continuous``.
+        max_score: High end of the same scale. Required for ``continuous``.
         level_names: For level-based scores, the names of each level
         has_unknown_level: For level-based scores, whether -1 means unknown
 
-    Returns:
-        Configured MetricConfig instance
+    Raises:
+        ValueError: if a ``continuous`` metric is missing either bound.
     """
-    config = MetricConfig(
-        evaluation_description=description,
-        lower_is_better=lower_is_better,
-        score_type=score_type,
-    )
+    fields: dict = {
+        'evaluation_description': description,
+        'lower_is_better': lower_is_better,
+        'score_type': score_type,
+    }
 
     if score_type == ScoreType.continuous:
-        config.min_score = min_score
-        config.max_score = max_score
+        if min_score is None or max_score is None:
+            raise ValueError(
+                'a continuous metric needs min_score and max_score — the '
+                "scale the score was computed on. Pass float('inf') for a "
+                'quantity with no ceiling.'
+            )
+        fields['min_score'] = min_score
+        fields['max_score'] = max_score
     elif score_type == ScoreType.levels and level_names:
-        config.level_names = level_names
-        config.has_unknown_level = has_unknown_level
+        fields['level_names'] = level_names
+        fields['has_unknown_level'] = has_unknown_level
 
-    return config
+    return MetricConfig(**fields)
 
 
 def make_evaluation_result(
@@ -75,8 +83,8 @@ def make_evaluation_result(
     description: str,
     lower_is_better: bool = False,
     score_type: ScoreType = ScoreType.continuous,
-    min_score: float = 0.0,
-    max_score: float = 1.0,
+    min_score: Optional[float] = None,
+    max_score: Optional[float] = None,
     details: Optional[Dict[str, Any]] = None,
     generation_config: Optional[Dict[str, Any]] = None,
 ) -> EvaluationResult:

--- a/tests/test_active_adapter_publication.py
+++ b/tests/test_active_adapter_publication.py
@@ -32,14 +32,11 @@ def test_bfcl_keeps_valid_rows_when_another_row_is_malformed(
         }
     )
     for spec in bfcl.METRIC_SPECS:
-        if spec.use_observed_max:
+        if spec.unbounded_above:
             valid[spec.column] = '1'
     invalid = valid | {'Overall Acc': 'nan'}
 
-    bounds = bfcl.compute_observed_max_scores([valid, invalid])
-    result = bfcl.convert_rows(
-        [valid, invalid], tmp_path / 'data', bounds, '123'
-    )
+    result = bfcl.convert_rows([valid, invalid], tmp_path / 'data', '123')
 
     assert len(result.records) == 1
     assert len(result.failures) == 1

--- a/tests/test_arc_agi_adapter.py
+++ b/tests/test_arc_agi_adapter.py
@@ -187,7 +187,9 @@ def test_score_and_cost_results_carry_source_fields():
     assert cost_result.score_details.score == 8.42
     assert cost_result.metric_config.lower_is_better is True
     # Bounds come from the largest observed value across the payload.
-    assert cost_result.metric_config.max_score == 17.0
+    # Cost has no ceiling. Declaring the batch's dearest model as one made the
+    # same metric a different scale on every refresh.
+    assert cost_result.metric_config.max_score == float('inf')
 
 
 def test_cost_metric_used_when_cost_per_task_missing():

--- a/tests/test_artificial_analysis_adapter.py
+++ b/tests/test_artificial_analysis_adapter.py
@@ -1,6 +1,7 @@
 from every_eval_ever.adapters.artificial_analysis.adapter import (
-    compute_observed_max_scores,
+    METRIC_SPECS,
     convert_models,
+    make_metric_config,
 )
 
 
@@ -26,13 +27,11 @@ def test_bad_metric_keeps_model_with_other_valid_metrics(tmp_path):
             'mmlu_pro': 'not-a-score',
         },
     )
-    bounds = compute_observed_max_scores([valid])
 
     result = convert_models(
         [valid],
         {},
         tmp_path / 'data' / 'artificial-analysis-llms',
-        bounds,
         '1234',
     )
 
@@ -55,16 +54,35 @@ def test_bad_identity_does_not_discard_other_models(tmp_path):
         '',
         {'artificial_analysis_intelligence_index': 25},
     )
-    bounds = compute_observed_max_scores([good, bad])
 
     result = convert_models(
         [good, bad],
         {},
         tmp_path / 'data' / 'artificial-analysis-llms',
-        bounds,
         '1234',
     )
 
     assert len(result.records) == 1
     assert len(result.failures) == 1
     assert result.failures[0].source_record == bad
+
+
+def _spec(name):
+    return next(s for s in METRIC_SPECS if s.evaluation_name.endswith(name))
+
+
+def test_an_unbounded_quantity_declares_no_ceiling():
+    """A price has none, and the dearest model in a batch is not one."""
+    config = make_metric_config(_spec('price_1m_input_tokens'), {})
+    assert config.max_score == float('inf')
+    assert config.additional_details['bound_strategy'] == 'unbounded_above'
+
+
+def test_a_metric_with_no_published_range_declares_no_bounds():
+    config = make_metric_config(
+        _spec('artificial_analysis_intelligence_index'), {}
+    )
+    assert config.min_score is None
+    assert config.max_score is None
+    assert config.score_type is None
+    assert config.additional_details['bounds_status'] == 'unknown'

--- a/tests/test_converter_metric_bounds.py
+++ b/tests/test_converter_metric_bounds.py
@@ -124,17 +124,30 @@ def test_a_dispersion_metric_claims_no_direction():
     assert config.additional_details == {'polarity': 'not_applicable'}
 
 
-def test_the_same_metric_name_can_mean_two_scales():
-    """lm-eval's `bleu` is sacrebleu's 0-100; HELM's `bleu_1` is nltk's 0-1.
+def test_a_harness_percentage_is_declared_on_its_canonical_scale():
+    """lm-eval reports sacrebleu's `bleu` on 0-100, and `bleu` resolves.
 
-    This is why the bounds are layered per harness rather than kept in one table
-    keyed by a bare metric name.
+    `fields.md` takes the bounds from the resolved registry entry when the metric
+    resolves, and that entry is a proportion, so the record declares `[0, 1]` and
+    the adapter converts the value onto it. HELM's `bleu_1` is nltk's proportion
+    already and needs no conversion.
     """
     lm_eval_bleu = _config('bleu', LM_EVAL_METRIC_BOUNDS)
     helm_bleu = _config('bleu_1', HELM_METRIC_BOUNDS)
 
-    assert (lm_eval_bleu.min_score, lm_eval_bleu.max_score) == (0.0, 100.0)
+    assert (lm_eval_bleu.min_score, lm_eval_bleu.max_score) == (0.0, 1.0)
     assert (helm_bleu.min_score, helm_bleu.max_score) == (0.0, 1.0)
+
+
+def test_a_percentage_that_resolves_to_nothing_keeps_the_harness_scale():
+    """`chrf` is a percentage and is in no registry entry.
+
+    So it is published namespaced on the scale the harness used, which is why the
+    bounds stay layered per harness rather than folded into one table keyed by a
+    bare metric name.
+    """
+    chrf = _config('chrf', LM_EVAL_METRIC_BOUNDS)
+    assert (chrf.min_score, chrf.max_score) == (0.0, 100.0)
 
 
 def test_a_multi_class_brier_score_is_allowed_its_full_range():
@@ -231,11 +244,12 @@ def test_a_parameter_in_the_name_keeps_the_bounds_but_not_the_id():
     assert config.metric_parameters == {'k': 5}
 
 
-def test_the_unit_follows_the_scale_the_harness_actually_reported():
-    """lm-eval's `bleu` is sacrebleu's 0-100, HELM's `bleu_1` nltk's 0-1.
+def test_the_unit_follows_the_declared_scale():
+    """Two BLEUs under one canonical id now agree on their unit.
 
-    Both are BLEU and both say so in `metric_kind`; the unit is what keeps a
-    consumer from averaging 31.4 with 0.314.
+    Both say `text_overlap` in `metric_kind`. Before the conversion the unit was
+    the only thing keeping a consumer from averaging 31.4 with 0.314, and a join
+    key should not need a second field to be read safely.
     """
     lm_eval_bleu = _identified(
         'bleu', harness=LM_EVAL_HARNESS_ID, bounds_table=LM_EVAL_METRIC_BOUNDS
@@ -244,9 +258,14 @@ def test_the_unit_follows_the_scale_the_harness_actually_reported():
         'bleu_1', harness=HELM_HARNESS_ID, bounds_table=HELM_METRIC_BOUNDS
     )
 
-    assert lm_eval_bleu.metric_unit == 'percent'
+    assert lm_eval_bleu.metric_unit == 'proportion'
     assert helm_bleu.metric_unit == 'proportion'
     assert lm_eval_bleu.metric_kind == helm_bleu.metric_kind == 'text_overlap'
+
+    chrf = _identified(
+        'chrf', harness=LM_EVAL_HARNESS_ID, bounds_table=LM_EVAL_METRIC_BOUNDS
+    )
+    assert chrf.metric_unit == 'percent'
 
 
 def test_a_metric_with_no_resolved_range_claims_no_unit():

--- a/tests/test_lm_eval_adapter.py
+++ b/tests/test_lm_eval_adapter.py
@@ -622,3 +622,52 @@ def test_directory_conversion_tracks_each_results_file_parent(tmp_path):
         for log in result.records
     }
     assert parents == {str(model_a), str(model_b)}
+
+
+def _bleu_log(tmp_path, stderr=None):
+    """A minimal lm-eval results file reporting sacrebleu's BLEU on 0-100."""
+    metric = {'bleu,none': 31.4}
+    if stderr is not None:
+        metric['bleu_stderr,none'] = stderr
+    payload = {
+        'results': {'wmt16': metric},
+        'configs': {'wmt16': {'metric_list': [{'metric': 'bleu'}]}},
+        'higher_is_better': {'wmt16': {'bleu': True}},
+        'n-samples': {'wmt16': {'effective': 2000, 'original': 2000}},
+        'model_name': 'openai/gpt-4o',
+        'config': {'model': 'hf', 'model_args': 'pretrained=openai/gpt-4o'},
+    }
+    path = tmp_path / 'results_bleu.json'
+    path.write_text(json.dumps(payload))
+    logs = LMEvalAdapter().transform_from_file(path, _make_metadata_args())
+    return logs[0].evaluation_results[0]
+
+
+def test_a_percentage_is_converted_onto_the_canonical_proportion(tmp_path):
+    """`bleu` resolves, so the record declares the entry's scale and converts.
+
+    Publishing 31.4 under the canonical id `bleu` while declaring `[0, 100]` left
+    a consumer to average it with another source's 0.314.
+    """
+    result = _bleu_log(tmp_path)
+
+    assert result.score_details.score == pytest.approx(0.314)
+    assert result.metric_config.max_score == 1.0
+    assert result.metric_config.metric_id == 'bleu'
+    details = result.score_details.details
+    assert details['canonical_rescale_factor'] == '0.01'
+    assert details['source_score'] == '31.4'
+
+
+def test_the_spread_moves_with_the_score(tmp_path):
+    """A spread is in the score's units.
+
+    Left unconverted beside a converted score it reads as wider than the
+    metric's whole range, which is the shape of the bug #276 fixed elsewhere.
+    """
+    result = _bleu_log(tmp_path, stderr=0.82)
+
+    assert result.score_details.uncertainty.standard_error.value == pytest.approx(
+        0.0082
+    )
+    assert result.score_details.details['source_standard_error'] == '0.82'

--- a/tests/test_schema_helpers.py
+++ b/tests/test_schema_helpers.py
@@ -1,0 +1,64 @@
+"""The schema helpers refuse to guess a metric's scale.
+
+`make_metric_config` used to default `min_score=0.0, max_score=1.0` and build
+`MetricConfig` before assigning them, so the documented default path raised
+rather than producing a record — the helper could not emit a continuous metric at
+all. Fixing the crash without removing the default would have turned a broken
+helper into a silent one, since `[0, 1]` is a claim about the scale a score was
+computed on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from every_eval_ever.eval_types import ScoreType
+from every_eval_ever.helpers.schema import (
+    make_evaluation_result,
+    make_metric_config,
+)
+
+
+def test_a_continuous_metric_needs_both_bounds():
+    with pytest.raises(ValueError, match='needs min_score and max_score'):
+        make_metric_config('Accuracy on the thing')
+
+
+def test_stated_bounds_reach_the_config():
+    config = make_metric_config('Accuracy', min_score=0.0, max_score=100.0)
+    assert (config.min_score, config.max_score) == (0.0, 100.0)
+    assert config.score_type is ScoreType.continuous
+
+
+def test_a_quantity_with_no_ceiling_is_expressible():
+    config = make_metric_config(
+        'Cost in USD',
+        lower_is_better=True,
+        min_score=0.0,
+        max_score=float('inf'),
+    )
+    assert config.max_score == float('inf')
+
+
+def test_a_level_based_metric_needs_no_bounds():
+    config = make_metric_config(
+        'Risk level',
+        score_type=ScoreType.levels,
+        level_names=['low', 'medium', 'high'],
+        has_unknown_level=False,
+    )
+    assert config.level_names == ['low', 'medium', 'high']
+    assert config.min_score is None
+
+
+def test_the_result_helper_carries_the_same_requirement():
+    """It refuses before it reaches the part of itself that is stale.
+
+    `make_evaluation_result` never supplies `source_data`, which
+    `EvaluationResult` requires, so it cannot build a result even with bounds
+    given. That is a separate defect; this only pins that the missing-bounds
+    refusal happens first, and names the message so the caller is told what to
+    supply rather than shown a schema error.
+    """
+    with pytest.raises(ValueError, match='needs min_score and max_score'):
+        make_evaluation_result('MMLU', 73.4, 'Accuracy')

--- a/tests/test_verify_metric_ids.py
+++ b/tests/test_verify_metric_ids.py
@@ -1,0 +1,84 @@
+"""Offline cover for the registry verifier.
+
+The resolution pass needs a checkout of ``eval-card-registry``, but ``normalize``,
+``registry_index`` and ``bounds_conflicts`` do not — an inline seed exercises all
+three. ``normalize`` is the one most easily broken by a well-meaning edit, since
+dropping ``+`` from its character class silently maps ``chrf`` onto the registry's
+``chrF++``, which is a different metric.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip('yaml')
+
+from tools import verify_metric_ids as verifier  # noqa: E402
+
+SEED = """
+metrics:
+- id: bleu
+  display_name: bleu
+  aliases:
+  - spBLEU
+  min_score: 0.0
+  max_score: 1.0
+- id: chrf-plus-plus
+  display_name: chrF++
+  min_score: 0.0
+  max_score: 1.0
+- id: perplexity
+  min_score: 1.0
+  max_score: null
+"""
+
+
+@pytest.fixture
+def seed(tmp_path):
+    path = tmp_path / 'metrics.yaml'
+    path.write_text(SEED)
+    return path
+
+
+def test_normalize_keeps_the_plus_that_separates_two_metrics():
+    assert verifier.normalize('chrF++') != verifier.normalize('chrF')
+    assert verifier.normalize('chrF++') == 'chrf++'
+
+
+def test_normalize_folds_case_and_separators():
+    assert verifier.normalize('Exact Match') == verifier.normalize('exact_match')
+
+
+def test_registry_index_maps_every_surface_form(seed):
+    index = verifier.registry_index(seed)
+    assert index[verifier.normalize('spBLEU')] == {'bleu'}
+    assert index[verifier.normalize('chrF++')] == {'chrf-plus-plus'}
+    assert verifier.normalize('chrf') not in index
+
+
+def test_registry_bounds_reports_an_absent_ceiling_as_none(seed):
+    assert verifier.registry_bounds(seed)['perplexity'] == (1.0, None)
+
+
+def test_a_declared_scale_contradicting_its_entry_is_reported(seed, monkeypatch):
+    monkeypatch.setitem(verifier.CANONICAL_METRIC_IDS, 'bleu', 'bleu')
+    monkeypatch.setitem(verifier.LM_EVAL_METRIC_BOUNDS, 'bleu', (0.0, 100.0))
+    found = verifier.bounds_conflicts(seed)
+    assert any('bleu -> bleu' in row and '100.0' in row for row in found)
+
+
+def test_an_entry_declaring_no_ceiling_constrains_nothing(seed, monkeypatch):
+    monkeypatch.setitem(
+        verifier.CANONICAL_METRIC_IDS, 'perplexity', 'perplexity'
+    )
+    monkeypatch.setitem(
+        verifier.LM_EVAL_METRIC_BOUNDS, 'perplexity', (1.0, float('inf'))
+    )
+    assert not [r for r in verifier.bounds_conflicts(seed) if 'perplexity' in r]
+
+
+def test_an_unmapped_name_is_not_compared(seed, monkeypatch):
+    """A namespaced metric cites no entry, so it cannot contradict one."""
+    monkeypatch.delitem(verifier.CANONICAL_METRIC_IDS, 'bleu', raising=False)
+    monkeypatch.setitem(verifier.LM_EVAL_METRIC_BOUNDS, 'bleu', (0.0, 100.0))
+    assert not [r for r in verifier.bounds_conflicts(seed) if 'bleu' in r]

--- a/tools/verify_metric_ids.py
+++ b/tools/verify_metric_ids.py
@@ -16,6 +16,7 @@ of the test suite: it needs a checkout of a different repository.
 from __future__ import annotations
 
 import argparse
+import math
 import re
 import sys
 from pathlib import Path
@@ -84,6 +85,69 @@ def registry_index(seed_path: Path) -> dict[str, set[str]]:
     return index
 
 
+def registry_bounds(seed_path: Path) -> dict[str, tuple[float | None, float | None]]:
+    """Each canonical id's declared bounds, or ``None`` where it declares none.
+
+    An entry with no ``max_score`` asserts nothing about scale, which is the
+    correct state for a metric whose range depends on the implementation that
+    computed it. 117 of the registry's entries are in that state.
+    """
+    import yaml
+
+    loaded = yaml.safe_load(seed_path.read_text(encoding='utf-8'))
+    entries = (
+        loaded['metrics']
+        if isinstance(loaded, dict) and 'metrics' in loaded
+        else loaded
+    )
+    bounds: dict[str, tuple[float | None, float | None]] = {}
+    for entry in entries:
+        bounds[entry['id']] = (
+            entry.get('min_score'),
+            entry.get('max_score'),
+        )
+    return bounds
+
+
+def bounds_conflicts(seed_path: Path) -> list[str]:
+    """Names whose declared scale contradicts the entry they are published under.
+
+    ``fields.md`` takes the bounds from the resolved registry entry when the
+    metric resolves. A record that cites a canonical id while declaring a
+    different range tells a consumer two things at once, and the consumer that
+    normalizes from the entry gets the wrong number.
+    """
+    entry_bounds = registry_bounds(seed_path)
+    #: Every table a converter declares a scale in, so the check covers all
+    #: three rather than only the harness that happened to surface it.
+    declared_bounds: dict[str, tuple] = {}
+    for table in (
+        SHARED_METRIC_BOUNDS,
+        HELM_METRIC_BOUNDS,
+        LM_EVAL_METRIC_BOUNDS,
+    ):
+        declared_bounds.update(table)
+    found: list[str] = []
+    for name, declared in sorted(declared_bounds.items()):
+        canonical = CANONICAL_METRIC_IDS.get(name)
+        if canonical is None:
+            continue
+        entry = entry_bounds.get(canonical)
+        if entry is None:
+            continue
+        for position, index in (('min', 0), ('max', 1)):
+            ours, theirs = declared[index], entry[index]
+            if theirs is None or ours is None:
+                continue
+            if math.isinf(float(ours)) or float(ours) == float(theirs):
+                continue
+            found.append(
+                f'{name} -> {canonical}: declares {position}_score '
+                f'{ours}, entry says {theirs}'
+            )
+    return found
+
+
 def harness_report(harnesses_path: Path) -> str:
     """Which converters' namespaces the registry knows as harnesses.
 
@@ -131,6 +195,7 @@ def main(argv: list[str] | None = None) -> int:
     stale: list[str] = []
     ambiguous: list[str] = []
     newly_resolvable: list[str] = []
+    conflicting = bounds_conflicts(args.seed)
 
     for name in sorted(known_names):
         hits = index.get(normalize(name), set())
@@ -168,6 +233,7 @@ def main(argv: list[str] | None = None) -> int:
         ('MAPPED ID NO LONGER IN THE REGISTRY', stale),
         ('NOW RESOLVABLE, STILL NAMESPACED', newly_resolvable),
         ('AMBIGUOUS IN THE REGISTRY', ambiguous),
+        ('DECLARED SCALE CONTRADICTS THE ENTRY', conflicting),
     ):
         print(f'\n{label}: {len(rows)}')
         for row in rows:
@@ -187,7 +253,11 @@ def main(argv: list[str] | None = None) -> int:
         print(f'  {name}')
     print(f'\nHARNESS SLUGS: {harness_report(harnesses)}')
 
-    return 1 if stale or newly_resolvable or ambiguous else 0
+    return (
+        1
+        if stale or newly_resolvable or ambiguous or conflicting
+        else 0
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What / source

A metric's declared bounds are a claim about the scale its score was computed on. Four ways that claim was being made without anything to back it, and one check so the first of them cannot recur.

`fields.md` already states every rule here. Nothing enforced any of them, and the validator never consults the registry at all.

1. **A declared scale contradicting the entry it cites.** lm-eval published sacrebleu's BLEU as `31.4` under the canonical id `bleu`, declaring `max_score: 100.0`, while that entry says `1.0`. The cross-source join `metric_id` exists for would average it against another source's `0.314`, with `metric_unit` the only thing separating them. `bounds_conflicts` in `tools/verify_metric_ids.py` now compares every scale the three converter bounds tables declare against its entry, and the verifier exits non-zero on a disagreement. An entry with no `max_score` asserts nothing and constrains nothing — 117 of the registry's 397 entries are in that state.

2. **An observed maximum declared as a ceiling, at 22 sites across five adapters and one converter.** Two of them had a function called `compute_observed_max_scores`. The ceiling moved whenever a new model entered the leaderboard, so the same `metric_id` declared a different scale on every refresh and two records of one metric stopped being comparable — and three of the five adapters run on the daily cron, so it happened without anyone choosing it. Costs, durations, latencies, throughputs, a token count, an Elo rating, and a rank whose maximum was only that day's entrant count now declare no ceiling.

3. **BLEU converted onto the scale its entry declares.** BLEU is a brevity penalty times a geometric mean of clipped precisions, so the quantity is on `[0, 1]` and sacrebleu's ×100 is a rendering of it. Percent to proportion is provable from the definition, so the record declares `[0, 1]`, carries `canonical_rescale_factor` and the source figure, and **the standard error converts with the score** — a spread is in the score's units, which is the shape of the bug #276 fixed in the Papers with Code adapter.

4. **`make_metric_config` no longer guesses.** It defaulted `min_score=0.0, max_score=1.0` and built `MetricConfig` before assigning either, and the model rejects `continuous` without `min_score` — so its documented default path raised and it could not emit a continuous metric at all. Both bounds are now the caller's, with a message naming what to pass including `float('inf')`.

## Review lane

- [ ] **Fast**
- [x] **Needs a human** — a material change in outcome. The same input now produces different records for BLEU and for every metric that had an observed-maximum ceiling.

Design agreed in: nothing prior, and I want to be straight about that. Every change here applies a rule `fields.md` already states rather than proposing a new one, and each is a correction of a clear violation — but the outcome change is real and wants a maintainer's eye. Context for how these were found is on #250.

## Checklist

- [x] `uv run pytest tests` green — 1125 passed, 1 skipped
- [x] `uv run ruff check` clean
- [x] `uv run --extra all python tools/verify_metric_ids.py --seed <registry>/seed/metrics.yaml` reports **0** metrics whose declared scale contradicts their entry, with the registry unchanged
- [x] offline tests added: 7 for the verifier, which had none, plus 5 for the schema helper and 4 for the new bounds behaviour
- [ ] **count of already-published records this would change: not measured.** This is the rung-1 question and I have not answered it. Every BLEU record from the lm-eval converter and every record carrying an observed-maximum ceiling would differ on a re-run. Happy to measure it before this merges if you want the number first.

## Decisions & coverage

- Decision / where: Artificial Analysis' three composite indices — intelligence, coding, math.
  Chose **no bounds and no `score_type`, with `bounds_status: unknown`** / instead of: declaring infinity.
  Confidence: medium. The source publishes no range and the definition fixes none, and I could not establish one offline. `fields.md` says "not provided" beats a guess, and infinity is its own claim. If AA documents these as 0–100 it is a one-line change back.
  General? **yes** — the distinction between *unbounded* and *range unknown* applies to any leaderboard metric.

- Decision / where: the registry's `bleu` entry.
  Chose **leave it at `[0, 1]` and convert the value** / instead of: widening the entry to `[0, 100]`.
  Confidence: high. `[0, 1]` is the quantity's actual range; 0–100 is a percentage rendering. I drafted the entry change first and reverted it.
  General? no.

- Decision / where: `chrf` and `ter`.
  Chose **leave them on the harness's percent scale** / instead of: converting them too.
  Confidence: high. Neither resolves to a registry entry, so they are published namespaced and there is no canonical scale to convert onto. They now carry the point the rewritten tests were making about per-harness bounds tables.
  General? no.

**Coverage:** 22 declared-bound sites found by sweep, 22 fixed. 12 canonical metric mappings audited against the registry, 1 conflict found, 1 fixed. 0 dropped.

**Operator asked about policy calls?** No new canonical id, no schema or validator rule change, no data dropped. The two judgement calls are the AA indices and the registry entry, both above.

## Not in this PR

- `make_evaluation_result` never supplies the `source_data` that `EvaluationResult` requires, so it cannot build a result at all. Same module, separate defect.
- `bfcl`, `cocoabench` and `sciarena` have no adapter test of their own, so three of the five changed adapters are covered only by the shared publication test.
- `_aggregate_check_score_metadata` never looks at uncertainty, so a rescaled score can still keep an unrescaled spread and pass the gate. That check needs the failing count over datastore main first.
