### PR TITLE
Retry a Hub server error instead of ending the adapter's run

### DIFF
--- a/every_eval_ever/cron/flat_rebuild.py
+++ b/every_eval_ever/cron/flat_rebuild.py
@@ -1046,8 +1046,9 @@ class FlatPublisher:
                 landed = self._landed(operations)
                 if landed:
                     return
-                if attempt < store.COMMIT_ATTEMPTS and store.is_commit_conflict(
-                    exc
+                if (
+                    attempt < store.COMMIT_ATTEMPTS
+                    and store.is_retryable_commit_error(exc)
                 ):
                     store.wait_before_retry(attempt)
                     continue

--- a/every_eval_ever/cron/store.py
+++ b/every_eval_ever/cron/store.py
@@ -94,6 +94,14 @@ _COMMIT_IN_PROGRESS = 'commit operation is in progress'
 #: Hub errors name the status in their message, which is how a conflict is
 #: recognised when the exception carries no response to read it from.
 _STATUS_CODE = re.compile(r'\b(409|412)\b')
+#: Statuses that mean the Hub itself faulted rather than refusing the commit.
+#: The write was never applied, so replaying it is safe, and the same backoff
+#: that waits out a lock waits out a bad minute on the Hub.
+_TRANSIENT_STATUSES = frozenset({500, 502, 503, 504})
+#: The Hub's phrasing for a server fault. Matched against the whole clause
+#: rather than the bare number, because a request id or a byte count in the
+#: message would otherwise read as a status.
+_SERVER_STATUS = re.compile(r"server error '(500|502|503|504)\b", re.IGNORECASE)
 
 
 def is_commit_conflict(exc: BaseException) -> bool:
@@ -117,6 +125,25 @@ def is_commit_conflict(exc: BaseException) -> bool:
     ):
         return True
     return _STATUS_CODE.search(text) is not None
+
+
+def is_transient_hub_error(exc: BaseException) -> bool:
+    """Return whether the Hub faulted on its own side and may yet succeed.
+
+    A 5xx means the Hub failed to apply the commit, not that it refused one,
+    so nothing landed and replaying sends the same operations at a Hub that
+    has had time to recover. One fault therefore costs a wait rather than the
+    adapter's whole run, and the run's records for the day with it.
+    """
+    status = getattr(getattr(exc, 'response', None), 'status_code', None)
+    if status in _TRANSIENT_STATUSES:
+        return True
+    return _SERVER_STATUS.search(str(exc)) is not None
+
+
+def is_retryable_commit_error(exc: BaseException) -> bool:
+    """Return whether waiting and sending the same commit again is worthwhile."""
+    return is_commit_conflict(exc) or is_transient_hub_error(exc)
 
 
 def commit_retry_delay(attempt: int) -> float:
@@ -599,14 +626,19 @@ class RawStore:
                 )
             except Exception as exc:  # noqa: BLE001 - re-raised with context
                 last = attempt == COMMIT_ATTEMPTS
-                if last or not is_commit_conflict(exc):
+                if last or not is_retryable_commit_error(exc):
                     raise StoreError(
                         f'could not write to {self.repo_id}: '
                         f'{type(exc).__name__}: {exc}'
                     ) from exc
+                cause = (
+                    'lost the per-repository lock'
+                    if is_commit_conflict(exc)
+                    else 'hit a Hub server error'
+                )
                 print(
-                    f'{self.repo_id}: commit attempt {attempt} lost the '
-                    f'per-repository lock ({type(exc).__name__}), retrying',
+                    f'{self.repo_id}: commit attempt {attempt} {cause} '
+                    f'({type(exc).__name__}), retrying',
                     file=sys.stderr,
                 )
                 wait_before_retry(attempt)
