### PR TITLE
Address the archive's pre-namespace rows at the namespace they live at

### DIFF
--- a/every_eval_ever/adapters/hfopenllm_v2/adapter.py
+++ b/every_eval_ever/adapters/hfopenllm_v2/adapter.py
@@ -42,6 +42,15 @@ from every_eval_ever.helpers import (
 SOURCE_URL = 'https://open-llm-leaderboard-open-llm-leaderboard.hf.space/api/leaderboard/formatted'
 OUTPUT_DIR = 'data/hfopenllm_v2'
 
+# The archive predates Hugging Face namespacing every repository, so two rows
+# carry a bare model name. `gpt2` is the same weights as the namespaced rows
+# beside it (both report sha 607a30d783df), published under the namespace the
+# repository now lives at, so it is addressed there rather than dropped.
+LEGACY_UNNAMESPACED_IDS = {
+    'gpt2': 'openai-community/gpt2',
+}
+
+
 # Evaluation name mapping from API keys to display names
 EVALUATION_MAPPING = {
     'ifeval': 'IFEval',
@@ -112,6 +121,7 @@ def convert_model(
     list so valid metrics from the same model can still be published.
     """
     model_id = model_data['model']['name']
+    model_id = LEGACY_UNNAMESPACED_IDS.get(model_id, model_id)
     if '/' not in model_id:
         raise ValueError(f"Expected 'org/model' format, got: {model_id}")
     developer, model_name = model_id.split('/', 1)
@@ -232,6 +242,7 @@ def convert_models(
         failure_count_before = len(failures)
         try:
             model_id = model_data['model']['name']
+            model_id = LEGACY_UNNAMESPACED_IDS.get(model_id, model_id)
             if '/' not in model_id:
                 raise ValueError(
                     f"Expected 'org/model' format, got: {model_id}"

--- a/tests/test_hfopenllm_v2_adapter.py
+++ b/tests/test_hfopenllm_v2_adapter.py
@@ -89,3 +89,29 @@ def test_process_models_writes_valid_output_and_external_failure_report(
     assert report['converted_records'] == 1
     assert len(report['failed_records']) == 1
     assert not report_path.is_relative_to(output_dir)
+
+
+def test_a_row_predating_namespacing_is_addressed_at_its_namespace():
+    """The archive's two bare `gpt2` rows are the namespaced repo's weights."""
+    row = {
+        'model': {
+            'name': 'gpt2',
+            'sha': '607a30d783dfa663caf39e06633721c8d4cfcd7e',
+            'precision': 'bfloat16',
+            'type': 'pretrained',
+            'average_score': 6.39,
+        },
+        'evaluations': {
+            'ifeval': {'name': 'IFEval', 'value': 0.19, 'normalized_score': 19.3},
+        },
+        'metadata': {},
+        'features': {},
+    }
+
+    result = convert_models([row])
+
+    assert not result.failures
+    assert len(result.records) == 1
+    record = result.records[0]
+    assert (record.developer, record.model_name) == ('openai-community', 'gpt2')
+    assert record.eval_log.model_info.id == 'openai-community/gpt2'


### PR DESCRIPTION
Two of the 4,576 HF Open LLM Leaderboard v2 archive rows carry a bare `gpt2` with no publishing namespace. The `org/model` check rejected them, so `raise_if_incomplete` fired and the adapter produced nothing at all — 4,574 convertible rows lost to two bad names.

They are not junk rows. All four `gpt2` rows in the archive report sha `607a30d783df`, so the bare pair is the same weights as the `openai-community/gpt2` pair beside it, but submitted separately and scoring differently (6.3910 against 6.5108 at bfloat16). Dropping them would lose two real measurements.

The repository those weights live at is namespaced now, and the datastore already holds `data/hfopenllm_v2/openai-community/gpt2`, so they are addressed there. The map is applied in both places the identity is derived, since `convert_model` and `convert_models` build the id and the directory independently and disagreeing would trip the path warning.

`SourceRecordExclusion` would have been the wrong mechanism. It records a source row that is not an evaluation, and these are evaluations.

`gpt2` is the only org-less name in all 4,576 rows, so the map has one entry rather than a heuristic.