### PR TITLE
Add the Flat rebuild cron

### DIFF
--- a/.github/workflows/flat-rebuild.yml
+++ b/.github/workflows/flat-rebuild.yml
@@ -1,0 +1,92 @@
+# Rebuild the EEE_datastore flat view after each ingestion run.
+#
+# tools/build_flat_datastore.py in the datastore repository defines the flat
+# layout and rebuilds it from a local checkout, but that checkout no longer
+# fits an Actions runner (data/ is ~15 GB), so cron/flat_rebuild.py rebuilds
+# against the Hub API instead: it diffs data/ against the current snapshot,
+# downloads only new records, and commits the rebuilt indexes, manifests and
+# objects with the same retry discipline as the adapter ingestion.
+#
+# Setup this workflow needs, once:
+#   - the `cron` environment holding `HF_TOKEN`, with write access to the
+#     datastore (the same one adapter_cron.yml uses);
+#   - optional `EEE_DATASTORE_REPO_ID` repository variable to point a
+#     rehearsal run at a throwaway repository.
+
+name: Flat rebuild
+
+on:
+  workflow_run:
+    workflows: ['Adapter ingestion']
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Plan and report, commit nothing'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # 01:14 UTC catch-up sweep. Off the hour, because the hour is when
+    # everyone else runs. A run whose snapshot already matches commits
+    # nothing, so this only acts when data/ moved without an ingestion run.
+    - cron: '14 1 * * *'
+    # 02:44 UTC Sundays: the same sweep plus --verify, the deep pass that
+    # hashes every inherited data file against the snapshot, so same-length
+    # edits the nightly size diff cannot see still fail loudly.
+    - cron: '44 2 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  rebuild:
+    name: Rebuild flat/
+    # A fork inherits the schedule; it should not commit on our behalf, and
+    # a failed ingestion must not be flattened into the datastore.
+    if: >-
+      github.repository == 'evaleval/every_eval_ever'
+      && (
+        github.event_name != 'workflow_run'
+        || github.event.workflow_run.conclusion == 'success'
+      )
+    runs-on: ubuntu-latest
+    # The first run downloads every record added since the last snapshot;
+    # steady-state runs move a few hundred files and finish far sooner.
+    timeout-minutes: 240
+    environment: cron
+    concurrency:
+      group: flat-rebuild
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: astral-sh/setup-uv@v7.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        env:
+          # Keep the environment outside the checkout; nltk's import guard
+          # blocks dependency imports resolved beneath the working directory.
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
+        run: uv sync --locked
+
+      - name: Rebuild flat view
+        env:
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/eee-venv
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # Empty when unset, which the CLI treats as "use the default".
+          EEE_DATASTORE_REPO_ID: ${{ vars.EEE_DATASTORE_REPO_ID }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          SCHEDULE: ${{ github.event.schedule }}
+        run: |
+          set -euo pipefail
+          args=()
+          if [ "${DRY_RUN}" = "true" ]; then
+              args+=(--dry-run)
+          fi
+          if [ "${SCHEDULE}" = "44 2 * * 0" ]; then
+              args+=(--verify)
+          fi
+          uv run --locked python -m every_eval_ever.cron.flat_rebuild \
+              "${args[@]+"${args[@]}"}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,12 @@ convert external eval sources into it.
   name belongs to `eval-card-registry`.
 - `every_eval_ever/cron/` is the daily ingestion run (`uv run python -m
   every_eval_ever.cron`): stage → validate → fingerprint → stamp → snapshot raw →
-  one datastore PR per adapter. See its `README.md`.
+  commit straight to the datastore's default branch. See its `README.md`.
+- `every_eval_ever/cron/flat_rebuild.py` refreshes the datastore's `flat/`
+  view against the Hub after ingestion (workflow `Flat rebuild`): retires stale
+  collection indexes into `flat/indexes/retired/`, trims old snapshots past the
+  retention window while pinning the last manifest that indexes each object,
+  and never modifies `data/` or overwrites/deletes existing `flat/objects/`.
 - `every_eval_ever/helpers/raw_capture.py` snapshots what an adapter fetched. Inert
   unless a sink is active, so a manual run behaves exactly as before.
 - `every_eval_ever/converters/` — in-tree converters (`inspect`/`helm`/`lm_eval`, plus `alpaca_eval`; shared code in `common`), run via `uv run python -m every_eval_ever convert <inspect|helm|lm_eval> ...`. Cover one by adding a `ConverterCase` to `tests/converter_cases.py`; see "Testing a converter" in `converters/README.md`.

--- a/every_eval_ever/cron/README.md
+++ b/every_eval_ever/cron/README.md
@@ -402,7 +402,8 @@ completed with excluded conflicts (the job stays red until they are
 resolved). Records are not validated here: the ingestion cron validated
 each one before committing it. A run whose rebuilt manifest core hash
 matches the published one and that has no missing index, retire, or
-retention work commits nothing. Conflicts still produce exit code 2 on a no-op. A full initial build (no snapshot published yet) is expensive and
+retention work commits nothing. Conflicts still produce exit code 2 on a
+no-op. A full initial build (no snapshot published yet) is expensive and
 gated behind `--allow-bootstrap`.
 
 The repository defaults to `evaleval/EEE_datastore` when

--- a/every_eval_ever/cron/README.md
+++ b/every_eval_ever/cron/README.md
@@ -347,3 +347,122 @@ This is a deliberate MVP.
 - The write token is checked for a reported read-only role, which a
   fine-grained token need not report. Only a commit proves those scopes, so
   such a token still fails at the publish step rather than up front.
+
+## Flat datastore rebuild
+
+`flat_rebuild.py` refreshes the datastore's `flat/` view (content-addressed
+objects, per-collection indexes, snapshot manifests) after ingestion. It runs
+as the `Flat rebuild` workflow — triggered when `Adapter ingestion` completes,
+on manual dispatch, and on a nightly catch-up sweep — and can be run by
+hand against any snapshot of the datastore's state on the Hub:
+
+```bash
+uv run python -m every_eval_ever.cron.flat_rebuild --dry-run
+uv run python -m every_eval_ever.cron.flat_rebuild --repo-id evaleval/EEE_datastore
+```
+
+It does not clone the datastore (`data/` is ~15 GB, more than a runner
+holds). Instead it diffs the current `data/` tree against the published
+snapshot by path and size, downloads new and size-changed source files,
+and writes the flat row and manifest format in bounded commit batches.
+Unlike the checkout builder, it supports semantic reserialization and
+reports conflicting UUID reuse while preserving published objects. Commit
+conflicts use the ingestion retry helpers; adoption verifies file content.
+
+Three policies are built in, all decided in the 2026-09 design round:
+
+- **Retire, don't destroy.** A collection index whose collection no longer
+  exists under `data/` (renames are routine — `live_bench` became
+  `livebench`) is moved to `flat/indexes/retired/` rather than deleted, so
+  the removed collection stays browsable.
+- **Retention keeps the last reference.** Snapshots older than
+  `--retain-days` (default 90) are trimmed, except any manifest that is the
+  last remaining index into an object — so no object in `flat/objects/`
+  ever loses its row. Unscannable snapshots are conservatively kept.
+- **Conflicts are excluded, loudly.** A record re-emitted under a known
+  UUID with different content (a schema migration that reused UUIDs — 195
+  of them rode in with `livebench`'s 0.3.0 re-emission) cannot enter the
+  flat view without breaking object immutability. It is excluded, the
+  published object stays, the run exits 2 with every conflict enumerated,
+  and it stays red until upstream re-emits with fresh UUIDs. A pure
+  re-serialization of the same evaluation (byte-different, semantically
+  identical) is not a conflict: the row is re-pointed and the published
+  bytes stay.
+
+The nightly diff detects changes by size, which cannot see a same-length
+edit. `--verify` hashes inherited aggregate and companion source files
+against their snapshot sha256 values. Missing inherited files and content
+drift are errors; reserialization is accepted only against intact published
+objects. Objects explicitly planned for first upload are excluded from this
+inherited-file check. The
+workflow runs it in a weekly Sunday sweep; expect it to be slow.
+
+Exit codes follow the house convention: 0 clean or no-op, 1 error, 2
+completed with excluded conflicts (the job stays red until they are
+resolved). Records are not validated here: the ingestion cron validated
+each one before committing it. A run whose rebuilt manifest core hash
+matches the published one and that has no missing index, retire, or
+retention work commits nothing. Conflicts still produce exit code 2 on a no-op. A full initial build (no snapshot published yet) is expensive and
+gated behind `--allow-bootstrap`.
+
+The repository defaults to `evaleval/EEE_datastore` when
+`EEE_DATASTORE_REPO_ID` is unset or empty, matching the workflow's optional
+repository variable. An explicitly empty `--repo-id` is an error. The run
+summary prints the selected repository.
+
+Companion additions and removals are tracked independently of aggregate
+changes. A semantic change to a known companion is reported as a conflict;
+its published bytes remain intact. Existing rows retain their published
+companion, while a newly attached conflicting companion is omitted. An
+unreadable comparison is a hard error. Duplicate UUIDs across live paths
+are errors. Retention accounts for companion objects and protects both the
+previous and destination snapshots.
+
+A failed commit is accepted only after verifying the expected file content
+and deletions. An unverifiable commit outcome stops the run with an error.
+Unreadable retention entries are kept with a warning naming the snapshot
+and failure; unscanned snapshots are listed in the summary. Unchanged
+same-size source files still use the agreed size-based change detection.
+
+### Reviewer comments and changes
+
+The review found that companion reattachment could overwrite historical
+objects, adopted companions could advertise the wrong hash, and the deep
+verification pass skipped companions. The fixes apply these rules:
+
+- **Check the destination before attaching samples.** Compute the canonical
+  companion object path from the UUID even when the current row has no
+  companion path. The same attachment helper handles existing aggregates,
+  moved aggregates, and UUIDs returning from historical snapshots. An
+  existing destination is adopted only when its content matches; a
+  conflicting destination is preserved and reported, with no upload.
+- **Describe the bytes that are actually published.** When adopting an
+  existing companion, derive its hash and size from the published bytes.
+  Incoming whitespace or key-order differences must not alter this metadata.
+- **Compare JSONL as ordered records.** Identical bytes match immediately.
+  Otherwise parse companions one nonblank line at a time and compare the
+  resulting records without reordering or dropping duplicates. Aggregate
+  JSON remains a single document. Comparisons preserve value types,
+  including nested booleans versus numbers; numeric representation type
+  changes such as integer to float are treated conservatively as conflicts.
+- **Verify inherited companions too.** The deep pass hashes both aggregate
+  and companion source files. A source hash mismatch requires comparison
+  against a published object whose bytes still match the manifest hash.
+  Missing inherited sources or objects are reported as drift. Only object
+  paths explicitly scheduled for first upload are skipped; absence alone
+  never makes verification pass.
+- **Keep failure outcomes visible.** Conflicts are enumerated and yield
+  exit code 2. Missing comparison data and deep verification drift stop the
+  run before publication with exit code 1. Unreadable retention snapshots
+  remain preserved with warnings and entries in the run summary.
+
+Regression tests cover all three companion attachment paths, historical
+hash/size preservation, identical and reformatted multi-line JSONL, record
+order and count, nested JSON type differences, same-length companion drift,
+missing inherited objects, and explicit bootstrap uploads. Run the focused
+checks with:
+
+```bash
+uv run --frozen python -m pytest tests/test_flat_rebuild.py -q
+uv run --frozen ruff check every_eval_ever/cron/flat_rebuild.py tests/test_flat_rebuild.py
+```

--- a/every_eval_ever/cron/flat_rebuild.py
+++ b/every_eval_ever/cron/flat_rebuild.py
@@ -102,6 +102,21 @@ class Row:
     instance_sha: str | None = None
     instance_level_size_bytes: int | None = None
 
+    def __post_init__(self) -> None:
+        if self.instance_level_available:
+            if (
+                self.instance_level_path is None
+                or self.instance_sha is None
+                or self.instance_level_size_bytes is None
+            ):
+                raise ValueError(
+                    'instance_level_available rows require companion metadata'
+                )
+            return
+        object.__setattr__(self, 'instance_level_path', None)
+        object.__setattr__(self, 'instance_sha', None)
+        object.__setattr__(self, 'instance_level_size_bytes', None)
+
     def to_dict(self) -> dict[str, Any]:
         row: dict[str, Any] = {
             'object_uuid': self.object_uuid,
@@ -617,7 +632,7 @@ def build_rows(
                 f'{samples_path_for(path)}: samples changed under immutable '
                 f'UUID {old_row.object_uuid}; the row keeps its published object'
             )
-            excluded.add(path)
+            excluded.add(samples_path_for(path))
     seen = {uuid: row.legacy_path for uuid, row in rows.items()}
     added = 0
     moved = 0
@@ -674,7 +689,7 @@ def build_rows(
             )
             if conflict:
                 conflicts.append(conflict)
-                excluded.add(path)
+                excluded.add(samples_path_for(path))
             if row is None:
                 continue
             if (
@@ -1317,7 +1332,7 @@ def orchestrate(
     report.records = len(rows)
     report.collections = len({row.benchmark for row in rows})
 
-    new_manifest = manifest_for(rows, created_at=utc_now())
+    new_manifest = manifest_for(rows, created_at=now.isoformat())
     report.manifest_core_sha256 = new_manifest['manifest_core_sha256']
     noop_core = bool(manifest) and manifest_core(manifest) == manifest_core(
         new_manifest

--- a/every_eval_ever/cron/flat_rebuild.py
+++ b/every_eval_ever/cron/flat_rebuild.py
@@ -1,0 +1,1601 @@
+"""Rebuild the datastore's flat view against the Hub, without a clone.
+
+``tools/build_flat_datastore.py`` in the EEE_datastore repository defines the
+flat layout and rebuilds it from a local checkout. That checkout no longer
+fits a GitHub Actions runner — ``data/`` alone is ~15 GB — so this module
+writes the same flat layout against the Hub API instead:
+
+1. read the current snapshot: ``flat/latest_manifest.json`` and the
+   ``entries.jsonl`` it points at;
+2. recursively list the repository and diff ``data/`` against the snapshot
+   rows, using file size as the change signal;
+3. download new and size-changed source files (a full initial build is gated
+   behind ``--allow-bootstrap``);
+4. rebuild rows, collection indexes and the manifest, preserving published
+   bytes, accepting reserialization and reporting conflicting UUID reuse;
+5. retire collection indexes whose collection no longer exists under
+   ``data/`` (moved to ``flat/indexes/retired/``), trim snapshots past the
+   retention window, and commit everything in bounded batches with the
+   adapter ingestion's retry discipline (``cron.submit``).
+
+The retention rule keeps any manifest that is the last remaining index into
+an object, so no object in ``flat/objects/`` ever loses its row. Objects are
+never deleted, and ``data/`` is never touched: it is the source of truth,
+maintained by the ingestion cron and human pull requests. Records are not
+validated here either — the ingestion cron validated each one before
+committing it.
+
+A run whose rebuilt manifest core hash matches the published one and that
+has no missing index, retire or retention work commits nothing. Conflicts
+still produce exit code 2; comparison failures and verification drift stop
+publication with an error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+import warnings
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Sequence
+from uuid import UUID
+
+from huggingface_hub import (
+    CommitOperationAdd,
+    CommitOperationDelete,
+    HfApi,
+)
+from huggingface_hub.errors import EntryNotFoundError
+
+# Imported as a module, not by name: the retry helpers are replaced in tests
+# and the commit path has to see the replacement.
+from every_eval_ever.cron import store
+from every_eval_ever.cron.submit import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_DATASTORE_REPO,
+)
+
+LATEST_MANIFEST_PATH = 'flat/latest_manifest.json'
+INDEXES_PREFIX = 'flat/indexes/by_collection'
+RETIRE_PREFIX = 'flat/indexes/retired'
+BY_LEGACY_PATH = 'flat/indexes/by_legacy_path.jsonl'
+MANIFESTS_PREFIX = 'flat/manifests'
+DATA_PREFIX = 'data/'
+#: Fields of a manifest excluded from its content hash, mirroring
+#: ``manifest_core`` in ``tools/build_flat_datastore.py``.
+CORE_IGNORED_FIELDS = frozenset(
+    {'created_at', 'entries_path', 'manifest_core_sha256', 'manifest_path'}
+)
+DEFAULT_RETAIN_DAYS = 90
+DEFAULT_KEEP_NEWEST = 2
+#: Snapshots older than the retention window are scanned newest-first to
+#: decide between trim and pin; unscanned ones are conservatively kept.
+DEFAULT_SCAN_BUDGET = 20
+DOWNLOAD_WORKERS = 8
+
+
+class FlatRebuildError(RuntimeError):
+    """Raised when the flat view cannot be rebuilt or published safely."""
+
+
+@dataclass(frozen=True)
+class Row:
+    """One ``entries.jsonl`` row, mirroring the builder's row shape."""
+
+    object_uuid: str
+    object_path: str
+    sha256: str
+    size_bytes: int
+    legacy_path: str
+    benchmark: str
+    eval_schema_version: str
+    instance_level_available: bool = False
+    instance_level_path: str | None = None
+    instance_sha: str | None = None
+    instance_level_size_bytes: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        row: dict[str, Any] = {
+            'object_uuid': self.object_uuid,
+            'object_path': self.object_path,
+            'sha256': self.sha256,
+            'size_bytes': self.size_bytes,
+            'legacy_path': self.legacy_path,
+            'benchmark': self.benchmark,
+            'eval_schema_version': self.eval_schema_version,
+            'record_type': 'aggregate',
+            'instance_level_available': self.instance_level_available,
+        }
+        if self.instance_level_available:
+            row['instance_level_path'] = self.instance_level_path
+            row['instance_sha'] = self.instance_sha
+            row['instance_level_size_bytes'] = self.instance_level_size_bytes
+        return row
+
+    @classmethod
+    def from_dict(cls, row: dict[str, Any]) -> 'Row':
+        return cls(
+            object_uuid=row['object_uuid'],
+            object_path=row['object_path'],
+            sha256=row['sha256'],
+            size_bytes=row['size_bytes'],
+            legacy_path=row['legacy_path'],
+            benchmark=row['benchmark'],
+            eval_schema_version=row['eval_schema_version'],
+            instance_level_available=bool(row['instance_level_available']),
+            instance_level_path=row.get('instance_level_path'),
+            instance_sha=row.get('instance_sha'),
+            instance_level_size_bytes=row.get('instance_level_size_bytes'),
+        )
+
+
+@dataclass(frozen=True)
+class ManifestInfo:
+    """One snapshot directory under ``flat/manifests/``."""
+
+    manifest_path: str
+    entries_path: str
+    created_at: str
+    dir_path: str
+
+    @property
+    def created(self) -> datetime:
+        return datetime.fromisoformat(self.created_at)
+
+
+@dataclass(frozen=True)
+class Diff:
+    """What changed between a snapshot and the current ``data/`` tree."""
+
+    new_paths: tuple[str, ...]
+    new_sample_paths: tuple[str, ...]
+    removed_rows: tuple[Row, ...]
+    #: Aggregates still at their snapshot path whose size changed. Same-UUID
+    #: content changes are resolved by build_rows against the existing flat
+    #: object: a re-serialization is accepted, a semantic change is not.
+    changed_aggregates: tuple[str, ...]
+    #: Samples whose size changed under a still-present aggregate.
+    changed_samples: tuple[str, ...]
+    orphan_samples: tuple[str, ...]
+    removed_sample_paths: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    rows: tuple[Row, ...]
+    errors: tuple[str, ...]
+    #: Records re-emitted under a known UUID with different content. They
+    #: cannot enter the flat view without breaking object immutability, so
+    #: they are excluded (the old object stays, pinned by retention) and
+    #: reported for upstream to resolve - usually a schema migration that
+    #: should have carried fresh UUIDs.
+    conflicts: tuple[str, ...]
+    excluded_paths: frozenset[str]
+    added: int
+    moved: int
+    #: UUIDs whose aggregate object must be uploaded (never seen before).
+    upload_aggregates: frozenset[str]
+    #: UUIDs whose samples object must be uploaded (new or newly attached).
+    upload_samples: frozenset[str]
+
+
+@dataclass
+class RebuildReport:
+    """What one run saw and did; printed and written to the step summary."""
+
+    repo_id: str
+    dry_run: bool = False
+    noop: bool = False
+    old_records: int = 0
+    data_files: int = 0
+    added_records: int = 0
+    moved_records: int = 0
+    removed_records: int = 0
+    orphan_samples: int = 0
+    records: int = 0
+    collections: int = 0
+    indexes_added: tuple[str, ...] = ()
+    indexes_retired: tuple[str, ...] = ()
+    manifests_total: int = 0
+    manifests_trimmed: tuple[str, ...] = ()
+    manifests_pinned: tuple[str, ...] = ()
+    manifests_unscanned: tuple[str, ...] = ()
+    conflicts: tuple[str, ...] = ()
+    manifest_core_sha256: str | None = None
+    verified_files: int = 0
+    verified_reserialized: int = 0
+    commits: int = 0
+    uploads: int = 0
+    duration_seconds: float = 0.0
+
+
+# -- shared hashing helpers (mirroring tools/build_flat_datastore.py) ------
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def stable_json_bytes(payload: object) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(',', ':')).encode(
+        'utf-8'
+    )
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()
+
+
+def object_path_for(object_uuid: str, *, suffix: str) -> str:
+    return str(
+        PurePosixPath('flat', 'objects', object_uuid[:2], object_uuid[2:4])
+        / f'{object_uuid}{suffix}'
+    )
+
+
+def samples_path_for(legacy_path: str) -> str:
+    parent = PurePosixPath(legacy_path).parent
+    stem = PurePosixPath(legacy_path).stem
+    return str(parent / f'{stem}_samples.jsonl')
+
+
+def manifest_core(manifest: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in manifest.items()
+        if key not in CORE_IGNORED_FIELDS
+    }
+
+
+def jsonl_text(rows: 'Sequence[Row] | Sequence[dict[str, Any]]') -> str:
+    return ''.join(
+        json.dumps(
+            row.to_dict() if isinstance(row, Row) else row, sort_keys=True
+        )
+        + '\n'
+        for row in rows
+    )
+
+
+def manifest_for(rows: Sequence[Row], *, created_at: str) -> dict[str, Any]:
+    """Build the snapshot manifest exactly as the local builder would."""
+    entries_text = jsonl_text(rows)
+    encoded = entries_text.encode('utf-8')
+    benchmarks = {row.benchmark for row in rows}
+    instance_count = sum(1 for row in rows if row.instance_level_available)
+    core: dict[str, Any] = {
+        'source': {'type': 'legacy_data_tree', 'path': 'data'},
+        'eval_schema_versions': sorted(
+            {row.eval_schema_version for row in rows}
+        ),
+        'benchmark_count': len(benchmarks),
+        'aggregate_file_count': len(rows),
+        'instance_level_file_count': instance_count,
+        'total_file_count': len(rows) + instance_count,
+        'entries_sha256': sha256_bytes(encoded),
+        'entries_size_bytes': len(encoded),
+    }
+    core_sha256 = sha256_bytes(stable_json_bytes(core))
+    dir_path = f'{MANIFESTS_PREFIX}/sha256_{core_sha256}'
+    return {
+        **core,
+        'created_at': created_at,
+        'entries_path': f'{dir_path}/entries.jsonl',
+        'manifest_core_sha256': core_sha256,
+        'manifest_path': f'{dir_path}/manifest.json',
+    }
+
+
+# -- reading remote state --------------------------------------------------
+
+
+def list_repo_sizes(api: HfApi, repo_id: str) -> dict[str, int]:
+    """Map every file path in the repository to its size in bytes."""
+    sizes: dict[str, int] = {}
+    for item in api.list_repo_tree(
+        repo_id=repo_id, repo_type='dataset', recursive=True
+    ):
+        size = getattr(item, 'size', None)
+        if size is not None:
+            sizes[item.path] = size
+    return sizes
+
+
+def read_snapshot(
+    api: HfApi, repo_id: str
+) -> tuple[dict[str, Any], list[Row]] | None:
+    """Return the current snapshot manifest and its rows, or ``None``."""
+    try:
+        latest_local = api.hf_hub_download(
+            repo_id=repo_id, repo_type='dataset', filename=LATEST_MANIFEST_PATH
+        )
+    except EntryNotFoundError:
+        return None
+    manifest = json.loads(Path(latest_local).read_text(encoding='utf-8'))
+    entries_local = api.hf_hub_download(
+        repo_id=repo_id, repo_type='dataset', filename=manifest['entries_path']
+    )
+    rows = [
+        Row.from_dict(json.loads(line))
+        for line in Path(entries_local).read_text(encoding='utf-8').splitlines()
+        if line.strip()
+    ]
+    return manifest, rows
+
+
+def download_bytes(
+    api: HfApi, repo_id: str, paths: Sequence[str]
+) -> dict[str, bytes]:
+    """Download paths in parallel; a missing file aborts the run."""
+
+    def one(path: str) -> tuple[str, bytes]:
+        local = api.hf_hub_download(
+            repo_id=repo_id, repo_type='dataset', filename=path
+        )
+        return path, Path(local).read_bytes()
+
+    if not paths:
+        return {}
+    with ThreadPoolExecutor(max_workers=DOWNLOAD_WORKERS) as pool:
+        return dict(pool.map(one, paths))
+
+
+# -- planning (pure; unit-tested without network) --------------------------
+
+
+def diff_against_snapshot(
+    old_rows: Sequence[Row], listing: dict[str, int]
+) -> Diff:
+    """Diff ``data/`` against the snapshot rows by path and size.
+
+    New paths and size changes are downloaded for comparison against
+    published objects. Companion presence and size are tracked separately.
+    Size-equal files carry their row and hash forward; the optional deep
+    verification pass checks for same-length drift.
+    """
+    aggregate_paths = {
+        path
+        for path in listing
+        if path.startswith(DATA_PREFIX) and path.endswith('.json')
+    }
+    old_by_path = {row.legacy_path: row for row in old_rows}
+    new_paths = tuple(
+        path for path in sorted(aggregate_paths) if path not in old_by_path
+    )
+    new_sample_paths = tuple(
+        samples_path_for(path)
+        for path in sorted(aggregate_paths)
+        if samples_path_for(path) in listing
+        and (
+            path not in old_by_path
+            or not old_by_path[path].instance_level_available
+        )
+    )
+    changed_aggregates = tuple(
+        path
+        for path in sorted(aggregate_paths)
+        if path in old_by_path and listing[path] != old_by_path[path].size_bytes
+    )
+    changed_samples = tuple(
+        path
+        for path in sorted(aggregate_paths & old_by_path.keys())
+        if old_by_path[path].instance_level_available
+        and samples_path_for(path) in listing
+        and listing[samples_path_for(path)]
+        != old_by_path[path].instance_level_size_bytes
+    )
+    removed_sample_paths = tuple(
+        path
+        for path in sorted(aggregate_paths & old_by_path.keys())
+        if old_by_path[path].instance_level_available
+        and samples_path_for(path) not in listing
+    )
+    removed_rows = tuple(
+        row for row in old_rows if row.legacy_path not in aggregate_paths
+    )
+    orphan_samples = tuple(
+        sorted(
+            path
+            for path in listing
+            if path.startswith(DATA_PREFIX)
+            and path.endswith('_samples.jsonl')
+            and path[: -len('_samples.jsonl')] + '.json' not in aggregate_paths
+        )
+    )
+    return Diff(
+        new_paths=new_paths,
+        new_sample_paths=new_sample_paths,
+        removed_rows=removed_rows,
+        changed_aggregates=changed_aggregates,
+        changed_samples=changed_samples,
+        orphan_samples=orphan_samples,
+        removed_sample_paths=removed_sample_paths,
+    )
+
+
+def semantically_equal(a: bytes, b: bytes, *, jsonl: bool = False) -> bool:
+    """Compare JSON values or ordered JSONL records without coercing types."""
+    if a == b:
+        return True
+
+    def equal(left: Any, right: Any) -> bool:
+        if type(left) is not type(right):
+            return False
+        if isinstance(left, dict):
+            return left.keys() == right.keys() and all(
+                equal(left[key], right[key]) for key in left
+            )
+        if isinstance(left, list):
+            return len(left) == len(right) and all(
+                equal(x, y) for x, y in zip(left, right)
+            )
+        return left == right
+
+    try:
+        if jsonl:
+            left = [json.loads(line) for line in a.splitlines() if line.strip()]
+            right = [
+                json.loads(line) for line in b.splitlines() if line.strip()
+            ]
+            return equal(left, right)
+        return equal(json.loads(a), json.loads(b))
+    except ValueError:
+        return False
+
+
+def verify_rows(
+    api: HfApi,
+    repo_id: str,
+    rows: Sequence[Row],
+    listing: dict[str, int],
+    *,
+    workers: int = DOWNLOAD_WORKERS,
+    pending_objects: frozenset[str] = frozenset(),
+) -> tuple[int, int, list[str]]:
+    """Check inherited aggregates and companions against their snapshot hashes.
+
+    Only explicitly planned new objects are skipped. Missing inherited files
+    are drift. Reserialization is accepted only against intact published
+    objects, using ordered, type-preserving JSONL comparison for companions.
+    Returns ``(checked, reserialized, drift)``; source hashing streams bytes.
+    """
+    targets: list[tuple[str, str, str, bool]] = []
+    for row in rows:
+        targets.append((row.legacy_path, row.object_path, row.sha256, False))
+        if row.instance_level_available:
+            if not row.instance_level_path or not row.instance_sha:
+                raise FlatRebuildError(
+                    f'{row.legacy_path}: incomplete companion metadata'
+                )
+            targets.append(
+                (
+                    samples_path_for(row.legacy_path),
+                    row.instance_level_path,
+                    row.instance_sha,
+                    True,
+                )
+            )
+    targets = [target for target in targets if target[1] not in pending_objects]
+    drift: list[str] = []
+
+    def check(target: tuple[str, str, str, bool]) -> tuple[str, str | None]:
+        source, destination, expected_sha, jsonl = target
+        for path in (source, destination):
+            if path not in listing:
+                return 'drift', f'{path}: inherited file is missing'
+        local = api.hf_hub_download(
+            repo_id=repo_id, repo_type='dataset', filename=source
+        )
+        with Path(local).open('rb') as handle:
+            actual_sha = hashlib.file_digest(handle, 'sha256').hexdigest()
+        if actual_sha == expected_sha:
+            return 'clean', None
+        object_local = api.hf_hub_download(
+            repo_id=repo_id, repo_type='dataset', filename=destination
+        )
+        object_bytes = Path(object_local).read_bytes()
+        if sha256_bytes(object_bytes) != expected_sha:
+            return (
+                'drift',
+                f'{destination}: published object no longer matches its snapshot sha256',
+            )
+        if semantically_equal(
+            object_bytes, Path(local).read_bytes(), jsonl=jsonl
+        ):
+            return 'reserialized', None
+        return (
+            'drift',
+            f'{source}: data file no longer matches its snapshot sha256 ({expected_sha}) nor its flat object',
+        )
+
+    checked = 0
+    reserialized = 0
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        for status, message in pool.map(check, targets):
+            checked += 1
+            if status == 'reserialized':
+                reserialized += 1
+            elif message:
+                drift.append(message)
+    return checked, reserialized, drift
+
+
+def build_rows(
+    old_rows: Sequence[Row],
+    diff: Diff,
+    contents: dict[str, bytes],
+    existing_object: Callable[[str], bytes | None] | None = None,
+    listing: dict[str, int] | None = None,
+) -> BuildResult:
+    """Turn the diff into the new sorted row list, or errors.
+
+    A new ``data/`` file whose UUID already exists with different content is
+    resolved against the existing flat object (fetched through
+    ``existing_object``): a pure re-serialization of the same evaluation is
+    accepted, a semantic change under the same UUID violates the flat
+    layout's immutability and becomes a conflict that keeps the published
+    object. The same UUID reappearing with identical content at a new path
+    is a move: the row is re-pointed and nothing is re-uploaded. When
+    ``listing`` is given, an upload destination that already exists is
+    likewise adopted (the row takes the published bytes' sha256) or, if it
+    holds different data, recorded as a conflict - a published object is
+    never overwritten.
+    """
+    errors: list[str] = []
+    conflicts: list[str] = []
+    excluded: set[str] = set()
+    old_by_path = {row.legacy_path: row for row in old_rows}
+    old_by_uuid = {row.object_uuid: row for row in old_rows}
+    removed_paths = {row.legacy_path for row in diff.removed_rows}
+    rows: dict[str, Row] = {
+        row.object_uuid: row
+        for row in old_rows
+        if row.legacy_path not in removed_paths
+    }
+    upload_aggregates: set[str] = set()
+    upload_samples: set[str] = set()
+    for uuid, row in list(rows.items()):
+        if row.legacy_path in diff.removed_sample_paths:
+            rows[uuid] = _row_without_samples(row)
+        sample_path = samples_path_for(row.legacy_path)
+        if sample_path in diff.new_sample_paths:
+            if sample_path not in contents:
+                errors.append(
+                    f'{sample_path}: expected content was not downloaded'
+                )
+                continue
+            attached, upload, conflict = _attach_samples(
+                row, contents[sample_path], listing, existing_object, errors
+            )
+            if attached is not None:
+                rows[uuid] = attached
+            if upload:
+                upload_samples.add(uuid)
+            if conflict:
+                conflicts.append(conflict)
+                excluded.add(sample_path)
+    for path in diff.changed_aggregates:
+        old_row = old_by_path[path]
+        new_bytes = contents.get(path)
+        if new_bytes is None:
+            errors.append(f'{path}: expected content was not downloaded')
+            continue
+        old_object = _fetch_existing(
+            old_row.object_path, existing_object, errors
+        )
+        if old_object is None:
+            continue
+        if not semantically_equal(old_object, new_bytes):
+            conflicts.append(
+                f'{path}: content changed under immutable UUID '
+                f'{old_row.object_uuid}; the row keeps its published object'
+            )
+            excluded.add(path)
+    for path in diff.changed_samples:
+        old_row = old_by_path[path]
+        new_bytes = contents.get(samples_path_for(path))
+        if new_bytes is None:
+            errors.append(
+                f'{samples_path_for(path)}: expected content was not downloaded'
+            )
+            continue
+        old_object = _fetch_existing(
+            old_row.instance_level_path, existing_object, errors
+        )
+        if old_object is None:
+            continue
+        if not semantically_equal(old_object, new_bytes, jsonl=True):
+            conflicts.append(
+                f'{samples_path_for(path)}: samples changed under immutable '
+                f'UUID {old_row.object_uuid}; the row keeps its published object'
+            )
+            excluded.add(path)
+    seen = {uuid: row.legacy_path for uuid, row in rows.items()}
+    added = 0
+    moved = 0
+    for path in diff.new_paths:
+        data = contents.get(path)
+        if data is None:
+            errors.append(f'{path}: expected content was not downloaded')
+            continue
+        relative = PurePosixPath(path).relative_to('data')
+        if len(relative.parts) < 2:
+            errors.append(f'{path}: expected data/<collection>/.../<uuid>.json')
+            continue
+        benchmark = relative.parts[0]
+        try:
+            object_uuid = str(UUID(relative.stem))
+        except ValueError:
+            errors.append(f'{path}: filename is not a valid UUID')
+            continue
+        if object_uuid in seen:
+            errors.append(
+                f'{path}: duplicate UUID {object_uuid}; already present at {seen[object_uuid]}'
+            )
+            continue
+        seen[object_uuid] = path
+        if (
+            samples_path_for(path) in diff.new_sample_paths
+            and samples_path_for(path) not in contents
+        ):
+            errors.append(f'{path}: expected samples were not downloaded')
+            continue
+        schema_version = schema_version_of(data, path, errors)
+        if schema_version is None:
+            continue
+        sha256 = sha256_bytes(data)
+        old = old_by_uuid.get(object_uuid)
+        if old is not None:
+            if old.sha256 != sha256:
+                old_object = _fetch_existing(
+                    old.object_path, existing_object, errors
+                )
+                if old_object is None:
+                    continue
+                if not semantically_equal(old_object, data):
+                    conflicts.append(
+                        f'{path}: UUID {object_uuid} re-emitted with '
+                        f'different content ({old.legacy_path}); excluded'
+                    )
+                    excluded.add(path)
+                    continue
+            moved += 1
+            samples = contents.get(samples_path_for(path))
+            row, conflict = _row_for_move(
+                old, path, benchmark, samples, existing_object, errors, listing
+            )
+            if conflict:
+                conflicts.append(conflict)
+                excluded.add(path)
+            if row is None:
+                continue
+            if (
+                row.instance_level_available
+                and not old.instance_level_available
+                and (listing is None or row.instance_level_path not in listing)
+            ):
+                upload_samples.add(object_uuid)
+            rows[object_uuid] = row
+            continue
+        row = Row(
+            object_uuid=object_uuid,
+            object_path=object_path_for(object_uuid, suffix='.json'),
+            sha256=sha256,
+            size_bytes=len(data),
+            legacy_path=path,
+            benchmark=benchmark,
+            eval_schema_version=schema_version,
+        )
+        if listing is not None and row.object_path in listing:
+            old_object = _fetch_existing(
+                row.object_path, existing_object, errors
+            )
+            if old_object is None:
+                continue
+            if not semantically_equal(old_object, data):
+                conflicts.append(
+                    f'{path}: destination object already holds different '
+                    f'bytes under immutable UUID {object_uuid}; excluded'
+                )
+                excluded.add(path)
+                continue
+            # the object already holds this evaluation: adopt its bytes and
+            # skip the upload
+            row = replace(
+                row,
+                sha256=sha256_bytes(old_object),
+                size_bytes=len(old_object),
+            )
+        else:
+            upload_aggregates.add(object_uuid)
+        added += 1
+        samples = contents.get(samples_path_for(path))
+        if samples is not None:
+            attached, upload, conflict = _attach_samples(
+                row, samples, listing, existing_object, errors
+            )
+            if attached is None:
+                continue
+            row = attached
+            if upload:
+                upload_samples.add(object_uuid)
+            if conflict:
+                conflicts.append(conflict)
+                excluded.add(samples_path_for(path))
+        rows[object_uuid] = row
+    return BuildResult(
+        rows=tuple(sorted(rows.values(), key=lambda row: row.legacy_path)),
+        errors=tuple(errors),
+        conflicts=tuple(conflicts),
+        excluded_paths=frozenset(excluded),
+        added=added,
+        moved=moved,
+        upload_aggregates=frozenset(upload_aggregates),
+        upload_samples=frozenset(upload_samples),
+    )
+
+
+def _fetch_existing(
+    object_path: str,
+    existing_object: Callable[[str], bytes | None] | None,
+    errors: list[str],
+) -> bytes | None:
+    """Fetch the published flat object, or None with a hard error.
+
+    A content comparison that cannot fetch the published object is not
+    guessable, so the caller treats it as a hard failure rather than a
+    conflict it could exclude.
+    """
+    old_object = existing_object(object_path) if existing_object else None
+    if old_object is None:
+        errors.append(
+            f'{object_path}: content changed under a UUID whose existing '
+            'flat object could not be fetched to compare'
+        )
+    return old_object
+
+
+def _attach_samples(
+    row: Row,
+    samples: bytes,
+    listing: dict[str, int] | None,
+    existing_object: Callable[[str], bytes | None] | None,
+    errors: list[str],
+) -> tuple[Row | None, bool, str | None]:
+    """Attach new samples or adopt matching historical bytes; never overwrite."""
+    destination = object_path_for(row.object_uuid, suffix='_samples.jsonl')
+    if listing is not None and destination in listing:
+        published = _fetch_existing(destination, existing_object, errors)
+        if published is None:
+            return None, False, None
+        if not semantically_equal(published, samples, jsonl=True):
+            return (
+                row,
+                False,
+                (
+                    f'{samples_path_for(row.legacy_path)}: destination object already '
+                    f'holds different content under immutable UUID {row.object_uuid}; '
+                    'the aggregate is published without these samples'
+                ),
+            )
+        return _row_with_samples(row, published), False, None
+    return _row_with_samples(row, samples), True, None
+
+
+def _row_for_move(
+    old: Row,
+    path: str,
+    benchmark: str,
+    samples: bytes | None,
+    existing_object: Callable[[str], bytes | None] | None,
+    errors: list[str],
+    listing: dict[str, int] | None = None,
+) -> tuple[Row | None, str | None]:
+    """Re-point an identical record to its new ``data/`` path.
+
+    Returns ``(row, conflict)``. A samples change that is not a
+    re-serialization cannot enter the flat view; the row keeps its published
+    samples object and the caller records the conflict.
+    """
+    conflict = None
+    if samples is not None and old.instance_level_available:
+        old_object = _fetch_existing(
+            old.instance_level_path, existing_object, errors
+        )
+        if old_object is None:
+            return None, None
+        if not semantically_equal(old_object, samples, jsonl=True):
+            conflict = (
+                f'{samples_path_for(path)}: samples changed under immutable '
+                f'UUID {old.object_uuid}; the row keeps its published object'
+            )
+    row = replace(
+        old,
+        legacy_path=path,
+        benchmark=benchmark,
+    )
+    if samples is None:
+        row = _row_without_samples(row)
+    if samples is not None and not old.instance_level_available:
+        row, _, conflict = _attach_samples(
+            row, samples, listing, existing_object, errors
+        )
+    return row, conflict
+
+
+def _row_without_samples(row: Row) -> Row:
+    return replace(
+        row,
+        instance_level_available=False,
+        instance_level_path=None,
+        instance_sha=None,
+        instance_level_size_bytes=None,
+    )
+
+
+def _row_with_samples(row: Row, samples: bytes) -> Row:
+    return replace(
+        row,
+        instance_level_available=True,
+        instance_level_path=object_path_for(
+            row.object_uuid, suffix='_samples.jsonl'
+        ),
+        instance_sha=sha256_bytes(samples),
+        instance_level_size_bytes=len(samples),
+    )
+
+
+def schema_version_of(data: bytes, path: str, errors: list[str]) -> str | None:
+    try:
+        loaded = json.loads(data)
+    except json.JSONDecodeError as exc:
+        errors.append(f'{path}: invalid JSON ({exc})')
+        return None
+    if not isinstance(loaded, dict):
+        errors.append(f'{path}: eval JSON must contain an object')
+        return None
+    version = loaded.get('schema_version')
+    if not isinstance(version, str) or not version:
+        errors.append(f'{path}: missing schema_version')
+        return None
+    return version
+
+
+def plan_retire(
+    listing: dict[str, int], live_benchmarks: set[str], *, today: str
+) -> list[tuple[str, str]]:
+    """Move stale collection index paths into ``flat/indexes/retired/``.
+
+    An index whose collection no longer has rows under ``data/`` is a stale
+    view of a removed or renamed collection (upstream renames are routine).
+    Retiring keeps it browsable; the builder and validator only scan
+    ``by_collection/``, so the retired copy stays invisible to them.
+    """
+    moves: list[tuple[str, str]] = []
+    prefix = f'{INDEXES_PREFIX}/'
+    for path in sorted(listing):
+        if not path.startswith(prefix):
+            continue
+        relative = path[len(prefix) :]
+        if relative.endswith('.jsonl') and '/' not in relative:
+            benchmark = relative[: -len('.jsonl')]
+            if benchmark in live_benchmarks:
+                continue
+        destination = f'{RETIRE_PREFIX}/{relative}'
+        if destination in listing:
+            stem, dot, suffix = destination.rpartition('.')
+            destination = f'{stem}.{today}{dot}{suffix}'
+        moves.append((path, destination))
+    return moves
+
+
+@dataclass(frozen=True)
+class RetentionPlan:
+    delete_dirs: tuple[str, ...]
+    pinned: tuple[str, ...]
+    unscanned: tuple[str, ...]
+
+
+def plan_retention(
+    manifests: Sequence[ManifestInfo],
+    *,
+    new_uuids: set[str],
+    current_manifest_path: str | None,
+    now: datetime,
+    retain_days: int,
+    keep_newest: int,
+    scan_budget: int,
+    uuids_of: Callable[[ManifestInfo], set[str]],
+    new_manifest_path: str | None = None,
+) -> RetentionPlan:
+    """Classify old snapshot directories as trim, pin, or leave.
+
+    Reference keys include aggregate UUIDs and companion object paths.
+    A manifest older than the window is trimmed only if every object it
+    references is still referenced by the new snapshot. A manifest holding
+    any object the new snapshot dropped is the last index into that object
+    and is pinned, so no object ever loses its row. Snapshots that could
+    not be scanned within the budget are conservatively kept.
+    """
+    protected: set[str] = set()
+    if new_manifest_path:
+        protected.add(PurePosixPath(new_manifest_path).parent.as_posix())
+    if current_manifest_path:
+        protected.add(PurePosixPath(current_manifest_path).parent.as_posix())
+    for info in sorted(manifests, key=lambda info: info.created, reverse=True)[
+        :keep_newest
+    ]:
+        protected.add(info.dir_path)
+    cutoff = now - timedelta(days=retain_days)
+    old = sorted(
+        (
+            info
+            for info in manifests
+            if info.dir_path not in protected and info.created < cutoff
+        ),
+        key=lambda info: info.created,
+        reverse=True,
+    )
+    delete: list[str] = []
+    pinned: list[str] = []
+    unscanned: list[str] = []
+    for scanned, info in enumerate(old):
+        if scanned >= scan_budget:
+            unscanned.append(info.dir_path)
+            continue
+        try:
+            uuids = uuids_of(info)
+        except Exception as exc:  # noqa: BLE001 - unreadable snapshots are kept
+            warnings.warn(
+                f'Keeping unreadable snapshot {info.dir_path}: {exc}',
+                stacklevel=2,
+            )
+            unscanned.append(info.dir_path)
+            continue
+        if any(uuid not in new_uuids for uuid in uuids):
+            pinned.append(info.dir_path)
+        else:
+            delete.append(info.dir_path)
+    return RetentionPlan(
+        delete_dirs=tuple(delete),
+        pinned=tuple(pinned),
+        unscanned=tuple(unscanned),
+    )
+
+
+def batch_units(units: Sequence[Sequence[Any]], size: int) -> list[list[Any]]:
+    """Greedy-fill commits with whole units; a unit is never split."""
+    batches: list[list[Any]] = []
+    current: list[Any] = []
+    count = 0
+    for unit in units:
+        if current and count + len(unit) > size:
+            batches.append(current)
+            current = []
+            count = 0
+        current.extend(unit)
+        count += len(unit)
+    if current:
+        batches.append(current)
+    return batches
+
+
+# -- publishing ------------------------------------------------------------
+
+
+class FlatPublisher:
+    """Commit whole units to the datastore with the ingestion's retries."""
+
+    def __init__(
+        self, api: HfApi, repo_id: str, batch_size: int = DEFAULT_BATCH_SIZE
+    ) -> None:
+        self.api = api
+        self.repo_id = repo_id
+        self.batch_size = batch_size
+
+    def publish(
+        self, units: Sequence[Sequence[Any]], *, message: str, description: str
+    ) -> int:
+        batches = batch_units(units, self.batch_size)
+        for index, batch in enumerate(batches, start=1):
+            suffix = f' ({index}/{len(batches)})' if len(batches) > 1 else ''
+            self._commit_batch(
+                batch,
+                message=f'{message}{suffix}',
+                description=description,
+            )
+        return len(batches)
+
+    def _commit_batch(
+        self, operations: list[Any], *, message: str, description: str
+    ) -> None:
+        for attempt in range(1, store.COMMIT_ATTEMPTS + 1):
+            try:
+                self.api.create_commit(
+                    repo_id=self.repo_id,
+                    repo_type='dataset',
+                    operations=operations,
+                    commit_message=message,
+                    commit_description=description,
+                )
+                return
+            except Exception as exc:  # noqa: BLE001 - re-raised with context
+                landed = self._landed(operations)
+                if landed:
+                    return
+                if attempt < store.COMMIT_ATTEMPTS and store.is_commit_conflict(
+                    exc
+                ):
+                    store.wait_before_retry(attempt)
+                    continue
+                raise FlatRebuildError(
+                    f'could not commit to {self.repo_id} '
+                    f'({type(exc).__name__}: {exc})'
+                ) from exc
+
+    def _landed(self, operations: Sequence[Any]) -> bool:
+        """Verify every expected byte and deletion after a commit error.
+
+        An unreadable result raises rather than guessing whether to retry.
+        """
+        try:
+            files = set(
+                self.api.list_repo_files(
+                    repo_id=self.repo_id, repo_type='dataset'
+                )
+            )
+            for operation in operations:
+                if isinstance(operation, CommitOperationAdd):
+                    if operation.path_in_repo not in files:
+                        return False
+                    local = self.api.hf_hub_download(
+                        repo_id=self.repo_id,
+                        repo_type='dataset',
+                        filename=operation.path_in_repo,
+                    )
+                    with operation.as_file() as expected:
+                        expected_sha = hashlib.file_digest(
+                            expected, 'sha256'
+                        ).hexdigest()
+                    with Path(local).open('rb') as actual:
+                        actual_sha = hashlib.file_digest(
+                            actual, 'sha256'
+                        ).hexdigest()
+                    if actual_sha != expected_sha:
+                        return False
+                elif operation.path_in_repo in files:
+                    return False
+            return True
+        except Exception as exc:
+            raise FlatRebuildError(
+                f'Commit outcome is unverifiable for {self.repo_id}; stopping: {exc}'
+            ) from exc
+
+
+# -- orchestration ---------------------------------------------------------
+
+
+def collect_manifests(
+    api: HfApi, repo_id: str, listing: dict[str, int]
+) -> list[ManifestInfo]:
+    """Read every snapshot manifest under ``flat/manifests/``."""
+    manifest_paths = sorted(
+        path
+        for path in listing
+        if path.startswith(f'{MANIFESTS_PREFIX}/')
+        and path.endswith('/manifest.json')
+    )
+    contents = download_bytes(api, repo_id, manifest_paths)
+    infos: list[ManifestInfo] = []
+    for path in manifest_paths:
+        loaded = json.loads(contents[path].decode('utf-8'))
+        infos.append(
+            ManifestInfo(
+                manifest_path=path,
+                entries_path=loaded['entries_path'],
+                created_at=loaded['created_at'],
+                dir_path=str(PurePosixPath(path).parent),
+            )
+        )
+    return infos
+
+
+def operation_units(
+    *,
+    rows: Sequence[Row],
+    build: BuildResult,
+    contents: dict[str, bytes],
+    index_adds: Sequence[str],
+    rows_by_benchmark: dict[str, list[dict[str, Any]]],
+    retire_moves: Sequence[tuple[str, str]],
+    retire_contents: dict[str, bytes],
+    new_manifest: dict[str, Any],
+    delete_dirs: Sequence[str],
+    manifests: Sequence[ManifestInfo],
+    publish_snapshot: bool,
+    by_legacy_bytes: bytes | None = None,
+) -> list[list[Any]]:
+    """Operation units in publication order.
+
+    Objects, indexes, retire moves, the new snapshot, the pointer flip, and
+    finally retention trims: any crash before the flip leaves the previous
+    snapshot fully intact, and a flipped pointer is never invalidated by a
+    later trim because the current snapshot is always protected. When the
+    manifest core hash is unchanged (a run that only retires or trims), the
+    snapshot files and pointer are already correct and are not re-committed.
+    """
+    units: list[list[Any]] = []
+    row_by_uuid = {row.object_uuid: row for row in rows}
+    for object_uuid in sorted(build.upload_aggregates):
+        row = row_by_uuid[object_uuid]
+        units.append(
+            [
+                CommitOperationAdd(
+                    path_in_repo=row.object_path,
+                    path_or_fileobj=contents[row.legacy_path],
+                )
+            ]
+        )
+    for object_uuid in sorted(build.upload_samples):
+        row = row_by_uuid[object_uuid]
+        units.append(
+            [
+                CommitOperationAdd(
+                    path_in_repo=row.instance_level_path,
+                    path_or_fileobj=contents[samples_path_for(row.legacy_path)],
+                )
+            ]
+        )
+    for benchmark in index_adds:
+        units.append(
+            [
+                CommitOperationAdd(
+                    path_in_repo=f'{INDEXES_PREFIX}/{benchmark}.jsonl',
+                    path_or_fileobj=jsonl_text(
+                        rows_by_benchmark[benchmark]
+                    ).encode('utf-8'),
+                )
+            ]
+        )
+    if by_legacy_bytes is not None:
+        units.append(
+            [
+                CommitOperationAdd(
+                    path_in_repo=BY_LEGACY_PATH,
+                    path_or_fileobj=by_legacy_bytes,
+                )
+            ]
+        )
+    for source, destination in retire_moves:
+        units.append(
+            [
+                CommitOperationAdd(
+                    path_in_repo=destination,
+                    path_or_fileobj=retire_contents[source],
+                ),
+                CommitOperationDelete(path_in_repo=source),
+            ]
+        )
+    if publish_snapshot:
+        manifest_bytes = (
+            json.dumps(new_manifest, indent=2, sort_keys=True) + '\n'
+        ).encode('utf-8')
+        entries_bytes = jsonl_text(rows).encode('utf-8')
+        units.append(
+            [
+                CommitOperationAdd(
+                    path_in_repo=new_manifest['entries_path'],
+                    path_or_fileobj=entries_bytes,
+                )
+            ]
+        )
+        units.append(
+            [
+                CommitOperationAdd(
+                    path_in_repo=new_manifest['manifest_path'],
+                    path_or_fileobj=manifest_bytes,
+                )
+            ]
+        )
+        units.append(
+            [
+                CommitOperationAdd(
+                    path_in_repo=LATEST_MANIFEST_PATH,
+                    path_or_fileobj=manifest_bytes,
+                )
+            ]
+        )
+    by_dir = {info.dir_path: info for info in manifests}
+    for dir_path in delete_dirs:
+        info = by_dir[dir_path]
+        units.append(
+            [
+                CommitOperationDelete(path_in_repo=info.manifest_path),
+                CommitOperationDelete(path_in_repo=info.entries_path),
+            ]
+        )
+    return units
+
+
+def orchestrate(
+    api: HfApi,
+    repo_id: str,
+    *,
+    retain_days: int = DEFAULT_RETAIN_DAYS,
+    keep_newest: int = DEFAULT_KEEP_NEWEST,
+    scan_budget: int = DEFAULT_SCAN_BUDGET,
+    allow_bootstrap: bool = False,
+    dry_run: bool = False,
+    verify: bool = False,
+    now: datetime | None = None,
+) -> RebuildReport:
+    """Plan and, unless dry, publish one flat rebuild. Returns the report."""
+    if not repo_id.strip():
+        raise FlatRebuildError('repo_id must not be empty')
+    started = time.monotonic()
+    now = now or datetime.now(UTC)
+    report = RebuildReport(repo_id=repo_id, dry_run=dry_run)
+
+    snapshot = read_snapshot(api, repo_id)
+    if snapshot is None and not allow_bootstrap:
+        raise FlatRebuildError(
+            f'{LATEST_MANIFEST_PATH} does not exist, so this would be a full '
+            'initial build of every record in data/. Pass --allow-bootstrap '
+            'to allow that.'
+        )
+    manifest, old_rows = snapshot or ({}, [])
+    report.old_records = len(old_rows)
+
+    listing = list_repo_sizes(api, repo_id)
+    report.data_files = sum(
+        1
+        for path in listing
+        if path.startswith(DATA_PREFIX) and path.endswith('.json')
+    )
+
+    diff = diff_against_snapshot(old_rows, listing)
+    report.orphan_samples = len(diff.orphan_samples)
+    needed = sorted(
+        {
+            *diff.new_paths,
+            *diff.new_sample_paths,
+            *diff.changed_aggregates,
+            *(samples_path_for(path) for path in diff.changed_samples),
+        }
+    )
+    contents = download_bytes(api, repo_id, needed)
+    object_cache: dict[str, bytes] = {}
+
+    def existing_object(object_path: str) -> bytes | None:
+        """Fetch an existing flat object for semantic comparison."""
+        if object_path not in listing:
+            return None
+        if object_path not in object_cache:
+            object_cache.update(download_bytes(api, repo_id, [object_path]))
+        return object_cache[object_path]
+
+    build = build_rows(old_rows, diff, contents, existing_object, listing)
+    if build.errors:
+        raise FlatRebuildError(
+            f'{len(build.errors)} record(s) cannot be flattened:\n'
+            + '\n'.join(build.errors)
+        )
+    report.conflicts = build.conflicts
+    rows = build.rows
+    if verify:
+        pending_objects = frozenset(
+            [
+                object_path_for(uuid, suffix='.json')
+                for uuid in build.upload_aggregates
+            ]
+            + [
+                object_path_for(uuid, suffix='_samples.jsonl')
+                for uuid in build.upload_samples
+            ]
+        )
+        checked, reserialized, drift = verify_rows(
+            api, repo_id, rows, listing, pending_objects=pending_objects
+        )
+        report.verified_files = checked
+        report.verified_reserialized = reserialized
+        if drift:
+            raise FlatRebuildError(
+                f'{len(drift)} data file(s) no longer match the published '
+                'snapshot:\n' + '\n'.join(drift)
+            )
+    report.added_records = build.added
+    report.moved_records = build.moved
+    report.removed_records = len(diff.removed_rows)
+    report.records = len(rows)
+    report.collections = len({row.benchmark for row in rows})
+
+    new_manifest = manifest_for(rows, created_at=utc_now())
+    report.manifest_core_sha256 = new_manifest['manifest_core_sha256']
+    noop_core = bool(manifest) and manifest_core(manifest) == manifest_core(
+        new_manifest
+    )
+
+    live_benchmarks = {row.benchmark for row in rows}
+    retire_moves = plan_retire(listing, live_benchmarks, today=f'{now:%Y%m%d}')
+    report.indexes_retired = tuple(source for source, _ in retire_moves)
+
+    old_by_benchmark: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in old_rows:
+        old_by_benchmark[row.benchmark].append(row.to_dict())
+    new_by_benchmark: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        new_by_benchmark[row.benchmark].append(row.to_dict())
+    single = f'{INDEXES_PREFIX}/'
+    present_indexes = {
+        path[len(single) : -len('.jsonl')]
+        for path in listing
+        if path.startswith(single)
+        and path.endswith('.jsonl')
+        and '/' not in path[len(single) :]
+    }
+    index_adds: list[str] = []
+    for benchmark in sorted(live_benchmarks):
+        unchanged = old_by_benchmark.get(benchmark) == new_by_benchmark.get(
+            benchmark
+        )
+        if f'{benchmark}' in present_indexes and unchanged:
+            continue
+        index_adds.append(benchmark)
+    report.indexes_added = tuple(index_adds)
+
+    manifests = collect_manifests(api, repo_id, listing)
+    report.manifests_total = len(manifests)
+    new_uuids = {row.object_uuid for row in rows}
+    new_uuids.update(
+        row.instance_level_path for row in rows if row.instance_level_available
+    )
+
+    def uuids_of(info: ManifestInfo) -> set[str]:
+        local = api.hf_hub_download(
+            repo_id=repo_id,
+            repo_type='dataset',
+            filename=info.entries_path,
+        )
+        references: set[str] = set()
+        for line in Path(local).read_text(encoding='utf-8').splitlines():
+            if not line.strip():
+                continue
+            row = Row.from_dict(json.loads(line))
+            references.add(row.object_uuid)
+            if row.instance_level_available:
+                if not row.instance_level_path:
+                    raise FlatRebuildError(
+                        f'{info.entries_path}: missing samples object path'
+                    )
+                references.add(row.instance_level_path)
+        return references
+
+    retention = plan_retention(
+        manifests,
+        new_uuids=new_uuids,
+        current_manifest_path=manifest.get('manifest_path'),
+        new_manifest_path=new_manifest['manifest_path'],
+        now=now,
+        retain_days=retain_days,
+        keep_newest=keep_newest,
+        scan_budget=scan_budget,
+        uuids_of=uuids_of,
+    )
+    report.manifests_trimmed = retention.delete_dirs
+    report.manifests_pinned = retention.pinned
+    report.manifests_unscanned = retention.unscanned
+
+    if (
+        noop_core
+        and not index_adds
+        and BY_LEGACY_PATH in listing
+        and not retire_moves
+        and not retention.delete_dirs
+    ):
+        report.noop = True
+        report.duration_seconds = time.monotonic() - started
+        return report
+
+    retire_contents = download_bytes(
+        api, repo_id, [source for source, _ in retire_moves]
+    )
+    by_legacy_bytes = jsonl_text(rows).encode('utf-8')
+    if (
+        BY_LEGACY_PATH in listing
+        and existing_object(BY_LEGACY_PATH) == by_legacy_bytes
+    ):
+        by_legacy_bytes = None  # already published, byte for byte
+    units = operation_units(
+        rows=rows,
+        build=build,
+        contents=contents,
+        index_adds=index_adds,
+        rows_by_benchmark=dict(new_by_benchmark),
+        retire_moves=retire_moves,
+        retire_contents=retire_contents,
+        new_manifest=new_manifest,
+        delete_dirs=retention.delete_dirs,
+        manifests=manifests,
+        publish_snapshot=not noop_core,
+        by_legacy_bytes=by_legacy_bytes,
+    )
+    report.uploads = sum(
+        1
+        for unit in units
+        for operation in unit
+        if isinstance(operation, CommitOperationAdd)
+    )
+
+    if dry_run:
+        report.duration_seconds = time.monotonic() - started
+        return report
+
+    publisher = FlatPublisher(api, repo_id, batch_size=DEFAULT_BATCH_SIZE)
+    report.commits = publisher.publish(
+        units,
+        message=(
+            f'cron: flat rebuild {now:%Y-%m-%d} '
+            f'({report.records} aggregate record(s))'
+        ),
+        description=(
+            f'Rebuilt flat/ from data/ against snapshot '
+            f'{manifest.get("manifest_core_sha256", "bootstrap")}: '
+            f'+{report.added_records} new, -{report.removed_records} '
+            f'removed, {len(retire_moves)} stale index(es) retired, '
+            f'{len(retention.delete_dirs)} old snapshot(s) trimmed.'
+        ),
+    )
+    report.duration_seconds = time.monotonic() - started
+    return report
+
+
+# -- reporting -------------------------------------------------------------
+
+
+def summary_lines(report: RebuildReport) -> list[str]:
+    lines = [
+        f'## Flat rebuild — {report.repo_id}',
+        '',
+        f'- records: {report.old_records} -> {report.records} '
+        f'(+{report.added_records} / -{report.removed_records}) across '
+        f'{report.collections} collection(s)',
+        f'- stale indexes retired: {len(report.indexes_retired)}',
+        f'- snapshots: {report.manifests_total} total, '
+        f'{len(report.manifests_trimmed)} trimmed, '
+        f'{len(report.manifests_pinned)} pinned, '
+        f'{len(report.manifests_unscanned)} unscanned',
+        f'- manifest core sha256: `{report.manifest_core_sha256}`',
+    ]
+    if report.verified_files:
+        lines.append(
+            f'- deep verification: {report.verified_files} data file(s) '
+            f'hashed, {report.verified_reserialized} re-serialization(s) '
+            'accepted'
+        )
+    if report.noop:
+        lines.append('- **no-op**: the published snapshot already matches')
+    elif report.dry_run:
+        lines.append(
+            f'- **dry run**: {report.uploads} file(s) would be committed'
+        )
+    else:
+        lines.append(
+            f'- published in {report.commits} commit(s), '
+            f'{report.uploads} file(s) uploaded'
+        )
+    if report.conflicts:
+        lines.append(
+            f'- **conflicts: {len(report.conflicts)}** record(s) excluded - '
+            're-emitted under a known UUID with different content; the '
+            'published objects stay, upstream should re-emit with fresh '
+            'UUIDs'
+        )
+    for label, paths in (
+        ('Excluded records', report.conflicts),
+        ('Retired indexes', report.indexes_retired),
+        ('Trimmed snapshots', report.manifests_trimmed),
+        ('Pinned snapshots', report.manifests_pinned),
+        ('Unscanned snapshots (kept)', report.manifests_unscanned),
+    ):
+        if paths:
+            lines.append(f'\n<details><summary>{label}</summary>\n')
+            lines.extend(f'- `{path}`' for path in paths)
+            lines.append('\n</details>')
+    return lines
+
+
+def exit_code_for(report: RebuildReport) -> int:
+    """0 clean or no-op, 2 completed with exclusions, per the house codes."""
+    return 2 if report.conflicts else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        '--repo-id',
+        default=os.environ.get('EEE_DATASTORE_REPO_ID')
+        or DEFAULT_DATASTORE_REPO,
+        help='EEE datastore dataset repository (unset or empty environment uses %(default)s).',
+    )
+    parser.add_argument(
+        '--retain-days',
+        type=int,
+        default=DEFAULT_RETAIN_DAYS,
+        help='Keep snapshots younger than this many days (default: %(default)s).',
+    )
+    parser.add_argument(
+        '--keep-newest',
+        type=int,
+        default=DEFAULT_KEEP_NEWEST,
+        help='Always keep this many newest snapshots (default: %(default)s).',
+    )
+    parser.add_argument(
+        '--scan-budget',
+        type=int,
+        default=DEFAULT_SCAN_BUDGET,
+        help='Max old snapshots to classify per run (default: %(default)s).',
+    )
+    parser.add_argument(
+        '--allow-bootstrap',
+        action='store_true',
+        help='Allow a full initial build when no snapshot exists yet.',
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Plan and report, commit nothing.',
+    )
+    parser.add_argument(
+        '--verify',
+        action='store_true',
+        help=(
+            'Deep pass: hash every inherited data file against the '
+            'snapshot, so same-length edits the size diff cannot see fail '
+            'loudly. Slow; intended for a periodic sweep, not every run.'
+        ),
+    )
+    args = parser.parse_args(argv)
+    started = time.monotonic()
+    try:
+        report = orchestrate(
+            HfApi(),
+            args.repo_id,
+            retain_days=args.retain_days,
+            keep_newest=args.keep_newest,
+            scan_budget=args.scan_budget,
+            allow_bootstrap=args.allow_bootstrap,
+            dry_run=args.dry_run,
+            verify=args.verify,
+        )
+    except FlatRebuildError as exc:
+        if os.environ.get('GITHUB_ACTIONS'):
+            print(f'::error::{exc}', file=sys.stderr)
+        else:
+            print(f'error: {exc}', file=sys.stderr)
+        return 1
+    lines = summary_lines(report)
+    print('\n'.join(lines))
+    summary_path = os.environ.get('GITHUB_STEP_SUMMARY')
+    if summary_path:
+        with Path(summary_path).open('a', encoding='utf-8') as handle:
+            handle.write('\n'.join(lines) + '\n')
+    if report.conflicts and os.environ.get('GITHUB_ACTIONS'):
+        print(
+            f'::warning::{len(report.conflicts)} record(s) excluded from '
+            'the flat view: re-emitted under known UUIDs with different '
+            'content. See the run summary for the full list.'
+        )
+    print(f'done in {time.monotonic() - started:.1f}s')
+    return exit_code_for(report)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_flat_rebuild.py
+++ b/tests/test_flat_rebuild.py
@@ -181,6 +181,26 @@ def test_row_dict_omits_absent_samples() -> None:
     assert 'instance_level_path' not in row.to_dict()
 
 
+def test_row_from_dict_normalizes_absent_samples() -> None:
+    row = make_row(str(uuid4()), 'gsm8k')
+    loaded = fr.Row.from_dict(
+        {
+            **row.to_dict(),
+            'instance_level_path': 'flat/objects/keep-me-out.jsonl',
+            'instance_sha': 'abc',
+            'instance_level_size_bytes': 1,
+        }
+    )
+    assert loaded == row
+
+
+def test_row_from_dict_rejects_incomplete_samples() -> None:
+    row = make_row(str(uuid4()), 'gsm8k').to_dict()
+    row['instance_level_available'] = True
+    with pytest.raises(ValueError, match='companion metadata'):
+        fr.Row.from_dict(row)
+
+
 def test_manifest_shape_matches_builder() -> None:
     rows = [make_row(str(uuid4()), 'gsm8k')]
     manifest = fr.manifest_for(rows, created_at='2026-01-01T00:00:00+00:00')
@@ -300,6 +320,25 @@ def test_same_uuid_semantic_change_becomes_conflict() -> None:
     # without the existing object there is nothing to compare against
     result = fr.build_rows([old_row], diff, contents)
     assert 'could not be fetched' in result.errors[0]
+
+
+def test_changed_samples_conflict_excludes_samples_path() -> None:
+    row = fr._row_with_samples(make_row(str(uuid4()), 'gsm8k'), b'{"x":1}\n')
+    sample_path = fr.samples_path_for(row.legacy_path)
+    changed = b'{"x":2000}\n'
+    result = fr.build_rows(
+        [row],
+        fr.diff_against_snapshot(
+            [row], {row.legacy_path: row.size_bytes, sample_path: len(changed)}
+        ),
+        {sample_path: changed},
+        lambda object_path: (
+            b'{"x":1}\n' if object_path == row.instance_level_path else None
+        ),
+    )
+    assert not result.errors
+    assert len(result.conflicts) == 1
+    assert result.excluded_paths == {sample_path}
 
 
 def test_reserialized_move_is_accepted() -> None:
@@ -619,6 +658,7 @@ def test_orchestrate_rebuild_then_noop(
     assert report.commits >= 1
     latest = json.loads(api.files[fr.LATEST_MANIFEST_PATH])
     assert latest['aggregate_file_count'] == 3
+    assert latest['created_at'] == NOW.isoformat()
     assert 'flat/indexes/by_collection/gsm8k.jsonl' in api.files
     assert 'flat/indexes/by_collection/hle.jsonl' in api.files
     assert 'flat/indexes/by_legacy_path.jsonl' in api.files
@@ -1098,6 +1138,31 @@ def test_moved_multiline_companion_is_not_a_conflict(incoming):
     assert not result.conflicts
     assert result.rows[0].instance_sha == row.instance_sha
     assert not result.upload_samples
+
+
+def test_moved_companion_conflict_excludes_samples_path():
+    published = b'{"x":1}\n'
+    row = fr._row_with_samples(make_row(str(uuid4()), 'gsm8k'), published)
+    path = row.legacy_path.replace('/gsm8k/', '/other/')
+    sample_path = fr.samples_path_for(path)
+    result = fr.build_rows(
+        [row],
+        fr.diff_against_snapshot(
+            [row],
+            {
+                path: len(record_bytes(row.object_uuid, 'gsm8k')),
+                sample_path: len(b'{"x":2000}\n'),
+            },
+        ),
+        {
+            path: record_bytes(row.object_uuid, 'gsm8k'),
+            sample_path: b'{"x":2000}\n',
+        },
+        lambda object_path: published if object_path == row.instance_level_path else None,
+    )
+    assert not result.errors
+    assert len(result.conflicts) == 1
+    assert result.excluded_paths == {sample_path}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_flat_rebuild.py
+++ b/tests/test_flat_rebuild.py
@@ -1,0 +1,1200 @@
+"""Tests for the Hub-backed flat rebuild (cron.flat_rebuild)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path, PurePosixPath
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from huggingface_hub import CommitOperationAdd, CommitOperationDelete
+from huggingface_hub.errors import EntryNotFoundError
+
+from every_eval_ever.cron import flat_rebuild as fr
+from every_eval_ever.cron import store
+
+NOW = datetime(2026, 9, 6, 12, 0, 0, tzinfo=UTC)
+OLD = NOW - timedelta(days=100)
+OLDER = NOW - timedelta(days=101)
+RECENT = NOW - timedelta(days=1)
+SCHEMA = '0.2.2'
+
+
+def record_bytes(uuid: str, benchmark: str) -> bytes:
+    return json.dumps(
+        {
+            'schema_version': SCHEMA,
+            'evaluation_id': f'{benchmark}/dev/model/{uuid}',
+            'model_info': {'id': 'dev/model', 'developer': 'dev'},
+            'evaluation_results': [
+                {
+                    'evaluation_name': benchmark,
+                    'metric_config': {'metric_id': 'accuracy'},
+                    'score_details': {'score': 1},
+                }
+            ],
+        }
+    ).encode()
+
+
+@dataclass
+class FakeRepoFile:
+    path: str
+    size: int
+
+
+class FakeApi:
+    """In-memory HfApi: enough surface for flat_rebuild, no network."""
+
+    def __init__(self, files: dict[str, bytes], tmp_path: Path) -> None:
+        self.files = dict(files)
+        self.downloads = tmp_path / 'downloads'
+        self.commits: list[str] = []
+        self.commit_ops: list[list[Any]] = []
+        self.fail_next = 0
+
+    def list_repo_tree(self, repo_id: str, repo_type: str, recursive: bool):
+        for path in sorted(self.files):
+            yield FakeRepoFile(path, len(self.files[path]))
+
+    def list_repo_files(
+        self, repo_id: str, repo_type: str, revision: str | None = None
+    ) -> list[str]:
+        return sorted(self.files)
+
+    def hf_hub_download(
+        self, repo_id: str, repo_type: str, filename: str
+    ) -> str:
+        if filename not in self.files:
+            raise EntryNotFoundError(filename)
+        target = self.downloads / filename.replace('/', '_')
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(self.files[filename])
+        return str(target)
+
+    def create_commit(
+        self,
+        repo_id: str,
+        repo_type: str,
+        operations: list[Any],
+        commit_message: str,
+        commit_description: str | None = None,
+    ) -> None:
+        if self.fail_next > 0:
+            self.fail_next -= 1
+            raise RuntimeError('simulated hub error')
+        self.commits.append(commit_message)
+        self.commit_ops.append(list(operations))
+        for operation in operations:
+            if isinstance(operation, CommitOperationAdd):
+                data = operation.path_or_fileobj
+                if isinstance(data, str):
+                    data = Path(data).read_bytes()
+                self.files[operation.path_in_repo] = bytes(data)
+            elif isinstance(operation, CommitOperationDelete):
+                self.files.pop(operation.path_in_repo, None)
+
+
+def committed_paths(api: FakeApi) -> set[str]:
+    return {
+        operation.path_in_repo
+        for operations in api.commit_ops
+        for operation in operations
+    }
+
+
+def seed_manifest_files(
+    files: dict[str, bytes], rows: list[fr.Row], created_at: str
+) -> dict[str, Any]:
+    """Write a snapshot's manifest and entries without moving the pointer."""
+    manifest = fr.manifest_for(rows, created_at=created_at)
+    files[manifest['entries_path']] = fr.jsonl_text(rows).encode()
+    files[manifest['manifest_path']] = (
+        json.dumps(manifest, indent=2, sort_keys=True) + '\n'
+    ).encode()
+    return manifest
+
+
+def seed_pointer(files: dict[str, bytes], manifest: dict[str, Any]) -> None:
+    files[fr.LATEST_MANIFEST_PATH] = (
+        json.dumps(manifest, indent=2, sort_keys=True) + '\n'
+    ).encode()
+
+
+def seed_derived(files: dict[str, bytes], rows: list[fr.Row]) -> None:
+    """Write the index files a published snapshot would have, so a run
+    whose rows are unchanged is a clean no-op."""
+    ordered = sorted(rows, key=lambda row: row.legacy_path)
+    files[fr.BY_LEGACY_PATH] = fr.jsonl_text(ordered).encode()
+    by_benchmark: dict[str, list[fr.Row]] = {}
+    for row in ordered:
+        by_benchmark.setdefault(row.benchmark, []).append(row)
+    for benchmark, brows in by_benchmark.items():
+        files[f'{fr.INDEXES_PREFIX}/{benchmark}.jsonl'] = fr.jsonl_text(
+            brows
+        ).encode()
+
+
+def make_row(uuid: str, benchmark: str, *, legacy: str | None = None) -> fr.Row:
+    path = legacy or f'data/{benchmark}/dev/model/{uuid}.json'
+    data = record_bytes(uuid, benchmark)
+    return fr.Row(
+        object_uuid=uuid,
+        object_path=fr.object_path_for(uuid, suffix='.json'),
+        sha256=fr.sha256_bytes(data),
+        size_bytes=len(data),
+        legacy_path=path,
+        benchmark=benchmark,
+        eval_schema_version=SCHEMA,
+    )
+
+
+def seed_datastore(
+    files: dict[str, bytes], benchmarks: dict[str, int]
+) -> list[fr.Row]:
+    """Populate data/ records and a snapshot one record behind them."""
+    rows: list[fr.Row] = []
+    for benchmark, count in benchmarks.items():
+        for _ in range(count):
+            uuid = str(uuid4())
+            path = f'data/{benchmark}/dev/model/{uuid}.json'
+            files[path] = record_bytes(uuid, benchmark)
+            rows.append(make_row(uuid, benchmark))
+    manifest = seed_manifest_files(files, rows[:-1], RECENT.isoformat())
+    seed_pointer(files, manifest)
+    return rows
+
+
+# -- row and manifest shapes -----------------------------------------------
+
+
+def test_row_round_trip() -> None:
+    row = make_row(str(uuid4()), 'gsm8k')
+    assert fr.Row.from_dict(row.to_dict()) == row
+
+
+def test_row_dict_omits_absent_samples() -> None:
+    row = make_row(str(uuid4()), 'gsm8k')
+    assert 'instance_level_path' not in row.to_dict()
+
+
+def test_manifest_shape_matches_builder() -> None:
+    rows = [make_row(str(uuid4()), 'gsm8k')]
+    manifest = fr.manifest_for(rows, created_at='2026-01-01T00:00:00+00:00')
+    assert manifest['aggregate_file_count'] == 1
+    assert manifest['benchmark_count'] == 1
+    assert manifest['total_file_count'] == 1
+    assert manifest['source'] == {'type': 'legacy_data_tree', 'path': 'data'}
+    core = fr.manifest_core(manifest)
+    assert 'created_at' not in core
+    assert 'entries_path' not in core
+    assert (
+        fr.sha256_bytes(fr.stable_json_bytes(core))
+        == (manifest['manifest_core_sha256'])
+    )
+
+
+def test_manifest_ignores_created_at() -> None:
+    rows = [make_row(str(uuid4()), 'gsm8k')]
+    one = fr.manifest_for(rows, created_at='2026-01-01T00:00:00+00:00')
+    two = fr.manifest_for(rows, created_at='2027-01-01T00:00:00+00:00')
+    assert fr.manifest_core(one) == fr.manifest_core(two)
+    assert one['manifest_core_sha256'] == two['manifest_core_sha256']
+
+
+# -- diff_against_snapshot ---------------------------------------------------
+
+
+def test_diff_finds_new_removed_and_orphans() -> None:
+    kept = str(uuid4())
+    gone = str(uuid4())
+    fresh = str(uuid4())
+    old_rows = [make_row(kept, 'gsm8k'), make_row(gone, 'gone_coll')]
+    listing = {
+        f'data/gsm8k/dev/model/{kept}.json': 10,
+        f'data/gsm8k/dev/model/{fresh}.json': 10,
+        f'data/gsm8k/dev/model/{fresh}_samples.jsonl': 10,
+        f'data/gone_coll/dev/{gone}_samples.jsonl': 10,
+    }
+    diff = fr.diff_against_snapshot(old_rows, listing)
+    assert len(diff.new_paths) == 1
+    assert diff.new_paths[0].endswith(f'{fresh}.json')
+    assert diff.new_sample_paths[0].endswith(f'{fresh}_samples.jsonl')
+    assert [row.object_uuid for row in diff.removed_rows] == [gone]
+    assert list(diff.orphan_samples) == [
+        f'data/gone_coll/dev/{gone}_samples.jsonl'
+    ]
+
+
+def test_diff_size_equal_is_not_new() -> None:
+    row = make_row(str(uuid4()), 'gsm8k')
+    diff = fr.diff_against_snapshot([row], {row.legacy_path: row.size_bytes})
+    assert diff.new_paths == ()
+    assert diff.removed_rows == ()
+
+
+# -- build_rows ---------------------------------------------------------------
+
+
+def test_build_new_aggregate_with_samples() -> None:
+    uuid = str(uuid4())
+    path = f'data/gsm8k/dev/model/{uuid}.json'
+    samples_path = f'data/gsm8k/dev/model/{uuid}_samples.jsonl'
+    contents = {path: record_bytes(uuid, 'gsm8k'), samples_path: b'{"x": 1}'}
+    diff = fr.diff_against_snapshot(
+        [], {path: len(contents[path]), samples_path: 8}
+    )
+    result = fr.build_rows([], diff, contents)
+    assert not result.errors
+    assert result.added == 1
+    row = result.rows[0]
+    assert row.instance_level_available
+    assert row.instance_level_path == fr.object_path_for(
+        uuid, suffix='_samples.jsonl'
+    )
+    assert uuid in result.upload_aggregates
+    assert uuid in result.upload_samples
+
+
+def test_build_move_repoints_without_uploads() -> None:
+    uuid = str(uuid4())
+    old_path = f'data/gsm8k/dev/model/{uuid}.json'
+    new_path = f'data/gsm8k/other/{uuid}.json'
+    data = record_bytes(uuid, 'gsm8k')
+    old_row = make_row(uuid, 'gsm8k', legacy=old_path)
+    diff = fr.diff_against_snapshot([old_row], {new_path: len(data)})
+    result = fr.build_rows([old_row], diff, {new_path: data})
+    assert not result.errors
+    assert result.moved == 1
+    assert result.added == 0
+    assert not result.upload_aggregates
+    assert result.rows[0].legacy_path == new_path
+
+
+def test_same_uuid_semantic_change_becomes_conflict() -> None:
+    old_row = make_row(str(uuid4()), 'gsm8k')
+    changed = json.loads(record_bytes(old_row.object_uuid, 'gsm8k'))
+    changed['evaluation_results'][0]['score_details']['score'] = 100
+    contents = {old_row.legacy_path: json.dumps(changed).encode()}
+    listing = {old_row.legacy_path: len(contents[old_row.legacy_path])}
+    diff = fr.diff_against_snapshot([old_row], listing)
+    old_object = record_bytes(old_row.object_uuid, 'gsm8k')
+    result = fr.build_rows(
+        [old_row],
+        diff,
+        contents,
+        lambda object_path: (
+            old_object if object_path == old_row.object_path else None
+        ),
+    )
+    assert not result.errors
+    assert len(result.conflicts) == 1
+    assert 'immutable' in result.conflicts[0]
+    assert result.excluded_paths == {old_row.legacy_path}
+    assert result.rows[0] == old_row  # the published object stays
+    assert not result.upload_aggregates
+
+    # without the existing object there is nothing to compare against
+    result = fr.build_rows([old_row], diff, contents)
+    assert 'could not be fetched' in result.errors[0]
+
+
+def test_reserialized_move_is_accepted() -> None:
+    old_row = make_row(str(uuid4()), 'gsm8k')
+    new_path = old_row.legacy_path.replace('/gsm8k/', '/other/')
+    parsed = json.loads(record_bytes(old_row.object_uuid, 'gsm8k'))
+    reserialized = json.dumps(parsed, indent=2, sort_keys=True).encode()
+    diff = fr.diff_against_snapshot([old_row], {new_path: len(reserialized)})
+    result = fr.build_rows(
+        [old_row],
+        diff,
+        {new_path: reserialized},
+        lambda object_path: (
+            record_bytes(old_row.object_uuid, 'gsm8k')
+            if object_path == old_row.object_path
+            else None
+        ),
+    )
+    assert not result.errors
+    assert result.moved == 1
+    assert not result.upload_aggregates
+    assert result.rows[0].legacy_path == new_path
+    assert result.rows[0].sha256 == old_row.sha256
+
+
+def test_changed_in_place_reserialization_is_kept() -> None:
+    old_row = make_row(str(uuid4()), 'gsm8k')
+    parsed = json.loads(record_bytes(old_row.object_uuid, 'gsm8k'))
+    reserialized = json.dumps(parsed, indent=2).encode()
+    diff = fr.diff_against_snapshot(
+        [old_row], {old_row.legacy_path: len(reserialized)}
+    )
+    result = fr.build_rows(
+        [old_row],
+        diff,
+        {old_row.legacy_path: reserialized},
+        lambda object_path: (
+            record_bytes(old_row.object_uuid, 'gsm8k')
+            if object_path == old_row.object_path
+            else None
+        ),
+    )
+    assert not result.errors
+    assert result.rows[0] == old_row
+    assert not result.upload_aggregates
+
+
+def test_build_rejects_invalid_uuid_and_bad_json() -> None:
+    bad_path = 'data/coll/dev/model/not-a-uuid.json'
+    diff = fr.diff_against_snapshot([], {bad_path: 2})
+    result = fr.build_rows([], diff, {bad_path: b'{}'})
+    assert any('valid UUID' in error for error in result.errors)
+
+    uuid = str(uuid4())
+    path = f'data/coll/dev/model/{uuid}.json'
+    diff = fr.diff_against_snapshot([], {path: 2})
+    result = fr.build_rows([], diff, {path: b'[]'})
+    assert any('object' in error for error in result.errors)
+
+
+# -- plan_retire ----------------------------------------------------------------
+
+
+def test_retire_moves_stale_and_keeps_live() -> None:
+    listing = {
+        'flat/indexes/by_collection/live.jsonl': 10,
+        'flat/indexes/by_collection/dead.jsonl': 10,
+        'flat/indexes/by_collection/legacy/aggregate.jsonl': 10,
+    }
+    moves = dict(fr.plan_retire(listing, {'live'}, today='20260906'))
+    assert moves['flat/indexes/by_collection/dead.jsonl'] == (
+        'flat/indexes/retired/dead.jsonl'
+    )
+    assert moves['flat/indexes/by_collection/legacy/aggregate.jsonl'] == (
+        'flat/indexes/retired/legacy/aggregate.jsonl'
+    )
+    assert all('live' not in source for source in moves)
+
+
+def test_retire_suffixes_on_collision() -> None:
+    listing = {
+        'flat/indexes/by_collection/dead.jsonl': 10,
+        'flat/indexes/retired/dead.jsonl': 10,
+    }
+    moves = fr.plan_retire(listing, set(), today='20260906')
+    assert moves[0][1] == 'flat/indexes/retired/dead.20260906.jsonl'
+
+
+# -- plan_retention ---------------------------------------------------------------
+
+
+def manifest_info(created_at: datetime, name: str) -> fr.ManifestInfo:
+    digest = fr.sha256_bytes(name.encode())
+    dir_path = f'flat/manifests/sha256_{digest}'
+    return fr.ManifestInfo(
+        manifest_path=f'{dir_path}/manifest.json',
+        entries_path=f'{dir_path}/entries.jsonl',
+        created_at=created_at.isoformat(),
+        dir_path=dir_path,
+    )
+
+
+def test_retention_trims_only_fully_covered() -> None:
+    live_uuid = str(uuid4())
+    dead_uuid = str(uuid4())
+    current = manifest_info(NOW, 'current')
+    within = manifest_info(RECENT, 'within')
+    trimmable = manifest_info(OLD, 'trim')
+    pinned = manifest_info(OLDER, 'pin')
+    uuids = {
+        current.dir_path: {live_uuid},
+        within.dir_path: {live_uuid},
+        trimmable.dir_path: {live_uuid},
+        pinned.dir_path: {dead_uuid, live_uuid},
+    }
+    plan = fr.plan_retention(
+        [current, within, trimmable, pinned],
+        new_uuids={live_uuid},
+        current_manifest_path=current.manifest_path,
+        now=NOW,
+        retain_days=90,
+        keep_newest=2,
+        scan_budget=10,
+        uuids_of=lambda info: uuids[info.dir_path],
+    )
+    assert plan.delete_dirs == (trimmable.dir_path,)
+    assert plan.pinned == (pinned.dir_path,)
+    assert plan.unscanned == ()
+
+
+def test_retention_budget_keeps_unscanned() -> None:
+    live_uuid = str(uuid4())
+    current = manifest_info(NOW, 'current')
+    old = [manifest_info(OLD - timedelta(days=i), f'm{i}') for i in range(3)]
+    uuids = {current.dir_path: {live_uuid}} | {
+        info.dir_path: {live_uuid} for info in old
+    }
+    plan = fr.plan_retention(
+        [current, *old],
+        new_uuids={live_uuid},
+        current_manifest_path=current.manifest_path,
+        now=NOW,
+        retain_days=90,
+        keep_newest=1,
+        scan_budget=1,
+        uuids_of=lambda info: uuids[info.dir_path],
+    )
+    assert len(plan.delete_dirs) == 1
+    assert len(plan.unscanned) == 2
+
+
+def test_retention_keeps_unreadable_snapshots() -> None:
+    live_uuid = str(uuid4())
+    current = manifest_info(NOW, 'current')
+    broken = manifest_info(OLD, 'broken')
+
+    def boom(info: fr.ManifestInfo) -> set[str]:
+        raise RuntimeError('download failed')
+
+    with pytest.warns(
+        UserWarning, match='Keeping unreadable snapshot.*download failed'
+    ):
+        plan = fr.plan_retention(
+            [current, broken],
+            new_uuids={live_uuid},
+            current_manifest_path=current.manifest_path,
+            now=NOW,
+            retain_days=90,
+            keep_newest=1,
+            scan_budget=10,
+            uuids_of=boom,
+        )
+    assert plan.delete_dirs == ()
+    assert broken.dir_path in plan.unscanned
+
+
+# -- batch_units and publishing ----------------------------------------------------
+
+
+def test_batch_units_never_splits() -> None:
+    units = [[1] * 2, [2] * 3, [3] * 4]
+    batches = fr.batch_units(units, 4)
+    flattened = [item for batch in batches for item in batch]
+    assert flattened == [1, 1, 2, 2, 2, 3, 3, 3, 3]
+    for batch in batches:
+        assert len(batch) <= 4
+
+
+def _fake_add(n: int) -> CommitOperationAdd:
+    return CommitOperationAdd(
+        path_in_repo=f'flat/objects/{n}.json', path_or_fileobj=b'{}'
+    )
+
+
+def test_publisher_batches_with_suffix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(store, 'wait_before_retry', lambda attempt: None)
+    api = FakeApi({}, tmp_path)
+    committed = fr.FlatPublisher(api, 'org/ds', batch_size=2).publish(
+        [[_fake_add(n)] for n in range(5)],
+        message='cron: flat rebuild 2026-09-06 (5 aggregate record(s))',
+        description='d',
+    )
+    assert committed == 3
+    assert api.commits[0].endswith('(1/3)')
+    assert api.commits[-1].endswith('(3/3)')
+
+
+def test_publisher_adopts_landed_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(store, 'wait_before_retry', lambda attempt: None)
+    add = _fake_add(1)
+    api = FakeApi({add.path_in_repo: b'{}'}, tmp_path)
+    api.fail_next = 1
+    committed = fr.FlatPublisher(api, 'org/ds').publish(
+        [[add]], message='m', description='d'
+    )
+    assert committed == 1
+
+
+def test_publisher_raises_when_landing_unverifiable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(store, 'wait_before_retry', lambda attempt: None)
+    api = FakeApi({}, tmp_path)
+    api.fail_next = 99
+
+    def broken_listing(**kwargs: Any) -> list[str]:
+        raise RuntimeError('hub unreachable')
+
+    api.list_repo_files = broken_listing  # type: ignore[method-assign]
+    with pytest.raises(fr.FlatRebuildError):
+        fr.FlatPublisher(api, 'org/ds').publish(
+            [[_fake_add(1)]], message='m', description='d'
+        )
+
+
+# -- orchestration end-to-end --------------------------------------------------------
+
+
+def test_verify_rows_clean(tmp_path: Path) -> None:
+    row = make_row(str(uuid4()), 'gsm8k')
+    data = record_bytes(row.object_uuid, 'gsm8k')
+    files = {row.legacy_path: data, row.object_path: data}
+    api = FakeApi(files, tmp_path)
+    checked, reserialized, drift = fr.verify_rows(
+        api, 'org/ds', [row], {p: len(v) for p, v in files.items()}
+    )
+    assert (checked, reserialized, drift) == (1, 0, [])
+
+
+def test_verify_rows_catches_same_length_drift(tmp_path: Path) -> None:
+    row = make_row(str(uuid4()), 'gsm8k')
+    parsed = json.loads(record_bytes(row.object_uuid, 'gsm8k'))
+    parsed['evaluation_results'][0]['score_details']['score'] = 2
+    mutated = json.dumps(parsed).encode()  # same length, different data
+    assert len(mutated) == row.size_bytes
+    files = {
+        row.legacy_path: mutated,
+        row.object_path: record_bytes(row.object_uuid, 'gsm8k'),
+    }
+    api = FakeApi(files, tmp_path)
+    checked, reserialized, drift = fr.verify_rows(
+        api, 'org/ds', [row], {p: len(v) for p, v in files.items()}
+    )
+    assert checked == 1 and reserialized == 0
+    assert len(drift) == 1 and row.legacy_path in drift[0]
+
+
+def test_verify_rows_accepts_reserialization(tmp_path: Path) -> None:
+    row = make_row(str(uuid4()), 'gsm8k')
+    parsed = json.loads(record_bytes(row.object_uuid, 'gsm8k'))
+    reserialized = json.dumps(parsed, indent=2, sort_keys=True).encode()
+    files = {
+        row.legacy_path: reserialized,
+        row.object_path: record_bytes(row.object_uuid, 'gsm8k'),
+    }
+    api = FakeApi(files, tmp_path)
+    checked, reserialized_count, drift = fr.verify_rows(
+        api, 'org/ds', [row], {p: len(v) for p, v in files.items()}
+    )
+    assert (checked, reserialized_count, drift) == (1, 1, [])
+
+
+def test_verify_rows_reports_missing_inherited_objects(tmp_path: Path) -> None:
+    row = make_row(str(uuid4()), 'gsm8k')
+    files = {row.legacy_path: record_bytes(row.object_uuid, 'gsm8k')}
+    api = FakeApi(files, tmp_path)
+    checked, reserialized, drift = fr.verify_rows(
+        api, 'org/ds', [row], {row.legacy_path: row.size_bytes}
+    )
+    assert (checked, reserialized) == (1, 0)
+    assert len(drift) == 1
+    assert 'inherited file is missing' in drift[0]
+
+
+def test_orchestrate_refuses_bootstrap(tmp_path: Path) -> None:
+    api = FakeApi({}, tmp_path)
+    with pytest.raises(fr.FlatRebuildError, match='allow-bootstrap'):
+        fr.orchestrate(api, 'org/ds', now=NOW)
+
+
+def test_orchestrate_rebuild_then_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(store, 'wait_before_retry', lambda attempt: None)
+    files: dict[str, bytes] = {}
+    seed_datastore(files, {'gsm8k': 2, 'hle': 1})
+    api = FakeApi(files, tmp_path)
+
+    report = fr.orchestrate(api, 'org/ds', allow_bootstrap=True, now=NOW)
+    assert not report.noop
+    assert report.records == 3
+    assert report.collections == 2
+    assert report.commits >= 1
+    latest = json.loads(api.files[fr.LATEST_MANIFEST_PATH])
+    assert latest['aggregate_file_count'] == 3
+    assert 'flat/indexes/by_collection/gsm8k.jsonl' in api.files
+    assert 'flat/indexes/by_collection/hle.jsonl' in api.files
+    assert 'flat/indexes/by_legacy_path.jsonl' in api.files
+    assert any(
+        message.startswith(
+            'cron: flat rebuild 2026-09-06 (3 aggregate record(s))'
+        )
+        for message in api.commits
+    )
+
+    commits_before = len(api.commits)
+    report = fr.orchestrate(api, 'org/ds', now=NOW)
+    assert report.noop
+    assert len(api.commits) == commits_before
+
+
+def test_orchestrate_picks_up_new_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(store, 'wait_before_retry', lambda attempt: None)
+    files: dict[str, bytes] = {}
+    seed_datastore(files, {'gsm8k': 2})
+    api = FakeApi(files, tmp_path)
+    fr.orchestrate(api, 'org/ds', allow_bootstrap=True, now=NOW)
+
+    uuid = str(uuid4())
+    api.files[f'data/gsm8k/dev/model/{uuid}.json'] = record_bytes(uuid, 'gsm8k')
+    commits_before = len(api.commits)
+    report = fr.orchestrate(api, 'org/ds', now=NOW)
+    assert not report.noop
+    assert report.added_records == 1
+    assert len(api.commits) > commits_before
+    committed = committed_paths(api)
+    assert fr.object_path_for(uuid, suffix='.json') in committed
+    assert 'flat/indexes/by_collection/gsm8k.jsonl' in committed
+    assert 'flat/indexes/by_legacy_path.jsonl' in committed
+
+
+def test_orchestrate_dry_run_commits_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(store, 'wait_before_retry', lambda attempt: None)
+    files: dict[str, bytes] = {}
+    seed_datastore(files, {'gsm8k': 1})
+    api = FakeApi(files, tmp_path)
+    pointer_before = api.files[fr.LATEST_MANIFEST_PATH]
+    report = fr.orchestrate(
+        api, 'org/ds', allow_bootstrap=True, dry_run=True, now=NOW
+    )
+    assert report.commits == 0
+    assert report.uploads > 0
+    assert api.files[fr.LATEST_MANIFEST_PATH] == pointer_before
+
+
+def test_orchestrate_retires_stale_indexes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(store, 'wait_before_retry', lambda attempt: None)
+    files: dict[str, bytes] = {}
+    seed_datastore(files, {'gsm8k': 1})
+    files['flat/indexes/by_collection/live_bench.jsonl'] = b'{"old": true}\n'
+    api = FakeApi(files, tmp_path)
+    report = fr.orchestrate(api, 'org/ds', allow_bootstrap=True, now=NOW)
+    assert 'flat/indexes/by_collection/live_bench.jsonl' in (
+        report.indexes_retired
+    )
+    assert 'flat/indexes/retired/live_bench.jsonl' in api.files
+    assert 'flat/indexes/by_collection/live_bench.jsonl' not in api.files
+
+
+def test_orchestrate_trims_and_pins_snapshots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(store, 'wait_before_retry', lambda attempt: None)
+    files: dict[str, bytes] = {}
+    seed_datastore(files, {'gsm8k': 2})
+    api = FakeApi(files, tmp_path)
+    fr.orchestrate(api, 'org/ds', allow_bootstrap=True, now=NOW, keep_newest=1)
+    live_rows = list(fr.read_snapshot(api, 'org/ds')[1])
+
+    # A snapshot holding a record that no longer exists in data/ is the
+    # last index into that record and must be pinned; one whose records
+    # are all still live may be trimmed. Snapshots need distinct rows,
+    # since identical ones dedupe into the same content-addressed dir.
+    dead_uuid = str(uuid4())
+    dead_row = make_row(
+        dead_uuid, 'gsm8k', legacy=f'data/gsm8k/dev/model/{dead_uuid}.json'
+    )
+    pinned = seed_manifest_files(
+        api.files, [*live_rows, dead_row], OLD.isoformat()
+    )
+    trimmed = seed_manifest_files(api.files, [live_rows[0]], OLDER.isoformat())
+
+    report = fr.orchestrate(api, 'org/ds', now=NOW, keep_newest=1)
+    trimmed_dir = PurePosixPath(trimmed['manifest_path']).parent.as_posix()
+    pinned_dir = PurePosixPath(pinned['manifest_path']).parent.as_posix()
+    assert trimmed_dir in report.manifests_trimmed
+    assert pinned_dir in report.manifests_pinned
+    assert pinned['entries_path'] in api.files
+    assert trimmed['entries_path'] not in api.files
+
+
+@pytest.mark.parametrize('env_value', ['', 'org/custom'])
+def test_cli_repository_environment(monkeypatch, env_value, capsys):
+    monkeypatch.setenv('EEE_DATASTORE_REPO_ID', env_value)
+    received = []
+
+    def capture(api, repo_id, **kwargs):
+        received.append(repo_id)
+        return fr.RebuildReport(repo_id=repo_id, noop=True)
+
+    monkeypatch.setattr(fr, 'orchestrate', capture)
+    assert fr.main([]) == 0
+    expected = env_value or fr.DEFAULT_DATASTORE_REPO
+    assert received == [expected]
+    assert expected in capsys.readouterr().out
+
+
+def test_cli_explicit_empty_repository_fails(capsys):
+    assert fr.main(['--repo-id', '']) == 1
+    assert 'repo_id must not be empty' in capsys.readouterr().err
+
+
+@pytest.mark.parametrize('path', [fr.LATEST_MANIFEST_PATH, fr.BY_LEGACY_PATH])
+def test_publisher_does_not_adopt_failed_overwrite(tmp_path, path):
+    api = FakeApi({path: b'old'}, tmp_path)
+    api.fail_next = 1
+    with pytest.raises(fr.FlatRebuildError, match='could not commit'):
+        fr.FlatPublisher(api, 'org/ds').publish(
+            [[CommitOperationAdd(path_in_repo=path, path_or_fileobj=b'new')]],
+            message='m',
+            description='d',
+        )
+    assert api.files[path] == b'old'
+
+
+def test_publisher_retries_conflict_on_existing_path(tmp_path, monkeypatch):
+    api = FakeApi({fr.LATEST_MANIFEST_PATH: b'old'}, tmp_path)
+    api.fail_next = 1
+    monkeypatch.setattr(store, 'is_commit_conflict', lambda exc: True)
+    monkeypatch.setattr(store, 'wait_before_retry', lambda attempt: None)
+    fr.FlatPublisher(api, 'org/ds').publish(
+        [
+            [
+                CommitOperationAdd(
+                    path_in_repo=fr.LATEST_MANIFEST_PATH, path_or_fileobj=b'new'
+                )
+            ]
+        ],
+        message='m',
+        description='d',
+    )
+    assert api.files[fr.LATEST_MANIFEST_PATH] == b'new'
+
+
+def test_publisher_adopts_actual_landed_overwrite(tmp_path):
+    api = FakeApi({fr.LATEST_MANIFEST_PATH: b'old'}, tmp_path)
+    commit = api.create_commit
+
+    def landed(**kwargs):
+        commit(**kwargs)
+        raise TimeoutError('response lost')
+
+    api.create_commit = landed
+    fr.FlatPublisher(api, 'org/ds').publish(
+        [
+            [
+                CommitOperationAdd(
+                    path_in_repo=fr.LATEST_MANIFEST_PATH, path_or_fileobj=b'new'
+                )
+            ]
+        ],
+        message='m',
+        description='d',
+    )
+    assert api.files[fr.LATEST_MANIFEST_PATH] == b'new'
+    assert len(api.commits) == 1
+
+
+def test_return_to_historical_snapshot_keeps_pointer_target(tmp_path):
+    a, b, c = [make_row(str(uuid4()), 'gsm8k') for _ in range(3)]
+    files = {a.legacy_path: record_bytes(a.object_uuid, 'gsm8k')}
+    target = seed_manifest_files(files, [a], OLD.isoformat())
+    seed_manifest_files(files, [a, b], RECENT.isoformat())
+    seed_pointer(files, seed_manifest_files(files, [a, b, c], NOW.isoformat()))
+    api = FakeApi(files, tmp_path)
+    report = fr.orchestrate(api, 'org/ds', now=NOW)
+    latest = json.loads(api.files[fr.LATEST_MANIFEST_PATH])
+    assert latest['entries_path'] == target['entries_path']
+    assert latest['entries_path'] in api.files
+    assert latest['manifest_path'] in api.files
+    assert (
+        str(PurePosixPath(latest['manifest_path']).parent)
+        not in report.manifests_trimmed
+    )
+
+
+@pytest.mark.parametrize('changed', [False, True])
+@pytest.mark.parametrize('companion', [False, True])
+def test_historical_objects_are_never_overwritten(tmp_path, changed, companion):
+    row = make_row(str(uuid4()), 'gsm8k')
+    data = record_bytes(row.object_uuid, 'gsm8k')
+    sample = b'{"x":1}\n'
+    if companion:
+        row = fr._row_with_samples(row, sample)
+    destination = row.instance_level_path if companion else row.object_path
+    files = {row.legacy_path: data, row.object_path: data}
+    if companion:
+        files[fr.samples_path_for(row.legacy_path)] = sample
+        files[destination] = sample
+    original = files[destination]
+    if changed:
+        source = (
+            fr.samples_path_for(row.legacy_path)
+            if companion
+            else row.legacy_path
+        )
+        parsed = json.loads(files[source])
+        if companion:
+            parsed['x'] = 100
+        else:
+            parsed['evaluation_results'][0]['score_details']['score'] = 100
+        files[source] = json.dumps(parsed).encode()
+    seed_manifest_files(files, [row], OLD.isoformat())
+    seed_pointer(files, seed_manifest_files(files, [], RECENT.isoformat()))
+    seed_derived(files, [row])
+    api = FakeApi(files, tmp_path)
+    report = fr.orchestrate(api, 'org/ds', now=NOW)
+    if changed:
+        assert report.conflicts
+    else:
+        assert not report.conflicts
+    # a published object is adopted or conflicted, never overwritten
+    assert destination not in committed_paths(api)
+    assert api.files[destination] == original
+
+
+def test_pre_flight_reports_every_immutable_mismatch(tmp_path):
+    bad_agg = make_row(str(uuid4()), 'gsm8k')
+    bad_sample = fr._row_with_samples(
+        make_row(str(uuid4()), 'hle'), b'{"x":1}\n'
+    )
+    files = {
+        bad_agg.legacy_path: record_bytes(bad_agg.object_uuid, 'gsm8k'),
+        bad_agg.object_path: b'{}',
+        bad_sample.legacy_path: record_bytes(bad_sample.object_uuid, 'hle'),
+        fr.samples_path_for(bad_sample.legacy_path): b'{"x":1}\n',
+        bad_sample.instance_level_path: b'{}',
+    }
+    seed_pointer(files, seed_manifest_files(files, [], RECENT.isoformat()))
+    api = FakeApi(files, tmp_path)
+    report = fr.orchestrate(api, 'org/ds', now=NOW)
+    message = '\n'.join(report.conflicts)
+    assert bad_agg.legacy_path in message
+    assert fr.samples_path_for(bad_sample.legacy_path) in message
+    # conflicting destinations keep their bytes; the clean record publishes
+    assert api.files[bad_agg.object_path] == b'{}'
+    assert api.files[bad_sample.instance_level_path] == b'{}'
+    assert fr.exit_code_for(report) == 2
+
+
+@pytest.mark.parametrize('change', ['add', 'remove', 'edit'])
+def test_existing_aggregate_companion_changes(tmp_path, change):
+    row = make_row(str(uuid4()), 'gsm8k')
+    sample = b'{"x":1}\n'
+    if change != 'add':
+        row = fr._row_with_samples(row, sample)
+    files = {row.legacy_path: record_bytes(row.object_uuid, 'gsm8k')}
+    seed_pointer(files, seed_manifest_files(files, [row], RECENT.isoformat()))
+    sample_path = fr.samples_path_for(row.legacy_path)
+    if change != 'add':
+        files[row.instance_level_path] = sample
+    if change != 'remove':
+        files[sample_path] = sample if change != 'edit' else b'{"x":2000}\n'
+    seed_derived(files, [row])
+    api = FakeApi(files, tmp_path)
+    if change == 'edit':
+        report = fr.orchestrate(api, 'org/ds', now=NOW)
+        assert report.conflicts
+        assert not api.commits
+    else:
+        report = fr.orchestrate(api, 'org/ds', now=NOW)
+        assert not report.noop
+        rebuilt = fr.read_snapshot(api, 'org/ds')[1][0]
+        assert rebuilt.instance_level_available == (change == 'add')
+        if change == 'add':
+            assert api.files[rebuilt.instance_level_path] == sample
+        else:
+            assert rebuilt.instance_level_path is None
+
+
+def test_retention_preserves_last_companion_reference(tmp_path):
+    a, b, c = [make_row(str(uuid4()), 'gsm8k') for _ in range(3)]
+    files = {
+        r.legacy_path: record_bytes(r.object_uuid, 'gsm8k') for r in [a, b, c]
+    }
+    historical = seed_manifest_files(
+        files, [fr._row_with_samples(a, b'{}')], OLD.isoformat()
+    )
+    seed_manifest_files(files, [a, b], RECENT.isoformat())
+    seed_pointer(files, seed_manifest_files(files, [a, b, c], NOW.isoformat()))
+    api = FakeApi(files, tmp_path)
+    report = fr.orchestrate(api, 'org/ds', now=NOW)
+    assert (
+        str(PurePosixPath(historical['manifest_path']).parent)
+        in report.manifests_pinned
+    )
+    assert historical['entries_path'] in api.files
+
+
+@pytest.mark.parametrize('existing', [False, True])
+@pytest.mark.parametrize('same_content', [False, True])
+def test_duplicate_uuid_paths_are_rejected(existing, same_content):
+    row = make_row(str(uuid4()), 'gsm8k')
+    other = row.legacy_path.replace('/gsm8k/', '/other/')
+    data = record_bytes(row.object_uuid, 'gsm8k')
+    contents = {
+        row.legacy_path: data,
+        other: data if same_content else data + b' ',
+    }
+    old = [row] if existing else []
+    diff = fr.diff_against_snapshot(
+        old, {p: len(v) for p, v in contents.items()}
+    )
+    result = fr.build_rows(old, diff, contents)
+    assert any('duplicate UUID' in error for error in result.errors)
+
+
+def test_moved_samples_compare_hash_not_only_size():
+    old = fr._row_with_samples(make_row(str(uuid4()), 'gsm8k'), b'{"x":1}')
+    path = old.legacy_path.replace('/gsm8k/', '/other/')
+    sample_path = fr.samples_path_for(path)
+    contents = {
+        path: record_bytes(old.object_uuid, 'gsm8k'),
+        sample_path: b'{"x":2}',
+    }
+    diff = fr.diff_against_snapshot(
+        [old], {p: len(v) for p, v in contents.items()}
+    )
+    result = fr.build_rows(
+        [old],
+        diff,
+        contents,
+        lambda object_path: (
+            b'{"x":1}' if object_path == old.instance_level_path else None
+        ),
+    )
+    assert not result.errors
+    assert len(result.conflicts) == 1
+    assert 'immutable' in result.conflicts[0]
+    # the moved row keeps its published samples object
+    assert result.rows[0].instance_sha == old.instance_sha
+
+
+def test_missing_index_is_repaired_even_when_snapshot_matches(tmp_path):
+    files = {}
+    seed_datastore(files, {'gsm8k': 1})
+    api = FakeApi(files, tmp_path)
+    fr.orchestrate(api, 'org/ds', now=NOW)
+    del api.files[f'{fr.INDEXES_PREFIX}/gsm8k.jsonl']
+    report = fr.orchestrate(api, 'org/ds', now=NOW)
+    assert not report.noop
+    assert f'{fr.INDEXES_PREFIX}/gsm8k.jsonl' in api.files
+
+
+def test_publisher_unreadable_overwrite_outcome_stops(tmp_path, monkeypatch):
+    api = FakeApi({fr.LATEST_MANIFEST_PATH: b'old'}, tmp_path)
+    api.fail_next = 1
+
+    def unreadable(**kwargs):
+        raise RuntimeError('download unavailable')
+
+    monkeypatch.setattr(api, 'hf_hub_download', unreadable)
+    monkeypatch.setattr(store, 'is_commit_conflict', lambda exc: True)
+    with pytest.raises(
+        fr.FlatRebuildError, match='unverifiable.*download unavailable'
+    ):
+        fr.FlatPublisher(api, 'org/ds').publish(
+            [
+                [
+                    CommitOperationAdd(
+                        path_in_repo=fr.LATEST_MANIFEST_PATH,
+                        path_or_fileobj=b'new',
+                    )
+                ]
+            ],
+            message='m',
+            description='d',
+        )
+    assert not api.commits
+
+
+def test_unreadable_retention_scan_consumes_budget():
+    snapshots = [
+        manifest_info(OLD - timedelta(days=i), f'broken{i}') for i in range(3)
+    ]
+    attempts = []
+
+    def unreadable(info):
+        attempts.append(info.dir_path)
+        raise RuntimeError('unavailable')
+
+    with pytest.warns(UserWarning, match='Keeping unreadable snapshot'):
+        plan = fr.plan_retention(
+            snapshots,
+            new_uuids=set(),
+            current_manifest_path=None,
+            now=NOW,
+            retain_days=90,
+            keep_newest=0,
+            scan_budget=1,
+            uuids_of=unreadable,
+        )
+    assert len(attempts) == 1
+    assert len(plan.unscanned) == 3
+    assert not plan.delete_dirs
+
+
+@pytest.mark.parametrize('mode', ['existing', 'moved', 'returning'])
+@pytest.mark.parametrize('conflicting', [False, True])
+def test_historical_companion_attachment_preserves_published_bytes(
+    tmp_path, mode, conflicting
+):
+    row = make_row(str(uuid4()), 'gsm8k')
+    published = b'{"x":1}\n{"x":2}\n'
+    incoming = b'{ "x": 1 }\n{ "x": 2 }\n' if not conflicting else b'{"x":9}\n'
+    historical = fr._row_with_samples(row, published)
+    path = (
+        row.legacy_path
+        if mode != 'moved'
+        else row.legacy_path.replace('/gsm8k/', '/other/')
+    )
+    files = {
+        path: record_bytes(row.object_uuid, 'gsm8k'),
+        row.object_path: record_bytes(row.object_uuid, 'gsm8k'),
+        historical.instance_level_path: published,
+        fr.samples_path_for(path): incoming,
+    }
+    seed_manifest_files(files, [historical], OLD.isoformat())
+    current_rows = [] if mode == 'returning' else [row]
+    seed_pointer(
+        files, seed_manifest_files(files, current_rows, RECENT.isoformat())
+    )
+    seed_derived(files, current_rows)
+    api = FakeApi(files, tmp_path)
+    report = fr.orchestrate(api, 'org/ds', now=NOW, verify=True)
+    assert bool(report.conflicts) == conflicting
+    assert api.files[historical.instance_level_path] == published
+    assert historical.instance_level_path not in committed_paths(api)
+    rebuilt = fr.read_snapshot(api, 'org/ds')[1][0]
+    assert rebuilt.instance_level_available == (not conflicting)
+    if not conflicting:
+        assert rebuilt.instance_sha == fr.sha256_bytes(published)
+        assert rebuilt.instance_level_size_bytes == len(published)
+
+
+@pytest.mark.parametrize(
+    'incoming', [b'{"x":1}\n{"x":2}\n', b'{ "x": 1 }\n{ "x": 2 }\n']
+)
+def test_moved_multiline_companion_is_not_a_conflict(incoming):
+    published = b'{"x":1}\n{"x":2}\n'
+    row = fr._row_with_samples(make_row(str(uuid4()), 'gsm8k'), published)
+    path = row.legacy_path.replace('/gsm8k/', '/other/')
+    contents = {
+        path: record_bytes(row.object_uuid, 'gsm8k'),
+        fr.samples_path_for(path): incoming,
+    }
+    result = fr.build_rows(
+        [row],
+        fr.diff_against_snapshot(
+            [row], {p: len(v) for p, v in contents.items()}
+        ),
+        contents,
+        lambda path: published,
+    )
+    assert not result.errors
+    assert not result.conflicts
+    assert result.rows[0].instance_sha == row.instance_sha
+    assert not result.upload_samples
+
+
+@pytest.mark.parametrize(
+    'incoming,accepted',
+    [
+        (b'{"x":2}\n{"x":2}\n', False),
+        (b'{ "x": 1 }\n{ "x": 2 }\n', True),
+        (b'{"x":2}\n{"x":1}\n', False),
+    ],
+)
+def test_deep_verification_checks_companions(tmp_path, incoming, accepted):
+    published = b'{"x":1}\n{"x":2}\n'
+    row = fr._row_with_samples(make_row(str(uuid4()), 'gsm8k'), published)
+    files = {
+        row.legacy_path: record_bytes(row.object_uuid, 'gsm8k'),
+        row.object_path: record_bytes(row.object_uuid, 'gsm8k'),
+        row.instance_level_path: published,
+        fr.samples_path_for(row.legacy_path): incoming,
+    }
+    api = FakeApi(files, tmp_path)
+    checked, reserialized, drift = fr.verify_rows(
+        api, 'org/ds', [row], {p: len(v) for p, v in files.items()}
+    )
+    assert checked == 2
+    assert bool(drift) == (not accepted)
+    assert reserialized == int(accepted)
+
+
+def test_verify_orchestration_rejects_same_length_companion_drift(tmp_path):
+    published = b'{"x":1}\n'
+    row = fr._row_with_samples(make_row(str(uuid4()), 'gsm8k'), published)
+    files = {
+        row.legacy_path: record_bytes(row.object_uuid, 'gsm8k'),
+        row.object_path: record_bytes(row.object_uuid, 'gsm8k'),
+        row.instance_level_path: published,
+        fr.samples_path_for(row.legacy_path): b'{"x":2}\n',
+    }
+    seed_pointer(files, seed_manifest_files(files, [row], RECENT.isoformat()))
+    seed_derived(files, [row])
+    api = FakeApi(files, tmp_path)
+    with pytest.raises(fr.FlatRebuildError, match='no longer match'):
+        fr.orchestrate(api, 'org/ds', now=NOW, verify=True)
+    assert not api.commits
+
+
+@pytest.mark.parametrize(
+    'left,right',
+    [
+        (b'{"score":true}', b'{"score":1}'),
+        (b'{"nested":[false]}', b'{"nested":[0]}'),
+        (b'{"score":"1"}', b'{"score":1}'),
+        (b'{"score":null}', b'{"score":false}'),
+    ],
+)
+@pytest.mark.parametrize('jsonl', [False, True])
+def test_semantic_comparison_preserves_types(left, right, jsonl):
+    assert not fr.semantically_equal(left, right, jsonl=jsonl)
+
+
+def test_semantic_comparison_preserves_record_order_and_count():
+    assert not fr.semantically_equal(
+        b'{"x":1}\n{"x":2}', b'{"x":2}\n{"x":1}', jsonl=True
+    )
+    assert not fr.semantically_equal(
+        b'{"x":1}\n{"x":1}', b'{"x":1}', jsonl=True
+    )
+    assert fr.semantically_equal(
+        b'{"b":2,"a":[true]}', b'{ "a": [true], "b": 2 }'
+    )
+
+
+def test_verify_skips_explicitly_pending_objects(tmp_path):
+    row = make_row(str(uuid4()), 'gsm8k')
+    api = FakeApi(
+        {row.legacy_path: record_bytes(row.object_uuid, 'gsm8k')}, tmp_path
+    )
+    assert fr.verify_rows(
+        api,
+        'org/ds',
+        [row],
+        {row.legacy_path: row.size_bytes},
+        pending_objects=frozenset({row.object_path}),
+    ) == (0, 0, [])
+
+
+def test_verify_bootstrap_allows_planned_new_objects(tmp_path):
+    row = make_row(str(uuid4()), 'gsm8k')
+    api = FakeApi(
+        {
+            row.legacy_path: record_bytes(row.object_uuid, 'gsm8k'),
+            fr.samples_path_for(row.legacy_path): b'{"x":1}\n',
+        },
+        tmp_path,
+    )
+    report = fr.orchestrate(
+        api, 'org/ds', now=NOW, verify=True, allow_bootstrap=True
+    )
+    assert not report.conflicts
+    assert report.verified_files == 0
+    assert row.object_path in api.files


### PR DESCRIPTION
Refreshes the datastore's flat/ view against the Hub API after each
ingestion run — no clone, since data/ is ~15 GB. Diffs data/ against
the published snapshot by path and size, resolves same-UUID
re-emissions by semantic equality (a re-serialization moves the row;
a semantic change is excluded with exit 2 and the published object
stays), publishes in batched commits with the ingestion cron's retry
and landed-anyway arbitration, retires stale collection indexes
instead of deleting them, and trims old snapshots while pinning the
last manifest that indexes each object. A weekly --verify sweep
hashes inherited source files to catch same-length edits the
size-based diff cannot see.