@@ -755,6 +787,8 @@ __all__ = [
     'inflight_operation',
     'inflight_path',
     'is_commit_conflict',
+    'is_retryable_commit_error',
+    'is_transient_hub_error',
     'pending_fingerprints_path',
     'plan_raw_upload',
     'raw_prefix',

--- a/every_eval_ever/cron/submit.py
+++ b/every_eval_ever/cron/submit.py
@@ -277,12 +277,13 @@ class DatastoreSubmitter:
                     if (
                         landed is not None
                         and attempt < store.COMMIT_ATTEMPTS
-                        and store.is_commit_conflict(exc)
+                        and store.is_retryable_commit_error(exc)
                     ):
                         # Every adapter job of a matrix publishes to this one
                         # branch, so the Hub's per-repository commit lock is
-                        # contended. Retried only where the datastore proved
-                        # the batch absent, so a retry cannot duplicate it.
+                        # contended, and the Hub itself faults from time to
+                        # time. Retried only where the datastore proved the
+                        # batch absent, so a retry cannot duplicate it.
                         store.wait_before_retry(attempt)
                         continue
                     unresolved: list[str] = []

--- a/tests/test_cron_store_and_submit.py
+++ b/tests/test_cron_store_and_submit.py
@@ -1138,10 +1138,12 @@ def test_a_record_and_its_sidecar_are_never_split_across_commits(
 
 def test_a_failure_before_anything_landed_reports_nothing_committed(
     tmp_path,
+    retry_waits,
 ) -> None:
+    """A Hub that faults for the whole retry budget still reports honestly."""
     tree = _upload_tree(tmp_path, 2)
     hub = FakeHub()
-    hub.commit_error = RuntimeError('502 Bad Gateway')
+    hub.commit_error = RuntimeError("Server error '502 Bad Gateway' for url...")
     sub = submit.DatastoreSubmitter(hub)
 
     with pytest.raises(submit.PartialSubmissionError) as caught:
@@ -1408,3 +1410,64 @@ def test_is_commit_conflict_detects_precondition_failed_messages() -> None:
     assert store.is_commit_conflict(exc1)
     assert store.is_commit_conflict(exc2)
     assert store.is_commit_conflict(exc3)
+
+
+def test_a_hub_server_error_is_retried_not_reported(retry_waits) -> None:
+    """A 5xx never applied the commit, so sending it again is the whole fix."""
+    hub = FakeHub(sha='headsha')
+    raw_store = store.RawStore(hub)
+    state = raw_store.read_state('hle')
+    state.fingerprints.add('a')
+    faulted = _conflict(500, "Server error '500 Internal Server Error' for url...")
+    attempts: list[dict] = []
+    real_create_commit = hub.create_commit
+
+    def fault_once(**kwargs):
+        attempts.append(kwargs)
+        if len(attempts) == 1:
+            raise faulted
+        return real_create_commit(**kwargs)
+
+    hub.create_commit = fault_once
+
+    raw_store.commit(store.state_operations(state), message='hle')
+
+    assert hub.files['state/hle.fingerprints'].split() == ['a']
+    assert retry_waits == [1], 'one wait, before the second attempt'
+
+
+def test_a_hub_that_stays_broken_still_fails(retry_waits) -> None:
+    """The retry budget bounds a Hub outage as well as it bounds a lock."""
+    hub = FakeHub(sha='headsha')
+    raw_store = store.RawStore(hub)
+    state = raw_store.read_state('hle')
+    hub.commit_error = _conflict(503, "Server error '503 Service Unavailable'")
+
+    with pytest.raises(store.StoreError, match='could not write'):
+        raw_store.commit(store.state_operations(state), message='hle')
+
+    assert retry_waits == list(range(1, store.COMMIT_ATTEMPTS))
+
+
+def test_transient_and_conflict_stay_separate_judgements() -> None:
+    """Each predicate answers only its own question, so neither name lies."""
+    server = RuntimeError("Server error '502 Bad Gateway' for url...")
+    lock = RuntimeError('409 Client Error: Conflict for url...')
+    denied = RuntimeError("Client error '403 Forbidden' for url...")
+
+    assert store.is_transient_hub_error(server)
+    assert not store.is_commit_conflict(server)
+    assert store.is_commit_conflict(lock)
+    assert not store.is_transient_hub_error(lock)
+    assert not store.is_retryable_commit_error(denied)
+
+
+def test_a_request_id_holding_a_status_number_is_not_a_status() -> None:
+    """Hub errors carry request ids; a 500 inside one must not read as a fault."""
+    exc = RuntimeError(
+        "Client error '403 Forbidden' for url 'https://huggingface.co/api' "
+        '(Request ID: Root=1-500-502503504)'
+    )
+
+    assert not store.is_transient_hub_error(exc)
+    assert not store.is_retryable_commit_error(exc)


### PR DESCRIPTION
## What happens today

`mt_bench` failed in the 2026-09-10 nightly on this, and nothing about it was the adapter's fault:

```
error: could not write to evaleval/EEE_raw: HfHubHTTPError: Server error
'500 Internal Server Error' for url 'https://huggingface.co/api/datasets/
evaleval/EEE_raw/commit/main'
```

The retry loop in `cron/store.py` is guarded by `is_commit_conflict`, which recognises 409 and 412 and nothing else. A 500 is therefore not retryable, so the very first attempt raises `StoreError` and the job dies — with eight attempts and jittered backoff sitting unused right beside it. One bad minute on the Hub costs that source its whole day.

## The change

A 5xx means the Hub failed to apply the commit rather than refusing one, so nothing landed and replaying the same operations is safe. That is a different question from "did I lose a race", so it gets its own predicate rather than widening `is_commit_conflict` past what its name and docstring claim:

- `is_transient_hub_error` — 500, 502, 503, 504
- `is_retryable_commit_error` — either that or a conflict

Three call sites now gate on the combined predicate: `RawStore.commit`, `DatastoreSubmitter.publish`, and `FlatPublisher._commit_batch` in the flat rebuild that just landed. The submitter's existing guard is untouched, so it still retries only where `_landed_anyway` proved the batch absent and a retry cannot duplicate records.

Status matching goes against the Hub's `Server error '5xx` clause rather than a bare number. These messages carry request ids like `Root=1-6aa264f2-3b5a4040556d7a837e54029b`, and a digit run inside one must not read as a status — `test_a_request_id_holding_a_status_number_is_not_a_status` pins that.

## Tests

`1422 passed, 1 skipped`, ruff clean. Four new, one amended:

- a 500 that clears on the second attempt commits, and waits exactly once
- a 503 that never clears still fails after the full budget
- the two predicates answer only their own question, and a 403 is retryable by neither
- a 403 whose request id contains `500` is not a server fault
- the existing "nothing landed" submitter test now uses a 502 in the Hub's real phrasing and takes the `retry_waits` fixture, since it retries before reporting

## Scope

This does not fix the other two nightly failures. `hal` is #289 and `terminal_bench_2` is #290, both still awaiting review. Those three are the whole of the current nightly redness, and the nightly being red also means the `Flat rebuild` workflow's `workflow_run` trigger never fires — only its 01:14 catch-up schedule does.
